### PR TITLE
Fix a DownloadFileAsync/UploadFileAsync bug

### DIFF
--- a/FluentFTP/Client/FtpClient_LowLevel.cs
+++ b/FluentFTP/Client/FtpClient_LowLevel.cs
@@ -1463,6 +1463,8 @@ namespace FluentFTP {
                 default:
                     throw new FtpException("Unsupported data type: " + type.ToString());
             }
+
+			CurrentDataType = type;
         }
 #endif
 		#endregion


### PR DESCRIPTION
CurrentDataType was not modified in SetDataTypeAsync(), so if async methods are used, the downloading may not switch to correct data type. Causing some files to be downloaded in ASCII mode accidentally and sometimes cause unexpected end of stream exception.
In SetDataType(), CurrentDataType is modified, and now SetDataTypeAsync is set to the same behavior.
