### PR TITLE
Fix a race condition with all async methods.

### DIFF
--- a/FluentFTP/Client/FtpClient_Connection.cs
+++ b/FluentFTP/Client/FtpClient_Connection.cs
@@ -876,8 +876,8 @@ namespace FluentFTP {
 			AsyncExecute func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncExecute(Execute)).BeginInvoke(command, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncExecute(Execute)).BeginInvoke(command, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1492,9 +1492,8 @@ namespace FluentFTP {
 			AsyncConnect func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncConnect(Connect)).BeginInvoke(callback, state);
-
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncConnect(Connect)).BeginInvoke(callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1618,8 +1617,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncDisconnect func;
 
-			ar = (func = new AsyncDisconnect(Disconnect)).BeginInvoke(callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncDisconnect(Disconnect)).BeginInvoke(callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 

--- a/FluentFTP/Client/FtpClient_Hash.cs
+++ b/FluentFTP/Client/FtpClient_Hash.cs
@@ -132,8 +132,8 @@ namespace FluentFTP {
 			AsyncGetHashAlgorithm func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncGetHashAlgorithm(GetHashAlgorithm)).BeginInvoke(callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncGetHashAlgorithm(GetHashAlgorithm)).BeginInvoke(callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -238,8 +238,8 @@ namespace FluentFTP {
 			AsyncSetHashAlgorithm func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncSetHashAlgorithm(SetHashAlgorithm)).BeginInvoke(type, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncSetHashAlgorithm(SetHashAlgorithm)).BeginInvoke(type, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -377,8 +377,8 @@ namespace FluentFTP {
 			AsyncGetHash func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncGetHash(GetHash)).BeginInvoke(path, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncGetHash(GetHash)).BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -550,10 +550,10 @@ namespace FluentFTP {
 		public IAsyncResult BeginGetChecksum(string path, AsyncCallback callback,
 			object state) {
 			AsyncGetChecksum func = new AsyncGetChecksum(GetChecksum);
-			IAsyncResult ar = func.BeginInvoke(path, callback, state);
-			;
+			IAsyncResult ar;
 
 			lock (m_asyncmethods) {
+				ar = func.BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -687,10 +687,10 @@ namespace FluentFTP {
 		/// <returns>IAsyncResult</returns>
 		public IAsyncResult BeginGetMD5(string path, AsyncCallback callback, object state) {
 			AsyncGetMD5 func = new AsyncGetMD5(GetMD5);
-			IAsyncResult ar = func.BeginInvoke(path, callback, state);
-			;
+			IAsyncResult ar;
 
 			lock (m_asyncmethods) {
+				ar = func.BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -775,9 +775,10 @@ namespace FluentFTP {
 		/// <returns>IAsyncResult</returns>
 		public IAsyncResult BeginGetXCRC(string path, AsyncCallback callback, object state) {
 			AsyncGetXCRC func = new AsyncGetXCRC(GetXCRC);
-			IAsyncResult ar = func.BeginInvoke(path, callback, state); ;
-
+			IAsyncResult ar;
+			
 			lock (m_asyncmethods) {
+				ar = func.BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -863,9 +864,10 @@ namespace FluentFTP {
 		/// <returns>IAsyncResult</returns>
 		public IAsyncResult BeginGetXMD5(string path, AsyncCallback callback, object state) {
 			AsyncGetXMD5 func = new AsyncGetXMD5(GetXMD5);
-			IAsyncResult ar = func.BeginInvoke(path, callback, state); ;
-
+			IAsyncResult ar;
+			
 			lock (m_asyncmethods) {
+				ar = func.BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -944,9 +946,10 @@ namespace FluentFTP {
 		/// <returns>IAsyncResult</returns>
 		public IAsyncResult BeginGetXSHA1(string path, AsyncCallback callback, object state) {
 			AsyncGetXSHA1 func = new AsyncGetXSHA1(GetXSHA1);
-			IAsyncResult ar = func.BeginInvoke(path, callback, state); ;
+			IAsyncResult ar;
 
 			lock (m_asyncmethods) {
+				ar = func.BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1026,9 +1029,10 @@ namespace FluentFTP {
 		/// <returns>IAsyncResult</returns>
 		public IAsyncResult BeginGetXSHA256(string path, AsyncCallback callback, object state) {
 			AsyncGetXSHA256 func = new AsyncGetXSHA256(GetXSHA256);
-			IAsyncResult ar = func.BeginInvoke(path, callback, state); ;
+			IAsyncResult ar;
 
 			lock (m_asyncmethods) {
+				ar = func.BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1108,9 +1112,10 @@ namespace FluentFTP {
 		/// <returns>IAsyncResult</returns>
 		public IAsyncResult BeginGetXSHA512(string path, AsyncCallback callback, object state) {
 			AsyncGetXSHA512 func = new AsyncGetXSHA512(GetXSHA512);
-			IAsyncResult ar = func.BeginInvoke(path, callback, state); ;
+			IAsyncResult ar;
 
 			lock (m_asyncmethods) {
+				ar = func.BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 

--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -269,8 +269,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncGetObjectInfo func;
 
-			ar = (func = new AsyncGetObjectInfo(GetObjectInfo)).BeginInvoke(path, dateModified, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncGetObjectInfo(GetObjectInfo)).BeginInvoke(path, dateModified, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -614,8 +614,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncGetListing func;
 
-			ar = (func = new AsyncGetListing(GetListing)).BeginInvoke(path, options, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncGetListing(GetListing)).BeginInvoke(path, options, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -987,8 +987,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncGetNameListing func;
 
-			ar = (func = new AsyncGetNameListing(GetNameListing)).BeginInvoke(path, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncGetNameListing(GetNameListing)).BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 

--- a/FluentFTP/Client/FtpClient_LowLevel.cs
+++ b/FluentFTP/Client/FtpClient_LowLevel.cs
@@ -888,8 +888,8 @@ namespace FluentFTP {
 			AsyncOpenRead func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncOpenRead(OpenRead)).BeginInvoke(path, type, restart, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncOpenRead(OpenRead)).BeginInvoke(path, type, restart, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1098,8 +1098,8 @@ namespace FluentFTP {
 			AsyncOpenWrite func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncOpenWrite(OpenWrite)).BeginInvoke(path, type, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncOpenWrite(OpenWrite)).BeginInvoke(path, type, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1280,8 +1280,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncOpenAppend func;
 
-			ar = (func = new AsyncOpenAppend(OpenAppend)).BeginInvoke(path, type, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncOpenAppend(OpenAppend)).BeginInvoke(path, type, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1429,8 +1429,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncSetDataType func;
 
-			ar = (func = new AsyncSetDataType(SetDataType)).BeginInvoke(type, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncSetDataType(SetDataType)).BeginInvoke(type, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 

--- a/FluentFTP/Client/FtpClient_Management.cs
+++ b/FluentFTP/Client/FtpClient_Management.cs
@@ -116,8 +116,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncDeleteFile func;
 
-			ar = (func = new AsyncDeleteFile(DeleteFile)).BeginInvoke(path, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncDeleteFile(DeleteFile)).BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -324,8 +324,8 @@ namespace FluentFTP {
 			AsyncDeleteDirectory func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncDeleteDirectory(DeleteDirectory)).BeginInvoke(path, options, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncDeleteDirectory(DeleteDirectory)).BeginInvoke(path, options, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -510,8 +510,8 @@ namespace FluentFTP {
 			AsyncDirectoryExists func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncDirectoryExists(DirectoryExists)).BeginInvoke(path, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncDirectoryExists(DirectoryExists)).BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -660,9 +660,10 @@ namespace FluentFTP {
 		/// <example><code source="..\Examples\BeginFileExists.cs" lang="cs" /></example>
 		public IAsyncResult BeginFileExists(string path, AsyncCallback callback, object state) {
 			AsyncFileExists func;
+			IAsyncResult ar;
 
-			IAsyncResult ar = (func = new AsyncFileExists(FileExists)).BeginInvoke(path, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncFileExists(FileExists)).BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -833,8 +834,8 @@ namespace FluentFTP {
 			AsyncCreateDirectory func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncCreateDirectory(CreateDirectory)).BeginInvoke(path, force, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncCreateDirectory(CreateDirectory)).BeginInvoke(path, force, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -955,8 +956,8 @@ namespace FluentFTP {
 			AsyncRename func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncRename(Rename)).BeginInvoke(path, dest, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncRename(Rename)).BeginInvoke(path, dest, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1070,8 +1071,8 @@ namespace FluentFTP {
 			AsyncMoveFile func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncMoveFile(MoveFile)).BeginInvoke(path, dest, existsMode, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncMoveFile(MoveFile)).BeginInvoke(path, dest, existsMode, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1201,8 +1202,8 @@ namespace FluentFTP {
 			AsyncMoveDirectory func;
 			IAsyncResult ar;
 
-			ar = (func = new AsyncMoveDirectory(MoveDirectory)).BeginInvoke(path, dest, existsMode, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncMoveDirectory(MoveDirectory)).BeginInvoke(path, dest, existsMode, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1586,8 +1587,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncDereferenceLink func;
 
-			ar = (func = new AsyncDereferenceLink(DereferenceLink)).BeginInvoke(item, recMax, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncDereferenceLink(DereferenceLink)).BeginInvoke(item, recMax, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1734,8 +1735,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncSetWorkingDirectory func;
 
-			ar = (func = new AsyncSetWorkingDirectory(SetWorkingDirectory)).BeginInvoke(path, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncSetWorkingDirectory(SetWorkingDirectory)).BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1826,8 +1827,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncGetWorkingDirectory func;
 
-			ar = (func = new AsyncGetWorkingDirectory(GetWorkingDirectory)).BeginInvoke(callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncGetWorkingDirectory(GetWorkingDirectory)).BeginInvoke(callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -1939,8 +1940,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncGetFileSize func;
 
-			ar = (func = new AsyncGetFileSize(GetFileSize)).BeginInvoke(path, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncGetFileSize(GetFileSize)).BeginInvoke(path, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -2059,8 +2060,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncGetModifiedTime func;
 
-			ar = (func = new AsyncGetModifiedTime(GetModifiedTime)).BeginInvoke(path, type, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncGetModifiedTime(GetModifiedTime)).BeginInvoke(path, type, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 
@@ -2183,8 +2184,8 @@ namespace FluentFTP {
 			IAsyncResult ar;
 			AsyncSetModifiedTime func;
 
-			ar = (func = new AsyncSetModifiedTime(SetModifiedTime)).BeginInvoke(path, date, type, callback, state);
 			lock (m_asyncmethods) {
+				ar = (func = new AsyncSetModifiedTime(SetModifiedTime)).BeginInvoke(path, date, type, callback, state);
 				m_asyncmethods.Add(ar, func);
 			}
 


### PR DESCRIPTION
Fix a race condition when BeginInvoke calls the callback before the IAsyncResult is added to m_asyncmethods.

By moving the BeginInvoke inside of the lock it is no longer possible for the End method to be called before the IAsyncResult is added to m_asyncmethods.

This fixes issue #294.