### PR TITLE
Async compiler keyword + More secure SSL protocols

### DIFF
--- a/FluentFTP/Client/FtpClient_Connection.cs
+++ b/FluentFTP/Client/FtpClient_Connection.cs
@@ -571,7 +571,7 @@ namespace FluentFTP {
 #endif
 
 #if CORE
-		private SslProtocols m_SslProtocols = SslProtocols.Tls11 | SslProtocols.Ssl3;
+		private SslProtocols m_SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
 #else
 		private SslProtocols m_SslProtocols = SslProtocols.Default;
 #endif
@@ -1102,7 +1102,7 @@ namespace FluentFTP {
 					throw new ObjectDisposedException("This FtpClient object has been disposed. It is no longer accessible.");
 
 				if (m_stream == null) {
-					m_stream = new FtpSocketStream();
+					m_stream = new FtpSocketStream(m_SslProtocols);
 					m_stream.ValidateCertificate += new FtpSocketStreamSslValidation(FireValidateCertficate);
 				} else {
 					if (IsConnected) {
@@ -1221,7 +1221,7 @@ namespace FluentFTP {
 
             if (m_stream == null)
             {
-                m_stream = new FtpSocketStream();
+                m_stream = new FtpSocketStream(m_SslProtocols);
                 m_stream.ValidateCertificate += new FtpSocketStreamSslValidation(FireValidateCertficate);
             }
             else

--- a/FluentFTP/Client/FtpClient_Connection.cs
+++ b/FluentFTP/Client/FtpClient_Connection.cs
@@ -19,7 +19,7 @@ using System.Web;
 #if (CORE || NETFX)
 using System.Threading;
 #endif
-#if NET45 || CORE
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -894,7 +894,7 @@ namespace FluentFTP {
 		}
 #endif
 
-#if NET45 || CORE
+#if ASYNC
         // TODO: Add cencellation support
 		/// <summary>
 		/// Performs an asynchronous execution of the specified command
@@ -1013,7 +1013,7 @@ namespace FluentFTP {
 			return reply;
 		}
 
-#if NET45 || CORE
+#if ASYNC
         // TODO: add example
         /// <summary>
         /// Retrieves a reply from the server. Do not execute this method
@@ -1203,7 +1203,7 @@ namespace FluentFTP {
 #endif
 		}
 
-#if NET45 || CORE
+#if ASYNC
         // TODO: add example
         /// <summary>
         /// Connect to the server
@@ -1340,7 +1340,7 @@ namespace FluentFTP {
 			stream.Connect(Host, Port, InternetProtocolVersions);
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Connect to the FTP server. Overwritten in proxy classes.
         /// </summary>
@@ -1358,7 +1358,7 @@ namespace FluentFTP {
 			stream.Connect(host, port, ipVersions);
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Connect to the FTP server. Overwritten in proxy classes.
         /// </summary>
@@ -1382,7 +1382,7 @@ namespace FluentFTP {
 			}
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Called during <see cref="ConnectAsync()"/>. Typically extended by FTP proxies.
         /// </summary>
@@ -1523,7 +1523,7 @@ namespace FluentFTP {
 			Authenticate(Credentials.UserName, Credentials.Password);
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Performs a login on the server. This method is overridable so
         /// that the login procedure can be changed to support, for example,
@@ -1551,7 +1551,7 @@ namespace FluentFTP {
 				throw new FtpCommandException(reply);
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Performs a login on the server. This method is overridable so
         /// that the login procedure can be changed to support, for example,
@@ -1635,7 +1635,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Disconnects from the server asynchronously
 		/// </summary>
@@ -1777,7 +1777,7 @@ namespace FluentFTP {
 			return path;
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Ensure a relative path is absolute by appending the working dir
         /// </summary>
@@ -1881,7 +1881,7 @@ namespace FluentFTP {
 			}
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Data shouldn't be on the socket, if it is it probably
         /// means we've been disconnected. Read and discard

--- a/FluentFTP/Client/FtpClient_Hash.cs
+++ b/FluentFTP/Client/FtpClient_Hash.cs
@@ -19,7 +19,7 @@ using System.Web;
 #if (CORE || NETFX)
 using System.Threading;
 #endif
-#if NET45 || CORE
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -149,7 +149,7 @@ namespace FluentFTP {
 			return GetAsyncDelegate<AsyncGetHashAlgorithm>(ar).EndInvoke(ar);
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the currently selected hash algorithm for the HASH command asynchronously.
 		/// </summary>
@@ -254,7 +254,7 @@ namespace FluentFTP {
 			GetAsyncDelegate<AsyncSetHashAlgorithm>(ar).EndInvoke(ar);
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Sets the hash algorithm on the server to be used with the HASH command asynchronously.
 		/// </summary>
@@ -394,7 +394,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the hash of an object on the server using the currently selected hash algorithm asynchronously. 
 		/// </summary>
@@ -582,7 +582,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Retrieves a checksum of the given file using a checksum method that the server supports, if any. 
 		/// </summary>
@@ -717,7 +717,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the MD5 hash of the specified file using MD5 asynchronously. This is a non-standard extension
 		/// to the protocol and may or may not work. A FtpCommandException will be
@@ -804,7 +804,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the CRC hash of the specified file using XCRC asynchronously. This is a non-standard extension
 		/// to the protocol and may or may not work. A FtpCommandException will be
@@ -892,7 +892,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the MD5 hash of the specified file using XMD5 asynchronously. This is a non-standard extension
 		/// to the protocol and may or may not work. A FtpCommandException will be
@@ -973,7 +973,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the SHA-1 hash of the specified file using XSHA1 asynchronously. This is a non-standard extension
 		/// to the protocol and may or may not work. A FtpCommandException will be
@@ -1055,7 +1055,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the SHA-256 hash of the specified file using XSHA256 asynchronously. This is a non-standard extension
 		/// to the protocol and may or may not work. A FtpCommandException will be
@@ -1137,7 +1137,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the SHA-512 hash of the specified file using XSHA512 asynchronously. This is a non-standard extension
 		/// to the protocol and may or may not work. A FtpCommandException will be

--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -288,7 +288,7 @@ namespace FluentFTP {
 			return UploadFiles(localFiles.Select(f => f.FullName), remoteDir, existsMode, createRemoteDir, verifyOptions, errorHandling);
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Uploads the given file paths to a single folder on the server asynchronously.
 		/// All files are placed directly into the given folder regardless of their path on the local filesystem.
@@ -548,7 +548,7 @@ namespace FluentFTP {
 			}
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Downloads the specified files into a local single directory.
 		/// High-level API that takes care of various edge cases internally.
@@ -706,7 +706,7 @@ namespace FluentFTP {
 			return UploadFileFromFile(localPath, remotePath, createRemoteDir, existsMode, false, false, verifyOptions);
 		}
 
-#if NET45 || CORE
+#if ASYNC
 
 		/// <summary>
 		/// Uploads the specified file directly onto the server asynchronously.
@@ -811,7 +811,7 @@ namespace FluentFTP {
 			return uploadSuccess && verified;
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		private async Task<bool> UploadFileFromFileAsync(string localPath, string remotePath, bool createRemoteDir, FtpExists existsMode,
 			bool fileExists, bool fileExistsKnown, FtpVerify verifyOptions, CancellationToken token) {
 
@@ -908,7 +908,7 @@ namespace FluentFTP {
 		}
 
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Uploads the specified stream as a file onto the server asynchronously.
 		/// High-level API that takes care of various edge cases internally.
@@ -1163,7 +1163,7 @@ namespace FluentFTP {
 			}
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Upload the given stream to the server as a new file asynchronously. Overwrites the file if it exists.
 		/// Writes data in chunks. Retries if server disconnects midway.
@@ -1421,7 +1421,7 @@ namespace FluentFTP {
 			return downloadSuccess && verified;
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Downloads the specified file onto the local file system asynchronously.
 		/// High-level API that takes care of various edge cases internally.
@@ -1593,7 +1593,7 @@ namespace FluentFTP {
 			return ok;
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Downloads the specified file into the specified stream asynchronously .
 		/// High-level API that takes care of various edge cases internally.
@@ -1827,7 +1827,7 @@ namespace FluentFTP {
 			}
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Download a file from the server and write the data into the given stream asynchronously.
 		/// Reads data in chunks. Retries if server disconnects midway.
@@ -2002,7 +2002,7 @@ namespace FluentFTP {
 			return true;
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		private async Task<bool> VerifyTransferAsync(string localPath, string remotePath) {
 
 			// verify args

--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -18,7 +18,7 @@ using System.Web;
 #if (CORE || NETFX)
 using System.Threading;
 #endif
-#if NET45 || CORE
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -286,7 +286,7 @@ namespace FluentFTP {
 			return GetAsyncDelegate<AsyncGetObjectInfo>(ar).EndInvoke(ar);
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Return information about a remote file system object asynchronously. 
 		/// </summary>
@@ -633,7 +633,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Gets a file listing from the server asynchronously. Each <see cref="FtpListItem"/> object returned
         /// contains information about the file that was able to be retrieved. 
@@ -1017,7 +1017,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Returns a file/directory listing using the NLST command asynchronously
 		/// </summary>

--- a/FluentFTP/Client/FtpClient_LowLevel.cs
+++ b/FluentFTP/Client/FtpClient_LowLevel.cs
@@ -19,7 +19,7 @@ using System.Web;
 #if (CORE || NETFX)
 using System.Threading;
 #endif
-#if NET45 || CORE
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -167,7 +167,7 @@ namespace FluentFTP {
 			return stream;
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Opens the specified type of passive data stream
         /// </summary>
@@ -413,7 +413,7 @@ namespace FluentFTP {
 			return stream;
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Opens the specified type of active data stream
         /// </summary>
@@ -608,7 +608,7 @@ namespace FluentFTP {
 			return stream;
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Opens a data stream.
         /// </summary>
@@ -905,7 +905,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Opens the specified file for reading asynchronously
 		/// </summary>
@@ -1115,7 +1115,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Opens the specified file for writing. Please call GetReply() after you have successfully transfered the file to read the "OK" command sent by the server and prevent stale data on the socket.
 		/// </summary>
@@ -1297,7 +1297,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Opens the specified file to be appended asynchronously
 		/// </summary>
@@ -1442,7 +1442,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Sets the data type of information sent over the data stream asynchronously
 		/// </summary>

--- a/FluentFTP/Client/FtpClient_Management.cs
+++ b/FluentFTP/Client/FtpClient_Management.cs
@@ -19,7 +19,7 @@ using System.Web;
 #if (CORE || NETFX)
 using System.Threading;
 #endif
-#if NET45 || CORE
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -134,7 +134,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Deletes a file from the server asynchronously
 		/// </summary>
@@ -342,7 +342,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Asynchronously removes a directory and all its contents.
 		/// </summary>
@@ -529,7 +529,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Tests if the specified directory exists on the server asynchronously. This
 		/// method works by trying to change the working directory to
@@ -680,7 +680,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Checks if a file exists on the server asynchronously.
 		/// </summary>
@@ -851,7 +851,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Creates a remote directory asynchronously
 		/// </summary>
@@ -973,7 +973,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Renames an object on the remote file system asynchronously.
 		/// Low level method that should NOT be used in most cases. Prefer MoveFile() and MoveDirectory().
@@ -1087,7 +1087,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 
 		/// <summary>
 		/// Moves a file asynchronously on the remote file system from one directory to another.
@@ -1218,7 +1218,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Moves a directory asynchronously on the remote file system from one directory to another.
 		/// Always checks if the source directory exists. Checks if the dest directory exists based on the `existsMode` parameter.
@@ -1299,7 +1299,7 @@ namespace FluentFTP {
 #endif
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Modify the permissions of the given file/folder.
 		/// Only works on *NIX systems, and not on Windows/IIS servers.
@@ -1337,7 +1337,7 @@ namespace FluentFTP {
 			SetFilePermissions(path, permissions);
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Modify the permissions of the given file/folder.
 		/// Only works on *NIX systems, and not on Windows/IIS servers.
@@ -1368,7 +1368,7 @@ namespace FluentFTP {
 			SetFilePermissions(path, CalcChmod(owner, group, other));
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Modify the permissions of the given file/folder.
 		/// Only works on *NIX systems, and not on Windows/IIS servers.
@@ -1401,7 +1401,7 @@ namespace FluentFTP {
 			SetFilePermissions(path, owner, group, other);
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Modify the permissions of the given file/folder.
 		/// Only works on *NIX systems, and not on Windows/IIS servers.
@@ -1443,7 +1443,7 @@ namespace FluentFTP {
 			return null;
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Retrieve the permissions of the given file/folder as an FtpListItem object with all "Permission" properties set.
 		/// Throws FtpCommandException if there is an issue.
@@ -1483,7 +1483,7 @@ namespace FluentFTP {
 			return item != null ? item.Chmod : 0;
 		}
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Retrieve the permissions of the given file/folder as an integer in the CHMOD format.
 		/// Throws FtpCommandException if there is an issue.
@@ -1619,7 +1619,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Derefence a FtpListItem object
         /// </summary>
@@ -1752,7 +1752,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Sets the working directory on the server asynchronously
 		/// </summary>
@@ -1845,7 +1845,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the current working directory asynchronously
 		/// </summary>
@@ -1958,7 +1958,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Retrieve the size of a remote file asynchronously
 		/// </summary>
@@ -2078,7 +2078,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the modified time of a remote file asynchronously
 		/// </summary>
@@ -2201,7 +2201,7 @@ namespace FluentFTP {
 		}
 
 #endif
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Gets the modified time of a remote file asynchronously
 		/// </summary>

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -21,6 +21,10 @@
     <DefineConstants>$(DefineConstants);CORE14;NO_SSL</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)'=='net45' Or $(DefineConstants.Contains('CORE'))">
+    <DefineConstants>$(DefineConstants);ASYNC</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <PackageId>FluentFTP</PackageId>
     <Description>An FTP and FTPS client for .NET &amp; .NET Standard, optimized for speed. Provides extensive FTP commands, File uploads/downloads, SSL/TLS connections, Automatic directory listing parsing, File hashing/checksums, File permissions/CHMOD, FTP proxies, UTF-8 support, Async/await support and more. Written entirely in C#, with no external dependencies.</Description>

--- a/FluentFTP/Stream/FtpDataStream.cs
+++ b/FluentFTP/Stream/FtpDataStream.cs
@@ -160,7 +160,7 @@ namespace FluentFTP {
 		/// Creates a new data stream object
 		/// </summary>
 		/// <param name="conn">The control connection to be used for carrying out this operation</param>
-		public FtpDataStream(FtpClient conn) {
+		public FtpDataStream(FtpClient conn) : base(conn.SslProtocols) {
 			if (conn == null)
 				throw new ArgumentException("The control connection cannot be null.");
 

--- a/FluentFTP/Stream/FtpDataStream.cs
+++ b/FluentFTP/Stream/FtpDataStream.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 using System.Diagnostics;
 using System.Threading;
 
-#if NET45 || CORE
+#if ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -81,7 +81,7 @@ namespace FluentFTP {
 			return read;
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Reads data off the stream asynchronously
         /// </summary>
@@ -108,7 +108,7 @@ namespace FluentFTP {
 			m_position += count;
 		}
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Writes data to the stream asynchronously
         /// </summary>

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -20,6 +20,12 @@ namespace FluentFTP
     /// </summary>
     public class FtpSocketStream : Stream, IDisposable
     {
+		private SslProtocols m_SslProtocols;
+		public FtpSocketStream(SslProtocols defaultSslProtocols)
+		{
+			m_SslProtocols = defaultSslProtocols;
+		}
+
         /// <summary>
         /// Used for tacking read/write activity on the socket
         /// to determine if Poll() should be used to test for
@@ -463,7 +469,7 @@ namespace FluentFTP
         }
 #endif
 
-#if CORE
+#if ASYNC && !NET45
         /// <summary>
         /// Bypass the stream and read directly off the socket.
         /// </summary>
@@ -1009,11 +1015,7 @@ namespace FluentFTP
         /// <param name="targethost">The host to authenticate the certificate against</param>
         public void ActivateEncryption(string targethost)
         {
-#if CORE
-			ActivateEncryption(targethost, null, SslProtocols.Tls11 | SslProtocols.Ssl3);
-#else
-            ActivateEncryption(targethost, null, SslProtocols.Default);
-#endif
+            ActivateEncryption(targethost, null, m_SslProtocols);
         }
 
 #if ASYNC
@@ -1025,11 +1027,7 @@ namespace FluentFTP
         /// <param name="targethost">The host to authenticate the certificate against</param>
         public async Task ActivateEncryptionAsync(string targethost)
         {
-#if CORE
-			await ActivateEncryptionAsync(targethost, null, SslProtocols.Tls11 | SslProtocols.Ssl3);
-#else
-            await ActivateEncryptionAsync(targethost, null, SslProtocols.Default);
-#endif
+            await ActivateEncryptionAsync(targethost, null, m_SslProtocols);
         }
 #endif
 
@@ -1042,11 +1040,7 @@ namespace FluentFTP
         /// <param name="clientCerts">A collection of client certificates to use when authenticating the SSL stream</param>
         public void ActivateEncryption(string targethost, X509CertificateCollection clientCerts)
         {
-#if CORE
-			ActivateEncryption(targethost, clientCerts, SslProtocols.Tls11 | SslProtocols.Ssl3);
-#else
-            ActivateEncryption(targethost, clientCerts, SslProtocols.Default);
-#endif
+            ActivateEncryption(targethost, clientCerts, m_SslProtocols);
         }
 
 #if ASYNC
@@ -1059,11 +1053,7 @@ namespace FluentFTP
         /// <param name="clientCerts">A collection of client certificates to use when authenticating the SSL stream</param>
         public async Task ActivateEncryptionAsync(string targethost, X509CertificateCollection clientCerts)
         {
-#if CORE
-			await ActivateEncryptionAsync(targethost, clientCerts, SslProtocols.Tls11 | SslProtocols.Ssl3);
-#else
-            await ActivateEncryptionAsync(targethost, clientCerts, SslProtocols.Default);
-#endif
+            await ActivateEncryptionAsync(targethost, clientCerts, m_SslProtocols);
         }
 #endif
 
@@ -1250,7 +1240,7 @@ namespace FluentFTP
         }
 #endif
 
-#if CORE
+#if ASYNC && !NET45
         /// <summary>
         /// Accepts a connection from a listening socket
         /// </summary>

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -408,7 +408,7 @@ namespace FluentFTP
             BaseStream.Flush();
         }
 
-#if NET45 || CORE
+#if ASYNC
 
 		/// <summary>
 		/// Flushes the stream asynchronously
@@ -512,7 +512,7 @@ namespace FluentFTP
 #endif
         }
 
-#if NET45 || CORE
+#if ASYNC
 
 		/// <summary>
 		/// Reads data from the stream
@@ -590,7 +590,7 @@ namespace FluentFTP
             }
         }
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Reads a line from the socket asynchronously
         /// </summary>
@@ -676,7 +676,7 @@ namespace FluentFTP
             m_lastActivity = DateTime.Now;
         }
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Writes data to the stream asynchronously
 		/// </summary>
@@ -705,7 +705,7 @@ namespace FluentFTP
             Write(data, 0, data.Length);
         }
 
-#if NET45 || CORE
+#if ASYNC
 		/// <summary>
 		/// Writes a line to the stream using the specified encoding asynchronously
 		/// </summary>
@@ -922,7 +922,7 @@ namespace FluentFTP
             m_lastActivity = DateTime.Now;
         }
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Connect to the specified host
         /// </summary>
@@ -1016,7 +1016,7 @@ namespace FluentFTP
 #endif
         }
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Activates SSL on this stream using default protocols. Fires the ValidateCertificate event. 
         /// If this event is not handled and there are SslPolicyErrors present, the certificate will 
@@ -1049,7 +1049,7 @@ namespace FluentFTP
 #endif
         }
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Activates SSL on this stream using default protocols. Fires the ValidateCertificate event.
         /// If this event is not handled and there are SslPolicyErrors present, the certificate will 
@@ -1130,7 +1130,7 @@ namespace FluentFTP
             }
         }
 
-#if NET45 || CORE
+#if ASYNC
         /// <summary>
         /// Activates SSL on this stream using the specified protocols. Fires the ValidateCertificate event.
         /// If this event is not handled and there are SslPolicyErrors present, the certificate will 


### PR DESCRIPTION
In a number of places in code the library uses `#if NET45 || CORE` to check if the framework supports await/async keywords. To make it more readable, I've added a `ASYNC` compiler keyword.

Also, I noticed that the library defaults to SSL3 + TLS 1.0 by default on .NET core. SSL3 is now considered obsolete and insecure, and the default since .NET 4.6 is to use TLS 1.0-1.2, so I've updated that.

The FtpClient class has an override to customise that (say you want to connect to older servers), but it was ignored by the `FtpSocketStream` class, so I've rectified that as well, making sure that we store the default `SslProtocols` value in a single place.