### PR TITLE
Added new upload option to AppendNoCheck so that we can append with no check.

### DIFF
--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -1023,8 +1023,18 @@ namespace FluentFTP {
 
 				// check if the file exists, and skip, overwrite or append
 				if (existsMode == FtpExists.NoCheck) {
+					checkFileExistsAgain = true;	
+				}
+				else if (existsMode == FtpExists.AppendNoCheck) {
 					checkFileExistsAgain = true;
-				} else {
+					
+					offset = GetFileSize(remotePath);
+					if (offset == -1)
+					{
+						offset = 0; // start from the beginning
+					}
+				}
+				else {
 					if (!fileExistsKnown) {
 						fileExists = FileExists(remotePath);
 					}

--- a/FluentFTP/Helpers/FtpEnums.cs
+++ b/FluentFTP/Helpers/FtpEnums.cs
@@ -486,7 +486,12 @@ namespace FluentFTP {
 		/// <summary>
 		/// Append to the file if it exists, by checking the length and adding the missing data.
 		/// </summary>
-		Append
+		Append,
+		/// <summary>
+		/// Append to the file, but don't check if it exists and add missing data.   This might be required if you don't have permissions on the server to list files in the folder.
+		/// Only use this if you are SURE that the file does not exist on the server otherwise it can cause the UploadFile method to hang due to filesize mismatch.
+		/// </summary>
+		AppendNoCheck
 	}
 
     /// <summary>


### PR DESCRIPTION
Added new upload option to AppendNoCheck so that we can append a file on the server without checking if it exists yet.  This is required if the server you are uplaoding to does not allow you to list the contents of the folder, but the file does exist.

The call will throw an exception when the NLIST command is used, this will bypass the exception since we are not checking the directory for the file.
