### PR TITLE
Bugfix active ftp for netcore

### DIFF
--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -1129,6 +1129,9 @@ namespace FluentFTP {
 		public async Task AcceptAsync() {
 			if (m_socket != null) {
                 m_socket = await m_socket.AcceptAsync();
+#if CORE
+				m_netStream = new NetworkStream(m_socket);
+#endif
 			}
 		}
 #else


### PR DESCRIPTION
m_netStream was never assigned in FtpSocketStream for netcore in active mode #221 