### PR TITLE
Fix AppVeyor failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ after_build:
 test_script:
 - cmd: >-
     dotnet test fluentftp.tests -f net452
+    
     dotnet test fluentftp.tests -f netcoreapp1.0
 
 artifacts:


### PR DESCRIPTION
AppVeyor recognized the two testing commands as one. Adding a new line between should fix this.