### PR TITLE
Fixes for using active FTP and specifying the ActivePorts

### DIFF
--- a/FluentFTP/Client/FtpClient_Connection.cs
+++ b/FluentFTP/Client/FtpClient_Connection.cs
@@ -784,6 +784,7 @@ namespace FluentFTP {
 			conn.RecursiveList = RecursiveList;
 			conn.DownloadDataType = DownloadDataType;
 			conn.UploadDataType = UploadDataType;
+			conn.ActivePorts = ActivePorts;
 #if !CORE
 			conn.PlainTextEncryption = PlainTextEncryption;
 #endif

--- a/FluentFTP/Client/FtpClient_LowLevel.cs
+++ b/FluentFTP/Client/FtpClient_LowLevel.cs
@@ -313,6 +313,7 @@ namespace FluentFTP {
 					try {
 						stream.Listen(m_stream.LocalEndPoint.Address, port);
 						success = true;
+						break;
 					} catch (SocketException se) {
 #if NETFX
 						// Already in use

--- a/FluentFTP/Client/FtpClient_LowLevel.cs
+++ b/FluentFTP/Client/FtpClient_LowLevel.cs
@@ -448,6 +448,7 @@ namespace FluentFTP {
                     {
                         stream.Listen(m_stream.LocalEndPoint.Address, port);
                         success = true;
+	                    break;
                     }
                     catch (SocketException se)
                     {


### PR DESCRIPTION
* FtpClient_LowLevel.cs need to break the foreach loop when a port is successful otherwise we get errors.
* FtpClient_Connection.cs needs to clone the ActivePorts as well when using EnableThreadSafeDataConnections.