### PR TITLE
Bug fixes for file downloading

### DIFF
--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -1795,6 +1795,8 @@ namespace FluentFTP {
 
 							// if we reach here means EOF encountered
 							// stop if we are in "read until EOF" mode
+							downStream.Dispose();
+
 							FtpReply reply = GetReply();
 							if (!readToEnd && offset != fileLen)
 								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
@@ -1853,6 +1855,8 @@ namespace FluentFTP {
 
 							// if we reach here means EOF encountered
 							// stop if we are in "read until EOF" mode
+							downStream.Dispose();
+
 							FtpReply reply = GetReply();
 							if (!readToEnd && offset != fileLen)
 								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
@@ -1879,7 +1883,6 @@ namespace FluentFTP {
 
 				// disconnect FTP stream before exiting
 				outStream.Flush();
-				downStream.Dispose();
 
 				return true;
 
@@ -1949,6 +1952,8 @@ namespace FluentFTP {
 
 							// if we reach here means EOF encountered
 							// stop if we are in "read until EOF" mode
+							downStream.Dispose();
+
 							FtpReply reply = await GetReplyAsync();
 							if (!readToEnd && offset != fileLen)
 								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
@@ -2003,6 +2008,8 @@ namespace FluentFTP {
 
 							// if we reach here means EOF encountered
 							// stop if we are in "read until EOF" mode
+							downStream.Dispose();
+
 							FtpReply reply = await GetReplyAsync();
 							if (!readToEnd && offset != fileLen)
 								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
@@ -2028,7 +2035,6 @@ namespace FluentFTP {
 
 				// disconnect FTP stream before exiting
 				await outStream.FlushAsync(token);
-				downStream.Dispose();
 
 				return true;
 

--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -1788,18 +1788,13 @@ namespace FluentFTP {
 
 							// if we reach here means EOF encountered
 							// stop if we are in "read until EOF" mode
-							downStream.Dispose();
+							if (readToEnd || offset == fileLen) {
+								break;
+							}
 
-							FtpReply reply = GetReply();
-							if (!readToEnd && offset != fileLen)
-								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
-							if (!reply.Code.StartsWith("2", StringComparison.Ordinal))
-								throw new IOException(
-									$"Unexpected EOF for remote file {remotePath} [{offset} bytes read but {reply.Code} received]",
-									new FtpCommandException(reply));
-							break;
-						}
-						catch (IOException ex) {
+							// zero return value (with no Exception) indicates EOS; so we should fail here and attempt to resume
+							throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
+						} catch (IOException ex) {
 
 							// resume if server disconnected midway, or throw if there is an exception doing that as well
 							if (!ResumeDownload(remotePath, ref downStream, offset, ex)) {
@@ -1848,18 +1843,13 @@ namespace FluentFTP {
 
 							// if we reach here means EOF encountered
 							// stop if we are in "read until EOF" mode
-							downStream.Dispose();
+							if (readToEnd || offset == fileLen) {
+								break;
+							}
 
-							FtpReply reply = GetReply();
-							if (!readToEnd && offset != fileLen)
-								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
-							if (!reply.Code.StartsWith("2", StringComparison.Ordinal))
-								throw new IOException(
-									$"Unexpected EOF for remote file {remotePath} [{offset} bytes read but {reply.Code} received]",
-									new FtpCommandException(reply));
-							break;
-						}
-						catch (IOException ex) {
+							// zero return value (with no Exception) indicates EOS; so we should fail here and attempt to resume
+							throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
+						} catch (IOException ex) {
 
 							// resume if server disconnected midway, or throw if there is an exception doing that as well
 							if (!ResumeDownload(remotePath, ref downStream, offset, ex)) {
@@ -1876,7 +1866,13 @@ namespace FluentFTP {
 
 				// disconnect FTP stream before exiting
 				outStream.Flush();
+				downStream.Dispose();
 
+				// FIX : if this is not added, there appears to be "stale data" on the socket
+				// listen for a success/failure reply
+				if (!m_threadSafeDataChannels) {
+					FtpReply status = GetReply();
+				}
 				return true;
 
 
@@ -1944,18 +1940,13 @@ namespace FluentFTP {
 
 							// if we reach here means EOF encountered
 							// stop if we are in "read until EOF" mode
-							downStream.Dispose();
+							if (readToEnd || offset == fileLen) {
+								break;
+							}
 
-							FtpReply reply = await GetReplyAsync();
-							if (!readToEnd && offset != fileLen)
-								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
-							if (!reply.Code.StartsWith("2", StringComparison.Ordinal))
-								throw new IOException(
-									$"Unexpected EOF for remote file {remotePath} [{offset} bytes read but {reply.Code} received]",
-									new FtpCommandException(reply));
-							break;
-						}
-						catch (IOException ex) {
+							// zero return value (with no Exception) indicates EOS; so we should fail here and attempt to resume
+							throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
+                        } catch (IOException ex) {
 
 							// resume if server disconnected midway, or throw if there is an exception doing that as well
 							if (!ResumeDownload(remotePath, ref downStream, offset, ex)) {
@@ -2000,18 +1991,13 @@ namespace FluentFTP {
 
 							// if we reach here means EOF encountered
 							// stop if we are in "read until EOF" mode
-							downStream.Dispose();
+							if (readToEnd || offset == fileLen) {
+								break;
+							}
 
-							FtpReply reply = await GetReplyAsync();
-							if (!readToEnd && offset != fileLen)
-								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
-							if (!reply.Code.StartsWith("2", StringComparison.Ordinal))
-								throw new IOException(
-									$"Unexpected EOF for remote file {remotePath} [{offset} bytes read but {reply.Code} received]",
-									new FtpCommandException(reply));
-							break;
-						}
-						catch (IOException ex) {
+							// zero return value (with no Exception) indicates EOS; so we should fail here and attempt to resume
+							throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
+						} catch (IOException ex) {
 
 							// resume if server disconnected midway, or throw if there is an exception doing that as well
 							if (!ResumeDownload(remotePath, ref downStream, offset, ex)) {
@@ -2027,7 +2013,13 @@ namespace FluentFTP {
 
 				// disconnect FTP stream before exiting
 				await outStream.FlushAsync(token);
+				downStream.Dispose();
 
+				// FIX : if this is not added, there appears to be "stale data" on the socket
+				// listen for a success/failure reply
+				if (!m_threadSafeDataChannels) {
+					FtpReply status = GetReply();
+				}
 				return true;
 
 			} catch (Exception ex1) {

--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -1754,7 +1754,7 @@ namespace FluentFTP {
 				
 				// get file size if downloading in binary mode (in ASCII mode we read until EOF)
 				long fileLen = 0;
-				if (CurrentDataType == FtpDataType.Binary){
+				if (DownloadDataType == FtpDataType.Binary){
 					fileLen = GetFileSize(remotePath);
 				}
 				
@@ -1909,7 +1909,8 @@ namespace FluentFTP {
 				
 				// get file size if downloading in binary mode (in ASCII mode we read until EOF)
 				long fileLen = 0;
-				if (CurrentDataType == FtpDataType.Binary){
+
+				if (DownloadDataType == FtpDataType.Binary){
 					fileLen = await GetFileSizeAsync(remotePath);
 				}
 				

--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -1795,7 +1795,7 @@ namespace FluentFTP {
 								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
 							if (!reply.Code.StartsWith("2", StringComparison.Ordinal))
 								throw new IOException(
-									$"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]",
+									$"Unexpected EOF for remote file {remotePath} [{offset} bytes read but {reply.Code} received]",
 									new FtpCommandException(reply));
 							break;
 						}
@@ -1855,7 +1855,7 @@ namespace FluentFTP {
 								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
 							if (!reply.Code.StartsWith("2", StringComparison.Ordinal))
 								throw new IOException(
-									$"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]",
+									$"Unexpected EOF for remote file {remotePath} [{offset} bytes read but {reply.Code} received]",
 									new FtpCommandException(reply));
 							break;
 						}
@@ -1950,7 +1950,7 @@ namespace FluentFTP {
 								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
 							if (!reply.Code.StartsWith("2", StringComparison.Ordinal))
 								throw new IOException(
-									$"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]",
+									$"Unexpected EOF for remote file {remotePath} [{offset} bytes read but {reply.Code} received]",
 									new FtpCommandException(reply));
 							break;
 						}
@@ -2006,7 +2006,7 @@ namespace FluentFTP {
 								throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
 							if (!reply.Code.StartsWith("2", StringComparison.Ordinal))
 								throw new IOException(
-									$"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]",
+									$"Unexpected EOF for remote file {remotePath} [{offset} bytes read but {reply.Code} received]",
 									new FtpCommandException(reply));
 							break;
 						}

--- a/FluentFTP/Stream/FtpDataStream.cs
+++ b/FluentFTP/Stream/FtpDataStream.cs
@@ -180,7 +180,7 @@ namespace FluentFTP {
 		/// </summary>
 		~FtpDataStream() {
 			try {
-				Dispose();
+				Dispose(false);
 			} catch (Exception ex) {
 				FtpTrace.WriteLine(FtpTraceLevel.Warn, "[Finalizer] Caught and discarded an exception while disposing the FtpDataStream: " + ex.ToString());
 			}

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -666,14 +666,6 @@ namespace FluentFTP {
 		/// <summary>
 		/// Disconnects from server
 		/// </summary>
-		public new void Dispose()
-		{
-			Dispose(true);
-		}
-
-		/// <summary>
-		/// Disconnects from server
-		/// </summary>
 		public void Close()
 		{
 			Dispose(true);

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -662,26 +662,29 @@ namespace FluentFTP {
 		}
 #endif
 
+#if CORE
 		/// <summary>
-		/// Disposes the stream
+		/// Disconnects from server
 		/// </summary>
-		protected override void Dispose(bool disposing)
+		public new void Dispose()
 		{
-			FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Disposing FtpSocketStream...");
-			Close();
+			Dispose(true);
 		}
 
 		/// <summary>
 		/// Disconnects from server
 		/// </summary>
-#if CORE
 		public void Close()
 		{
-			base.Dispose(true);
-#else
-		public override void Close() {
-			base.Close();
+			Dispose(true);
+		}
 #endif
+
+		/// <summary>
+		/// Disconnects from server
+		/// </summary>
+		protected override void Dispose(bool disposing) {
+			FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Disposing FtpSocketStream...");
 			if (m_socket != null) {
 				try {
 					if (m_socket.Connected) {

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -665,7 +665,8 @@ namespace FluentFTP {
 		/// <summary>
 		/// Disposes the stream
 		/// </summary>
-		public new void Dispose() {
+		protected override void Dispose(bool disposing)
+		{
 			FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Disposing FtpSocketStream...");
 			Close();
 		}


### PR DESCRIPTION
1. fix wrong type checking in DownloadFileInternal and DownloadFileInternalAsync
2. fix the bug that sometimes FtpSocketStream and FtpDataStream are not disposed in Dispose()