### PR TITLE
Make Dispose method of FTPClient virtual

### DIFF
--- a/FluentFTP/Client/FtpClient_Connection.cs
+++ b/FluentFTP/Client/FtpClient_Connection.cs
@@ -692,7 +692,7 @@ namespace FluentFTP {
 		/// Disconnects from the server, releases resources held by this
 		/// object.
 		/// </summary>
-		public void Dispose() {
+		public virtual void Dispose() {
 #if !CORE14
 			lock (m_lock) {
 #endif


### PR DESCRIPTION
In this PR the Dispose method of the FtpClient is made virtual. This makes it possible to add custom dispose logic in an inherited class. So far I have overriden the virtual Disconnect method. But I think making the dispose method virtual is more accurate.