### PR TITLE
Fixing incorrect stream closing/disposing

### DIFF
--- a/FluentFTP/Stream/FtpDataStream.cs
+++ b/FluentFTP/Stream/FtpDataStream.cs
@@ -140,21 +140,6 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
-		/// Disconnects (if necessary) and releases associated resources
-		/// </summary>
-		/// <param name="disposing">Disposing</param>
-		protected override void Dispose(bool disposing) {
-			if (disposing) {
-				if (IsConnected)
-					Close();
-
-				m_control = null;
-			}
-
-			base.Dispose(disposing);
-		}
-
-		/// <summary>
 		/// Closes the connection and reads the server's reply
 		/// </summary>
 		public new FtpReply Close() {

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -740,10 +740,13 @@ namespace FluentFTP
         /// Disconnects from server
         /// </summary>
 #if CORE
-		public void Close() {
+		public void Close()
+		{
+			base.Dispose(true);
 #else
         public override void Close()
         {
+            base.Close();
 #endif
             if (m_socket != null)
             {
@@ -808,10 +811,6 @@ namespace FluentFTP
                     m_sslStream = null;
                 }
             }
-#endif
-
-#if CORE
-            base.Dispose();
 #endif
         }
 


### PR DESCRIPTION
While working on the project testing, I stumbled upon a problem with some operations when running in .NET Standard. The library worked fine in .NET Framework, although it only did because it worked around the bug in the first place.

The .NET `Stream` class has three methods (relevant to this issue): `Close()`, `Dispose()` and `Dispose(bool)`. Both dispose methods are blank.  
`Dispose()` calls `Close()`  
`Close()` calls `Dispose(bool)`

The .NET Core's `Stream` class only has `Dispose()` and `Dispose(bool)`, both are blank.

To compensate for the missing `Close()`, the `FtpSocketStream` creates a new `Dispose()` method that calls `Close()`, overrides the `Close()` method (**not calling base.Close()**, and so not calling `Dispose(bool)`). For .NET Core, it creates a `Close()` method, and calls `Dispose()` inside. So we *already* have different paths in here.

In the `FtpDataStream` (derives from `FtpSocketStream`), the library overrides `Dispose(bool)` and **calls `Close()`**. This would actually cause the Close to call Dispose, but (un)luckily, the Close method doesn't call the base Close method, avoiding the circular call. This is the reason the error wasn't caught while running in .NET framework!

The main side-effect of this? In `FtpDataStream`'s `Dispose(bool)` method, we're clearing the `m_control` variable, without checking if the data stream has been properly cleared. In fact, just below, the `Close()` method checks if `m_control`'s property is not null, and if it's not, clears the control channel before nulling it.

If `Dispose(bool)` is called before `Close()` in this class, the library will never clear the data stream. That's exactly what happens when running under .NET core.
![image](https://user-images.githubusercontent.com/822898/30778469-a01088c8-a0ce-11e7-9429-9d31f75ac7f2.png)


Fixes #160 