### PR TITLE
Fixes Many Unexpected EOF for remote file IOException on Android

### DIFF
--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -2066,12 +2066,12 @@ namespace FluentFTP {
 
 		private bool ResumeDownload(string remotePath, ref Stream downStream, long offset, IOException ex) {
 			// resume if server disconnects midway (fixes #39)
-			if (ex.InnerException != null) {
+			if (ex.InnerException != null || ex.Message.StartsWith("Unexpected EOF for remote file")) {
 				var ie = ex.InnerException as System.Net.Sockets.SocketException;
 #if CORE
-				if (ie != null && (int)ie.SocketErrorCode == 10054) {
+				if (ie == null || (ie != null && (int)ie.SocketErrorCode == 10054)) {
 #else
-				if (ie != null && ie.ErrorCode == 10054) {
+				if (ie == null || (ie != null && ie.ErrorCode == 10054)) {
 #endif
 					downStream.Dispose();
 					downStream = OpenRead(remotePath, DownloadDataType, restart: offset);


### PR DESCRIPTION
Related with issue https://github.com/robinrodricks/FluentFTP/issues/308
In a multiplatform app for UWP and Android that shares assemblies for accesing ftp code I found that for the same files (of approximattely 6 MB each file) and same server (Filezilla server) the UWP app doesn't fails downloading  those files, but Android app fails almost every time with this exception:  IOException "Unexpected EOF for remote file ..." https://github.com/robinrodricks/FluentFTP/blob/master/FluentFTP/Client/FtpClient_HighLevel.cs#L1814

Problem could be caused by this behavior of the java bytecode to which is translated C# in a xamarin code: https://wiki.sei.cmu.edu/confluence/display/java/FIO10-J.+Ensure+the+array+is+filled+when+using+read%28%29+to+fill+an+array

Initially I tried to fix it with the proposed solution at that post, I mean retrying a read  when readbytes is 0 and the total size of the stream was not readed but despite initially it looked it worked, later I found it doesn't work cause at some point next reads always return a 0 value for bytes read.
What finally has worked properly is to include code in ResumeDownload method to also resume download when this exception is thrown.