### PR TITLE
Add Cancellation Token support and async timeout

### DIFF
--- a/FluentFTP.Examples/AsyncConnect.cs
+++ b/FluentFTP.Examples/AsyncConnect.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentFTP;
+
+namespace Examples
+{
+	static class AsyncConnectExample
+	{
+		public static async Task AsyncConnectAsync()
+		{
+			var cts = new CancellationTokenSource(10000);
+			using (var conn = new FtpClient())
+			{
+				conn.Host = "127.0.0.1";
+				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
+				await conn.ConnectAsync(cts.Token);
+				await conn.UploadAsync(new byte[1000 * 1000], "test/file", createRemoteDir: true, token: cts.Token);
+			}
+		}
+	}
+}

--- a/FluentFTP.Examples/Examples.csproj
+++ b/FluentFTP.Examples/Examples.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>
     <OutputType>Exe</OutputType>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/FluentFTP.Examples/Main.cs
+++ b/FluentFTP.Examples/Main.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Examples {
     class MainClass {
-        public static void Main(string[] args) {
+        public static async Task Main(string[] args) {
             Debug.Listeners.Add(new ConsoleTraceListener());
 
             try {
+                // await AsyncConnectExample.AsyncConnectAsync();
                 //BeginConnectExample.BeginConnect();
                 //BeginCreateDirectoryExample.BeginCreateDirectory();
                 //BeginDeleteDirectoryExample.BeginDeleteDirectory();

--- a/FluentFTP/Client/FtpClient_Hash.cs
+++ b/FluentFTP/Client/FtpClient_Hash.cs
@@ -412,6 +412,7 @@ namespace FluentFTP {
 		/// http://tools.ietf.org/html/draft-bryan-ftpext-hash-02
 		/// </remarks>
 		/// <param name="path">The file you want the server to compute the hash for</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <exception cref="FtpCommandException">
 		/// Thrown if the <see cref="HashAlgorithms"/> property is <see cref="FtpHashAlgorithm.NONE"/>, 
 		/// the remote path does not exist, or the command cannot be executed.
@@ -419,8 +420,7 @@ namespace FluentFTP {
 		/// <exception cref="ArgumentException">Path argument is null</exception>
 		/// <exception cref="NotImplementedException">Thrown when an unknown hash algorithm type is returned by the server</exception>
 		/// <returns>The hash of the file.</returns>
-		public async Task<FtpHash> GetHashAsync(string path) {
-			//TODO:  Add cancellation support
+		public async Task<FtpHash> GetHashAsync(string path, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 			FtpHash hash = new FtpHash();
 			Match m;
@@ -428,7 +428,7 @@ namespace FluentFTP {
 			if (path == null)
 				throw new ArgumentException("GetHash(path) argument can't be null");
 
-			if (!(reply = await ExecuteAsync("HASH " + path.GetFtpPath())).Success)
+			if (!(reply = await ExecuteAsync("HASH " + path.GetFtpPath(), token)).Success)
 				throw new FtpCommandException(reply);
 
 			// Current draft says the server should return this:
@@ -596,16 +596,16 @@ namespace FluentFTP {
 		/// 6. XCRC command
 		/// </remarks>
 		/// <param name="path">Full or relative path of the file to checksum</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <returns><see cref="FtpHash"/> object containing the value and algorithm. Use the <see cref="FtpHash.IsValid"/> property to
 		/// determine if this command was successful. <see cref="FtpCommandException"/>s can be thrown from
 		/// the underlying calls.</returns>
 		/// <example><code source="..\Examples\GetChecksum.cs" lang="cs" /></example>
 		/// <exception cref="FtpCommandException">The command fails</exception>
-		public async Task<FtpHash> GetChecksumAsync(string path) {
-			//TODO:  Add cancellation support
+		public async Task<FtpHash> GetChecksumAsync(string path, CancellationToken token = default(CancellationToken)) {
 			if (HasFeature(FtpCapability.HASH))
 			{
-				return await GetHashAsync(path);
+				return await GetHashAsync(path, token);
 			}
 			else
 			{
@@ -613,32 +613,32 @@ namespace FluentFTP {
 
 				if (HasFeature(FtpCapability.MD5))
 				{
-					res.Value = await GetMD5Async(path);
+					res.Value = await GetMD5Async(path, token);
 					res.Algorithm = FtpHashAlgorithm.MD5;
 				}
 				else if (HasFeature(FtpCapability.XMD5))
 				{
-					res.Value = await GetXMD5Async(path);
+					res.Value = await GetXMD5Async(path, token);
 					res.Algorithm = FtpHashAlgorithm.MD5;
 				}
 				else if (HasFeature(FtpCapability.XSHA1))
 				{
-					res.Value = await GetXSHA1Async(path);
+					res.Value = await GetXSHA1Async(path, token);
 					res.Algorithm = FtpHashAlgorithm.SHA1;
 				}
 				else if (HasFeature(FtpCapability.XSHA256))
 				{
-					res.Value = await GetXSHA256Async(path);
+					res.Value = await GetXSHA256Async(path, token);
 					res.Algorithm = FtpHashAlgorithm.SHA256;
 				}
 				else if (HasFeature(FtpCapability.XSHA512))
 				{
-					res.Value = await GetXSHA512Async(path);
+					res.Value = await GetXSHA512Async(path, token);
 					res.Algorithm = FtpHashAlgorithm.SHA512;
 				}
 				else if (HasFeature(FtpCapability.XCRC))
 				{
-					res.Value = await GetXCRCAsync(path);
+					res.Value = await GetXCRCAsync(path, token);
 					res.Algorithm = FtpHashAlgorithm.CRC;
 				}
 
@@ -724,13 +724,14 @@ namespace FluentFTP {
 		/// thrown if the command fails.
 		/// </summary>
 		/// <param name="path">Full or relative path to remote file</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <returns>Server response, presumably the MD5 hash.</returns>
 		/// <exception cref="FtpCommandException">The command fails</exception>
-		public async Task<string> GetMD5Async(string path) {
+		public async Task<string> GetMD5Async(string path, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 			string response;
 
-			if (!(reply = await ExecuteAsync("MD5 " + path)).Success)
+			if (!(reply = await ExecuteAsync("MD5 " + path, token)).Success)
 				throw new FtpCommandException(reply);
 
 			response = reply.Message;
@@ -812,13 +813,14 @@ namespace FluentFTP {
 		/// thrown if the command fails.
 		/// </summary>
 		/// <param name="path">Full or relative path to remote file</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <returns>Server response, presumably the CRC hash.</returns>
 		/// <exception cref="FtpCommandException">The command fails</exception>
-		public async Task<string> GetXCRCAsync(string path) {
+		public async Task<string> GetXCRCAsync(string path, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 			string response;
 
-			if (!(reply = await ExecuteAsync("MD5 " + path)).Success)
+			if (!(reply = await ExecuteAsync("MD5 " + path, token)).Success)
 				throw new FtpCommandException(reply);
 
 			response = reply.Message;
@@ -901,12 +903,13 @@ namespace FluentFTP {
 		/// thrown if the command fails.
 		/// </summary>
 		/// <param name="path">Full or relative path to remote file</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <returns>Server response, presumably the MD5 hash.</returns>
 		/// <exception cref="FtpCommandException">The command fails</exception>
-		public async Task<string> GetXMD5Async(string path) {
+		public async Task<string> GetXMD5Async(string path, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 
-			if (!(reply = await ExecuteAsync("XMD5 " + path)).Success)
+			if (!(reply = await ExecuteAsync("XMD5 " + path, token)).Success)
 				throw new FtpCommandException(reply);
 
 			return reply.Message;
@@ -983,12 +986,13 @@ namespace FluentFTP {
 		/// thrown if the command fails.
 		/// </summary>
 		/// <param name="path">Full or relative path to remote file</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <returns>Server response, presumably the SHA-1 hash.</returns>
 		/// <exception cref="FtpCommandException">The command fails</exception>
-		public async Task<string> GetXSHA1Async(string path) {
+		public async Task<string> GetXSHA1Async(string path, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 
-			if (!(reply = await ExecuteAsync("XSHA1 " + path)).Success)
+			if (!(reply = await ExecuteAsync("XSHA1 " + path, token)).Success)
 				throw new FtpCommandException(reply);
 
 			return reply.Message;
@@ -1066,12 +1070,13 @@ namespace FluentFTP {
 		/// thrown if the command fails.
 		/// </summary>
 		/// <param name="path">Full or relative path to remote file</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <returns>Server response, presumably the SHA-256 hash.</returns>
 		/// <exception cref="FtpCommandException">The command fails</exception>
-		public async Task<string> GetXSHA256Async(string path) {
+		public async Task<string> GetXSHA256Async(string path, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 
-			if (!(reply = await ExecuteAsync("XSHA256 " + path)).Success)
+			if (!(reply = await ExecuteAsync("XSHA256 " + path, token)).Success)
 				throw new FtpCommandException(reply);
 
 			return reply.Message;
@@ -1149,12 +1154,13 @@ namespace FluentFTP {
 		/// thrown if the command fails.
 		/// </summary>
 		/// <param name="path">Full or relative path to remote file</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <returns>Server response, presumably the SHA-512 hash.</returns>
 		/// <exception cref="FtpCommandException">The command fails</exception>
-		public async Task<string> GetXSHA512Async(string path) {
+		public async Task<string> GetXSHA512Async(string path, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 
-			if (!(reply = await ExecuteAsync("XSHA512 " + path)).Success)
+			if (!(reply = await ExecuteAsync("XSHA512 " + path, token)).Success)
 				throw new FtpCommandException(reply);
 
 			return reply.Message;

--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -311,7 +311,7 @@ namespace FluentFTP {
 		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
 		/// to propagate from this method.
 		/// </remarks>
-		public async Task<int> UploadFilesAsync(IEnumerable<string> localPaths, string remoteDir, FtpExists existsMode, bool createRemoteDir, FtpVerify verifyOptions, FtpError errorHandling, CancellationToken token) {
+		public async Task<int> UploadFilesAsync(IEnumerable<string> localPaths, string remoteDir, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = true, FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None, CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (!errorHandling.IsValidCombination())
@@ -335,14 +335,14 @@ namespace FluentFTP {
 
 			// create remote dir if wanted
 			if (createRemoteDir) {
-				if (!await DirectoryExistsAsync(remoteDir)) {
-					await CreateDirectoryAsync(remoteDir);
+				if (!await DirectoryExistsAsync(remoteDir, token)) {
+					await CreateDirectoryAsync(remoteDir, token);
 					checkFileExistence = false;
 				}
 			}
 
 			// get all the already existing files (if directory was created just create an empty array)
-			string[] existingFiles = checkFileExistence ? await GetNameListingAsync(remoteDir) : new string[0];
+			string[] existingFiles = checkFileExistence ? await GetNameListingAsync(remoteDir, token) : new string[0];
 
 			// per local file
 			foreach (string localPath in localPaths) {
@@ -406,31 +406,6 @@ namespace FluentFTP {
 			foreach (string remotePath in remotePaths) {
 				await this.DeleteFileAsync(remotePath);
 			}
-		}
-
-		/// <summary>
-		/// Uploads the given file paths to a single folder on the server asynchronously.
-		/// All files are placed directly into the given folder regardless of their path on the local filesystem.
-		/// High-level API that takes care of various edge cases internally.
-		/// Supports very large files since it uploads data in chunks.
-		/// Faster than uploading single files with <see cref="o:UploadFile"/> since it performs a single "file exists" check rather than one check per file.
-		/// </summary>
-		/// <param name="localPaths">The full or relative paths to the files on the local file system. Files can be from multiple folders.</param>
-		/// <param name="remoteDir">The full or relative path to the directory that files will be uploaded on the server</param>
-		/// <param name="existsMode">What to do if the file already exists? Skip, overwrite or append? Set this to FtpExists.None for fastest performance but only if you are SURE that the files do not exist on the server.</param>
-		/// <param name="createRemoteDir">Create the remote directory if it does not exist.</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful upload and what to do if it fails verification (See Remarks)</param>
-		/// <param name="errorHandling">Used to determine how errors are handled</param>
-		/// <returns>The count of how many files were uploaded successfully. Affected when files are skipped when they already exist.</returns>
-		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpExists.Overwrite"/>.
-		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
-		/// to propagate from this method.
-		/// </remarks>
-		public async Task<int> UploadFilesAsync(IEnumerable<string> localPaths, string remoteDir, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = true, FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None) {
-			return await UploadFilesAsync(localPaths, remoteDir, existsMode, createRemoteDir, verifyOptions, errorHandling, CancellationToken.None);
 		}
 #endif
 
@@ -569,8 +544,8 @@ namespace FluentFTP {
 		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
 		/// to propagate from this method.
 		/// </remarks>
-        public async Task<int> DownloadFilesAsync(string localDir, IEnumerable<string> remotePaths, FtpLocalExists existsMode, FtpVerify verifyOptions,
-			FtpError errorHandling, CancellationToken token) {
+        public async Task<int> DownloadFilesAsync(string localDir, IEnumerable<string> remotePaths, FtpLocalExists existsMode = FtpLocalExists.Overwrite,
+			FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None, CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (!errorHandling.IsValidCombination())
@@ -596,7 +571,7 @@ namespace FluentFTP {
 
 				// try to download it
 				try {
-                    bool ok = await DownloadFileToFileAsync(localPath, remotePath, existsMode, verifyOptions, token, null);
+                    bool ok = await DownloadFileToFileAsync(localPath, remotePath, existsMode, verifyOptions, token: token);
 					if (ok) {
 						successfulDownloads.Add(localPath);
 					} else if ((int)errorHandling > 1) {
@@ -638,30 +613,6 @@ namespace FluentFTP {
 			}
 
 			return successfulDownloads.Count;
-		}
-
-		/// <summary>
-		/// Downloads the specified files into a local single directory.
-		/// High-level API that takes care of various edge cases internally.
-		/// Supports very large files since it downloads data in chunks.
-		/// Same speed as <see cref="o:DownloadFile"/>.
-		/// </summary>
-		/// <param name="localDir">The full or relative path to the directory that files will be downloaded into.</param>
-		/// <param name="remotePaths">The full or relative paths to the files on the server</param>
-        /// <param name="existsMode">If the file exists on disk, should we skip it, resume the download or restart the download?</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful download and what to do if it fails verification (See Remarks)</param>
-		/// <param name="errorHandling">Used to determine how errors are handled</param>
-		/// <returns>The count of how many files were downloaded successfully. When existing files are skipped, they are not counted.</returns>
-		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically be set to true for subsequent attempts.
-		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
-		/// to propagate from this method.
-		/// </remarks>
-        public async Task<int> DownloadFilesAsync(string localDir, IEnumerable<string> remotePaths, FtpLocalExists existsMode = FtpLocalExists.Overwrite,
-			FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None) {
-            return await DownloadFilesAsync(localDir, remotePaths, existsMode, verifyOptions, errorHandling, CancellationToken.None);
 		}
 #endif
 
@@ -728,8 +679,7 @@ namespace FluentFTP {
 		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
 		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpExists.Overwrite"/>.
 		/// </remarks>
-		public async Task<bool> UploadFileAsync(string localPath, string remotePath, FtpExists existsMode, bool createRemoteDir,
-			FtpVerify verifyOptions, CancellationToken token, IProgress<double> progress) {
+		public async Task<bool> UploadFileAsync(string localPath, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false, FtpVerify verifyOptions = FtpVerify.None, IProgress<double> progress = null, CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (localPath.IsBlank())
@@ -739,7 +689,7 @@ namespace FluentFTP {
 
 			// skip uploading if the local file does not exist
 #if CORE
-			if (!await Task.Run(()=>File.Exists(localPath))) {
+			if (!await Task.Run(()=>File.Exists(localPath), token)) {
 #else
 			if (!File.Exists(localPath)) {
 #endif
@@ -750,27 +700,6 @@ namespace FluentFTP {
 			this.LogFunc("UploadFileAsync", new object[] { localPath, remotePath, existsMode, createRemoteDir, verifyOptions });
 
 			return await UploadFileFromFileAsync(localPath, remotePath, createRemoteDir, existsMode, false, false, verifyOptions, token, progress);
-		}
-
-		/// <summary>
-		/// Uploads the specified file directly onto the server asynchronously.
-		/// High-level API that takes care of various edge cases internally.
-		/// Supports very large files since it uploads data in chunks.
-		/// </summary>
-		/// <param name="localPath">The full or relative path to the file on the local file system</param>
-		/// <param name="remotePath">The full or relative path to the file on the server</param>
-		/// <param name="existsMode">What to do if the file already exists? Skip, overwrite or append? Set this to <see cref="FtpExists.NoCheck"/> for fastest performance 
-		/// but only if you are SURE that the files do not exist on the server.</param>
-		/// <param name="createRemoteDir">Create the remote directory if it does not exist. Slows down upload due to additional checks required.</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful upload and what to do if it fails verification (See Remarks)</param>
-		/// <returns>If true then the file was uploaded, false otherwise.</returns>
-		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpExists.Overwrite"/>.
-		/// </remarks>
-		public async Task<bool> UploadFileAsync(string localPath, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false, FtpVerify verifyOptions = FtpVerify.None) {
-			return await UploadFileAsync(localPath, remotePath, existsMode, createRemoteDir, verifyOptions, CancellationToken.None, null);
 		}
 #endif
 
@@ -831,12 +760,12 @@ namespace FluentFTP {
 
 				// write the file onto the server
 				using (var fileStream = new FileStream(localPath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true)) {
-					uploadSuccess = await UploadFileInternalAsync(fileStream, remotePath, createRemoteDir, existsMode, fileExists, fileExistsKnown, token, progress);
+					uploadSuccess = await UploadFileInternalAsync(fileStream, remotePath, createRemoteDir, existsMode, fileExists, fileExistsKnown, progress, token);
 					attemptsLeft--;
 
 					// If verification is needed, update the validated flag
 					if (verifyOptions != FtpVerify.None) {
-						verified = await VerifyTransferAsync(localPath, remotePath);
+						verified = await VerifyTransferAsync(localPath, remotePath, token);
 						this.LogStatus(FtpTraceLevel.Info, "File Verification: " + (verified ? "PASS" : "FAIL"));
 						if (!verified && attemptsLeft > 0) {
 							
@@ -849,7 +778,7 @@ namespace FluentFTP {
 			} while (!verified && attemptsLeft > 0);
 
 			if (uploadSuccess && !verified && verifyOptions.HasFlag(FtpVerify.Delete)) {
-				await this.DeleteFileAsync(remotePath);
+				await this.DeleteFileAsync(remotePath, token);
 			}
 
 			if (uploadSuccess && !verified && verifyOptions.HasFlag(FtpVerify.Throw)) {
@@ -930,7 +859,7 @@ namespace FluentFTP {
 		/// <param name="token">The token to monitor for cancellation requests.</param>
 		/// <param name="progress">Provide an implementation of IProgress to track upload progress. The value provided is in the range 0 to 100, indicating the percentage of the file transferred. If the progress is indeterminate, -1 is sent.</param>
 		/// <returns>If true then the file was uploaded, false otherwise.</returns>
-		public async Task<bool> UploadAsync(Stream fileStream, string remotePath, FtpExists existsMode, bool createRemoteDir, CancellationToken token, IProgress<double> progress) {
+		public async Task<bool> UploadAsync(Stream fileStream, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false, IProgress<double> progress = null, CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (fileStream == null)
@@ -941,7 +870,7 @@ namespace FluentFTP {
 			this.LogFunc("UploadAsync", new object[] { remotePath, existsMode, createRemoteDir });
 
 			// write the file onto the server
-			return await UploadFileInternalAsync(fileStream, remotePath, createRemoteDir, existsMode, false, false, token, progress);
+			return await UploadFileInternalAsync(fileStream, remotePath, createRemoteDir, existsMode, false, false, progress, token);
 		}
 
 		/// <summary>
@@ -957,7 +886,7 @@ namespace FluentFTP {
 		/// <param name="token">The token to monitor for cancellation requests.</param>
 		/// <param name="progress">Provide an implementation of IProgress to track upload progress. The value provided is in the range 0 to 100, indicating the percentage of the file transferred. If the progress is indeterminate, -1 is sent.</param>
 		/// <returns>If true then the file was uploaded, false otherwise.</returns>
-		public async Task<bool> UploadAsync(byte[] fileData, string remotePath, FtpExists existsMode, bool createRemoteDir, CancellationToken token, IProgress<double> progress) {
+		public async Task<bool> UploadAsync(byte[] fileData, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false, IProgress<double> progress = null, CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (fileData == null)
@@ -970,38 +899,8 @@ namespace FluentFTP {
 			// write the file onto the server
 			using (MemoryStream ms = new MemoryStream(fileData)) {
 				ms.Position = 0;
-				return await UploadFileInternalAsync(ms, remotePath, createRemoteDir, existsMode, false, false, token, progress);
+				return await UploadFileInternalAsync(ms, remotePath, createRemoteDir, existsMode, false, false, progress, token);
 			}
-		}
-
-		/// <summary>
-		/// Uploads the specified stream as a file onto the server asynchronously.
-		/// High-level API that takes care of various edge cases internally.
-		/// Supports very large files since it uploads data in chunks.
-		/// </summary>
-		/// <param name="fileStream">The full data of the file, as a stream</param>
-		/// <param name="remotePath">The full or relative path to the file on the server</param>
-		/// <param name="existsMode">What to do if the file already exists? Skip, overwrite or append? Set this to <see cref="FtpExists.NoCheck"/> for fastest performance,
-		///  but only if you are SURE that the files do not exist on the server.</param>
-		/// <param name="createRemoteDir">Create the remote directory if it does not exist. Slows down upload due to additional checks required.</param>
-		/// <returns>If true then the file was uploaded, false otherwise.</returns>
-		public async Task<bool> UploadAsync(Stream fileStream, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false) {
-			return await UploadAsync(fileStream, remotePath, existsMode, createRemoteDir, CancellationToken.None, null);
-		}
-
-		/// <summary>
-		/// Uploads the specified byte array as a file onto the server asynchronously.
-		/// High-level API that takes care of various edge cases internally.
-		/// Supports very large files since it uploads data in chunks.
-		/// </summary>
-		/// <param name="fileData">The full data of the file, as a byte array</param>
-		/// <param name="remotePath">The full or relative path to the file on the server</param>
-		/// <param name="existsMode">What to do if the file already exists? Skip, overwrite or append? Set this to <see cref="FtpExists.NoCheck"/> for fastest performance,
-		///  but only if you are SURE that the files do not exist on the server.</param>
-		/// <param name="createRemoteDir">Create the remote directory if it does not exist. Slows down upload due to additional checks required.</param>
-		/// <returns>If true then the file was uploaded, false otherwise.</returns>
-		public async Task<bool> UploadAsync(byte[] fileData, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false) {
-			return await UploadAsync(fileData, remotePath, existsMode, createRemoteDir, CancellationToken.None, null);
 		}
 #endif
 
@@ -1215,7 +1114,7 @@ namespace FluentFTP {
 		/// Upload the given stream to the server as a new file asynchronously. Overwrites the file if it exists.
 		/// Writes data in chunks. Retries if server disconnects midway.
 		/// </summary>
-		private async Task<bool> UploadFileInternalAsync(Stream fileData, string remotePath, bool createRemoteDir, FtpExists existsMode, bool fileExists, bool fileExistsKnown, CancellationToken token, IProgress<double> progress) {
+		private async Task<bool> UploadFileInternalAsync(Stream fileData, string remotePath, bool createRemoteDir, FtpExists existsMode, bool fileExists, bool fileExistsKnown, IProgress<double> progress, CancellationToken token = default(CancellationToken)) {
 			Stream upStream = null;
 			try {
 				long offset = 0;
@@ -1226,13 +1125,13 @@ namespace FluentFTP {
 					checkFileExistsAgain = true;
 				} else if (existsMode == FtpExists.AppendNoCheck) {
 					checkFileExistsAgain = true;
-					offset = await GetFileSizeAsync(remotePath);
+					offset = await GetFileSizeAsync(remotePath, token);
 					if (offset == -1) {
 						offset = 0; // start from the beginning
 					}
 				} else {
 					if (!fileExistsKnown) {
-						fileExists = await FileExistsAsync(remotePath);
+						fileExists = await FileExistsAsync(remotePath, token);
 					}
 					switch (existsMode) {
 						case FtpExists.Skip:
@@ -1243,12 +1142,12 @@ namespace FluentFTP {
 							break;
 						case FtpExists.Overwrite:
 							if (fileExists) {
-								await DeleteFileAsync(remotePath);
+								await DeleteFileAsync(remotePath, token);
 							}
 							break;
 						case FtpExists.Append:
 							if (fileExists) {
-								offset = await GetFileSizeAsync(remotePath);
+								offset = await GetFileSizeAsync(remotePath, token);
 								if (offset == -1) {
 									offset = 0; // start from the beginning
 								}
@@ -1260,8 +1159,8 @@ namespace FluentFTP {
 				// ensure the remote dir exists .. only if the file does not already exist!
 				if (createRemoteDir && !fileExists) {
 					string dirname = remotePath.GetFtpDirectoryName();
-					if (!await DirectoryExistsAsync(dirname)) {
-						await CreateDirectoryAsync(dirname);
+					if (!await DirectoryExistsAsync(dirname, token)) {
+						await CreateDirectoryAsync(dirname, token);
 					}
 				}
 				
@@ -1278,9 +1177,9 @@ namespace FluentFTP {
 
 				// open a file connection
 				if (offset == 0) {
-					upStream = await OpenWriteAsync(remotePath, UploadDataType, checkFileExistsAgain);
+					upStream = await OpenWriteAsync(remotePath, UploadDataType, checkFileExistsAgain, token);
 				} else {
-					upStream = await OpenAppendAsync(remotePath, UploadDataType, checkFileExistsAgain);
+					upStream = await OpenAppendAsync(remotePath, UploadDataType, checkFileExistsAgain, token);
 				}
 
 				// loop till entire file uploaded
@@ -1347,7 +1246,8 @@ namespace FluentFTP {
 								if (swTime >= 1000) {
 									double timeShouldTake = limitCheckBytes / rateLimitBytes * 1000;
 									if (timeShouldTake > swTime) {
-                                        await Task.Delay((int)(timeShouldTake - swTime));
+                                        await Task.Delay((int)(timeShouldTake - swTime), token);
+										token.ThrowIfCancellationRequested();
 									}
 									limitCheckBytes = 0;
 									sw.Restart();
@@ -1387,7 +1287,7 @@ namespace FluentFTP {
 				// FIX : if this is not added, there appears to be "stale data" on the socket
 				// listen for a success/failure reply
 				if (!m_threadSafeDataChannels) {
-					FtpReply status = await GetReplyAsync();
+					FtpReply status = await GetReplyAsync(token);
 
 					// Fix #353: if server sends 550 the transfer was received but could not be confirmed by the server
 					if (status.Code != null && status.Code != "" && status.Code.StartsWith("5")) {
@@ -1563,15 +1463,15 @@ namespace FluentFTP {
 		/// <param name="remotePath">The full or relative path to the file on the server</param>
         /// <param name="existsMode">Overwrite if you want the local file to be overwritten if it already exists. Append will also create a new file if it dosen't exists</param>
 		/// <param name="verifyOptions">Sets if checksum verification is required for a successful download and what to do if it fails verification (See Remarks)</param>
-		/// <param name="token">The token to monitor for cancellation requests</param>
 		/// <param name="progress">Provide an implementation of IProgress to track download progress. The value provided is in the range 0 to 100, indicating the percentage of the file transferred. If the progress is indeterminate, -1 is sent.</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <returns>If true then the file was downloaded, false otherwise.</returns>
 		/// <remarks>
 		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
 		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
 		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically be set to true for subsequent attempts.
 		/// </remarks>
-        public async Task<bool> DownloadFileAsync(string localPath, string remotePath, FtpLocalExists existsMode, FtpVerify verifyOptions, CancellationToken token, IProgress<double> progress) {
+        public async Task<bool> DownloadFileAsync(string localPath, string remotePath, FtpLocalExists existsMode = FtpLocalExists.Append, FtpVerify verifyOptions = FtpVerify.None, IProgress<double> progress = null, CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (localPath.IsBlank())
@@ -1581,47 +1481,27 @@ namespace FluentFTP {
 			
             this.LogFunc("DownloadFileAsync", new object[] { localPath, remotePath, existsMode, verifyOptions });
 
-            return await DownloadFileToFileAsync(localPath, remotePath, existsMode, verifyOptions, token, progress);
+            return await DownloadFileToFileAsync(localPath, remotePath, existsMode, verifyOptions, progress, token);
 		}
 
-		/// <summary>
-		/// Downloads the specified file onto the local file system asynchronously.
-		/// High-level API that takes care of various edge cases internally.
-		/// Supports very large files since it downloads data in chunks.
-		/// </summary>
-		/// <param name="localPath">The full or relative path to the file on the local file system</param>
-		/// <param name="remotePath">The full or relative path to the file on the server</param>
-        /// <param name="existsMode">If the file exists on disk, should we skip it, resume the download or restart the download?</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful download and what to do if it fails verification (See Remarks)</param>
-		/// <param name="progress">Provide an implementation of IProgress to track download progress. The value provided is in the range 0 to 100, indicating the percentage of the file transferred. If the progress is indeterminate, -1 is sent.</param>
-		/// <returns>If true then the file was downloaded, false otherwise.</returns>
-		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically be set to true for subsequent attempts.
-		/// </remarks>
-        public async Task<bool> DownloadFileAsync(string localPath, string remotePath, FtpLocalExists existsMode = FtpLocalExists.Overwrite, FtpVerify verifyOptions = FtpVerify.None, IProgress<double> progress = null) {
+		private async Task<bool> DownloadFileToFileAsync(string localPath, string remotePath, FtpLocalExists existsMode = FtpLocalExists.Append, FtpVerify verifyOptions = FtpVerify.None, IProgress<double> progress = null, CancellationToken token = default(CancellationToken)) {
+
+
 
 			// verify args
 			if (localPath.IsBlank())
 				throw new ArgumentException("Required parameter is null or blank.", "localPath");
 			if (remotePath.IsBlank())
 				throw new ArgumentException("Required parameter is null or blank.", "remotePath");
-			
+
             this.LogFunc("DownloadFileAsync", new object[] { localPath, remotePath, existsMode, verifyOptions });
 
-            return await DownloadFileToFileAsync(localPath, remotePath, existsMode, verifyOptions, CancellationToken.None, progress);
-		}
-
-        private async Task<bool> DownloadFileToFileAsync(string localPath, string remotePath, FtpLocalExists existsMode, FtpVerify verifyOptions, CancellationToken token, IProgress<double> progress) {
-			if (string.IsNullOrWhiteSpace(localPath))
-				throw new ArgumentNullException("localPath");
 
             FileMode outStreamFileMode = FileMode.Create;
 			// skip downloading if the local file exists
 #if CORE
-            if (existsMode == FtpLocalExists.Append && await Task.Run(() => File.Exists(localPath))) {
-                if ((await GetFileSizeAsync(remotePath)).Equals((await Task.Run(() => new FileInfo(localPath))).Length)) {
+            if (existsMode == FtpLocalExists.Append && await Task.Run(() => File.Exists(localPath), token)) {
+                if ((await GetFileSizeAsync(remotePath, token)).Equals((await Task.Run(() => new FileInfo(localPath), token)).Length)) {
 #else
 			if (existsMode == FtpLocalExists.Append && File.Exists(localPath)) {
 				if ((await GetFileSizeAsync(remotePath)).Equals(new FileInfo(localPath).Length)) {
@@ -1634,7 +1514,7 @@ namespace FluentFTP {
                 }
             }
 #if CORE
-			else if (existsMode == FtpLocalExists.Skip && await Task.Run(() => File.Exists(localPath))) {
+			else if (existsMode == FtpLocalExists.Skip && await Task.Run(() => File.Exists(localPath), token)) {
 #else
 			else if (existsMode == FtpLocalExists.Skip && File.Exists(localPath)) {
 #endif
@@ -1647,7 +1527,7 @@ namespace FluentFTP {
 				// create the folders
 				string dirPath = Path.GetDirectoryName(localPath);
 #if CORE
-				if (!String.IsNullOrWhiteSpace(dirPath) && !await Task.Run(() => Directory.Exists(dirPath))) {
+				if (!String.IsNullOrWhiteSpace(dirPath) && !await Task.Run(() => Directory.Exists(dirPath), token)) {
 #else
 				if (!String.IsNullOrWhiteSpace(dirPath) && !Directory.Exists(dirPath)) {
 #endif
@@ -1668,13 +1548,13 @@ namespace FluentFTP {
                 using (var outStream = new FileStream(localPath, outStreamFileMode, FileAccess.Write, FileShare.None, 4096, true)) {
 					
 					// download the file straight to a file stream
-                    downloadSuccess = await DownloadFileInternalAsync(remotePath, outStream, await Task.Run(() => File.Exists(localPath)) ? (await Task.Run(() => new FileInfo(localPath))).Length : 0, token, progress);
+                    downloadSuccess = await DownloadFileInternalAsync(remotePath, outStream, await Task.Run(() => File.Exists(localPath), token) ? (await Task.Run(() => new FileInfo(localPath), token)).Length : 0, progress, token);
 					attemptsLeft--;
 				}
 
 				// if verification is needed
 				if (downloadSuccess && verifyOptions != FtpVerify.None) {
-					verified = await VerifyTransferAsync(localPath, remotePath);
+					verified = await VerifyTransferAsync(localPath, remotePath, token);
 					this.LogStatus(FtpTraceLevel.Info, "File Verification: " + (verified ? "PASS" : "FAIL"));
 #if DEBUG
 					if (!verified && attemptsLeft > 0) {
@@ -1766,7 +1646,7 @@ namespace FluentFTP {
 		/// <param name="token">The token to monitor cancellation requests</param>
 		/// <param name="progress">Provide an implementation of IProgress to track download progress. The value provided is in the range 0 to 100, indicating the percentage of the file transferred. If the progress is indeterminate, -1 is sent.</param>
 		/// <returns>If true then the file was downloaded, false otherwise.</returns>
-        public async Task<bool> DownloadAsync(Stream outStream, string remotePath, long restartPosition, CancellationToken token, IProgress<double> progress = null) {
+        public async Task<bool> DownloadAsync(Stream outStream, string remotePath, long restartPosition = 0, IProgress<double> progress = null, CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (outStream == null)
@@ -1777,29 +1657,7 @@ namespace FluentFTP {
 			this.LogFunc("DownloadAsync", new object[] { remotePath });
 			
 			// download the file from the server
-            return await DownloadFileInternalAsync(remotePath, outStream, restartPosition, token, progress);
-		}
-
-		/// <summary>
-		/// Downloads the specified file into the specified stream asynchronously .
-		/// High-level API that takes care of various edge cases internally.
-		/// Supports very large files since it downloads data in chunks.
-		/// </summary>
-		/// <param name="outStream">The stream that the file will be written to. Provide a new MemoryStream if you only want to read the file into memory.</param>
-		/// <param name="remotePath">The full or relative path to the file on the server</param>
-		/// <returns>If true then the file was downloaded, false otherwise.</returns>
-		public async Task<bool> DownloadAsync(Stream outStream, string remotePath) {
-
-			// verify args
-			if (outStream == null)
-				throw new ArgumentException("Required parameter is null or blank.", "outStream");
-			if (remotePath.IsBlank())
-				throw new ArgumentException("Required parameter is null or blank.", "remotePath");
-			
-			this.LogFunc("DownloadAsync", new object[] { remotePath });
-			
-			// download the file from the server
-            return await DownloadFileInternalAsync(remotePath, outStream, 0, CancellationToken.None, null);
+            return await DownloadFileInternalAsync(remotePath, outStream, restartPosition, progress, token);
 		}
 
 		/// <summary>
@@ -1812,7 +1670,7 @@ namespace FluentFTP {
 		/// <param name="token">The token to monitor cancellation requests</param>
 		/// <param name="progress">Provide an implementation of IProgress to track download progress. The value provided is in the range 0 to 100, indicating the percentage of the file transferred. If the progress is indeterminate, -1 is sent.</param>
 		/// <returns>A byte array containing the contents of the downloaded file if successful, otherwise null.</returns>
-        public async Task<byte[]> DownloadAsync(string remotePath, long restartPosition, CancellationToken token, IProgress<double> progress = null) {
+        public async Task<byte[]> DownloadAsync(string remotePath, long restartPosition, IProgress<double> progress = null, CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (remotePath.IsBlank())
@@ -1822,7 +1680,7 @@ namespace FluentFTP {
 			
 			// download the file from the server
 			using (MemoryStream outStream = new MemoryStream()) {
-                bool ok = await DownloadFileInternalAsync(remotePath, outStream, restartPosition, token, progress);
+                bool ok = await DownloadFileInternalAsync(remotePath, outStream, restartPosition, progress, token);
 				return ok ? outStream.ToArray() : null;
 			}
 		}
@@ -1833,11 +1691,12 @@ namespace FluentFTP {
 		/// Supports very large files since it downloads data in chunks.
 		/// </summary>
 		/// <param name="remotePath">The full or relative path to the file on the server</param>
+		/// <param name="token">Cancellation Token</param>
 		/// <returns>A byte array containing the contents of the downloaded file if successful, otherwise null.</returns>
-		public async Task<byte[]> DownloadAsync(string remotePath) {
+		public async Task<byte[]> DownloadAsync(string remotePath, CancellationToken token = default(CancellationToken)) {
 
 			// download the file from the server
-            return await DownloadAsync(remotePath, 0, CancellationToken.None, null);
+            return await DownloadAsync(remotePath, 0, null, token);
 		}
 #endif
 
@@ -2002,7 +1861,7 @@ namespace FluentFTP {
 		/// Download a file from the server and write the data into the given stream asynchronously.
 		/// Reads data in chunks. Retries if server disconnects midway.
 		/// </summary>
-        private async Task<bool> DownloadFileInternalAsync(string remotePath, Stream outStream, long restartPosition, CancellationToken token, IProgress<double> progress) {
+        private async Task<bool> DownloadFileInternalAsync(string remotePath, Stream outStream, long restartPosition, IProgress<double> progress, CancellationToken token = default(CancellationToken)) {
 			Stream downStream = null;
 			try {
 				
@@ -2010,11 +1869,11 @@ namespace FluentFTP {
 				long fileLen = 0;
 
 				if (DownloadDataType == FtpDataType.Binary && progress != null){
-					fileLen = await GetFileSizeAsync(remotePath);
+					fileLen = await GetFileSizeAsync(remotePath, token);
 				}
 				
 				// open the file for reading
-                downStream = await OpenReadAsync(remotePath, DownloadDataType, restartPosition, fileLen > 0);
+                downStream = await OpenReadAsync(remotePath, DownloadDataType, restartPosition, fileLen > 0, token);
 				
 				// if the server has not provided a length for this file
 				// we read until EOF instead of reading a specific number of bytes
@@ -2088,7 +1947,8 @@ namespace FluentFTP {
 								if (swTime >= 1000) {
 									double timeShouldTake = limitCheckBytes / rateLimitBytes * 1000;
 									if (timeShouldTake > swTime) {
-                                        await Task.Delay((int)(timeShouldTake - swTime));
+                                        await Task.Delay((int)(timeShouldTake - swTime), token);
+										token.ThrowIfCancellationRequested();
                                     }
                                     limitCheckBytes = 0;
 									sw.Restart();
@@ -2127,7 +1987,7 @@ namespace FluentFTP {
 				// FIX : if this is not added, there appears to be "stale data" on the socket
 				// listen for a success/failure reply
 				if (!m_threadSafeDataChannels) {
-					FtpReply status = await GetReplyAsync();
+					FtpReply status = await GetReplyAsync(token);
 				}
 				return true;
 
@@ -2218,7 +2078,7 @@ namespace FluentFTP {
 		}
 
 #if ASYNC
-		private async Task<bool> VerifyTransferAsync(string localPath, string remotePath) {
+		private async Task<bool> VerifyTransferAsync(string localPath, string remotePath, CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (localPath.IsBlank())
@@ -2230,7 +2090,7 @@ namespace FluentFTP {
 				this.HasFeature(FtpCapability.XMD5) || this.HasFeature(FtpCapability.XCRC) ||
 				this.HasFeature(FtpCapability.XSHA1) || this.HasFeature(FtpCapability.XSHA256) ||
 				this.HasFeature(FtpCapability.XSHA512)) {
-				FtpHash hash = await this.GetChecksumAsync(remotePath);
+				FtpHash hash = await this.GetChecksumAsync(remotePath, token);
 				if (!hash.IsValid)
 					return false;
 

--- a/FluentFTP/Client/IFtpClient.cs
+++ b/FluentFTP/Client/IFtpClient.cs
@@ -73,10 +73,10 @@ namespace FluentFTP {
 		void DisableUTF8();
 
 #if ASYNC
-		Task<FtpReply> ExecuteAsync(string command);
-		Task<FtpReply> GetReplyAsync();
-		Task ConnectAsync();
-		Task DisconnectAsync();
+		Task<FtpReply> ExecuteAsync(string command, CancellationToken token = default(CancellationToken));
+		Task<FtpReply> GetReplyAsync(CancellationToken token = default(CancellationToken));
+		Task ConnectAsync(CancellationToken token = default(CancellationToken));
+		Task DisconnectAsync(CancellationToken token = default(CancellationToken));
 #endif
 
 
@@ -107,29 +107,29 @@ namespace FluentFTP {
 		void SetModifiedTime(string path, DateTime date, FtpDate type = FtpDate.Original);
 
 #if ASYNC
-		Task DeleteFileAsync(string path);
-		Task DeleteDirectoryAsync(string path);
-		Task DeleteDirectoryAsync(string path, FtpListOption options);
-		Task<bool> DirectoryExistsAsync(string path);
-		Task<bool> FileExistsAsync(string path);
-		Task CreateDirectoryAsync(string path, bool force);
-		Task CreateDirectoryAsync(string path);
-		Task RenameAsync(string path, string dest);
-		Task<bool> MoveFileAsync(string path, string dest, FtpExists existsMode = FtpExists.Overwrite);
-		Task<bool> MoveDirectoryAsync(string path, string dest, FtpExists existsMode = FtpExists.Overwrite);
-		Task SetFilePermissionsAsync(string path, int permissions);
-		Task ChmodAsync(string path, int permissions);
-		Task SetFilePermissionsAsync(string path, FtpPermission owner, FtpPermission group, FtpPermission other);
-		Task ChmodAsync(string path, FtpPermission owner, FtpPermission group, FtpPermission other);
-		Task<FtpListItem> GetFilePermissionsAsync(string path);
-		Task<int> GetChmodAsync(string path);
-		Task<FtpListItem> DereferenceLinkAsync(FtpListItem item, int recMax);
-		Task<FtpListItem> DereferenceLinkAsync(FtpListItem item);
-		Task SetWorkingDirectoryAsync(string path);
-		Task<string> GetWorkingDirectoryAsync();
-		Task<long> GetFileSizeAsync(string path);
-		Task<DateTime> GetModifiedTimeAsync(string path, FtpDate type = FtpDate.Original);
-		Task SetModifiedTimeAsync(string path, DateTime date, FtpDate type = FtpDate.Original);
+		Task DeleteFileAsync(string path, CancellationToken token = default(CancellationToken));
+		Task DeleteDirectoryAsync(string path, CancellationToken token = default(CancellationToken));
+		Task DeleteDirectoryAsync(string path, FtpListOption options, CancellationToken token = default(CancellationToken));
+		Task<bool> DirectoryExistsAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<bool> FileExistsAsync(string path, CancellationToken token = default(CancellationToken));
+		Task CreateDirectoryAsync(string path, bool force, CancellationToken token = default(CancellationToken));
+		Task CreateDirectoryAsync(string path, CancellationToken token = default(CancellationToken));
+		Task RenameAsync(string path, string dest, CancellationToken token = default(CancellationToken));
+		Task<bool> MoveFileAsync(string path, string dest, FtpExists existsMode = FtpExists.Overwrite, CancellationToken token = default(CancellationToken));
+		Task<bool> MoveDirectoryAsync(string path, string dest, FtpExists existsMode = FtpExists.Overwrite, CancellationToken token = default(CancellationToken));
+		Task SetFilePermissionsAsync(string path, int permissions, CancellationToken token = default(CancellationToken));
+		Task ChmodAsync(string path, int permissions, CancellationToken token = default(CancellationToken));
+		Task SetFilePermissionsAsync(string path, FtpPermission owner, FtpPermission group, FtpPermission other, CancellationToken token = default(CancellationToken));
+		Task ChmodAsync(string path, FtpPermission owner, FtpPermission group, FtpPermission other, CancellationToken token = default(CancellationToken));
+		Task<FtpListItem> GetFilePermissionsAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<int> GetChmodAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<FtpListItem> DereferenceLinkAsync(FtpListItem item, int recMax, CancellationToken token = default(CancellationToken));
+		Task<FtpListItem> DereferenceLinkAsync(FtpListItem item, CancellationToken token = default(CancellationToken));
+		Task SetWorkingDirectoryAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<string> GetWorkingDirectoryAsync(CancellationToken token = default(CancellationToken));
+		Task<long> GetFileSizeAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<DateTime> GetModifiedTimeAsync(string path, FtpDate type = FtpDate.Original, CancellationToken token = default(CancellationToken));
+		Task SetModifiedTimeAsync(string path, DateTime date, FtpDate type = FtpDate.Original, CancellationToken token = default(CancellationToken));
 #endif
 
 
@@ -144,11 +144,11 @@ namespace FluentFTP {
 
 #if ASYNC
 		Task<FtpListItem> GetObjectInfoAsync(string path, bool dateModified = false);
-		Task<FtpListItem[]> GetListingAsync(string path, FtpListOption options);
-		Task<FtpListItem[]> GetListingAsync(string path);
-		Task<FtpListItem[]> GetListingAsync();
-		Task<string[]> GetNameListingAsync(string path);
-		Task<string[]> GetNameListingAsync();
+		Task<FtpListItem[]> GetListingAsync(string path, FtpListOption options, CancellationToken token = default(CancellationToken));
+		Task<FtpListItem[]> GetListingAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<FtpListItem[]> GetListingAsync(CancellationToken token = default(CancellationToken));
+		Task<string[]> GetNameListingAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<string[]> GetNameListingAsync(CancellationToken token = default(CancellationToken));
 #endif
 
 
@@ -169,17 +169,17 @@ namespace FluentFTP {
 		Stream OpenAppend(string path, FtpDataType type, bool checkIfFileExists);
 
 #if ASYNC
-		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart, bool checkIfFileExists);
-		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart);
-		Task<Stream> OpenReadAsync(string path, FtpDataType type);
-		Task<Stream> OpenReadAsync(string path, long restart);
-		Task<Stream> OpenReadAsync(string path);
-		Task<Stream> OpenWriteAsync(string path, FtpDataType type, bool checkIfFileExists);
-		Task<Stream> OpenWriteAsync(string path, FtpDataType type);
-		Task<Stream> OpenWriteAsync(string path);
-		Task<Stream> OpenAppendAsync(string path, FtpDataType type, bool checkIfFileExists);
-		Task<Stream> OpenAppendAsync(string path, FtpDataType type);
-		Task<Stream> OpenAppendAsync(string path);
+		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart, bool checkIfFileExists, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenReadAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenReadAsync(string path, long restart, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenReadAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenWriteAsync(string path, FtpDataType type, bool checkIfFileExists, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenWriteAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenWriteAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenAppendAsync(string path, FtpDataType type, bool checkIfFileExists, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenAppendAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenAppendAsync(string path, CancellationToken token = default(CancellationToken));
 #endif
 
 
@@ -198,22 +198,15 @@ namespace FluentFTP {
 		bool Download(out byte[] outBytes, string remotePath, long restartPosition, IProgress<double> progress = null);
 
 #if ASYNC
-		Task<int> UploadFilesAsync(IEnumerable<string> localPaths, string remoteDir, FtpExists existsMode, bool createRemoteDir, FtpVerify verifyOptions, FtpError errorHandling, CancellationToken token);
-		Task<int> UploadFilesAsync(IEnumerable<string> localPaths, string remoteDir, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = true, FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None);
-		Task<int> DownloadFilesAsync(string localDir, IEnumerable<string> remotePaths, FtpLocalExists existsMode, FtpVerify verifyOptions, FtpError errorHandling, CancellationToken token);
-		Task<int> DownloadFilesAsync(string localDir, IEnumerable<string> remotePaths, FtpLocalExists existsMode = FtpLocalExists.Overwrite, FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None);
-		Task<bool> UploadFileAsync(string localPath, string remotePath, FtpExists existsMode, bool createRemoteDir, FtpVerify verifyOptions, CancellationToken token, IProgress<double> progress);
-		Task<bool> UploadFileAsync(string localPath, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false, FtpVerify verifyOptions = FtpVerify.None);
-		Task<bool> UploadAsync(Stream fileStream, string remotePath, FtpExists existsMode, bool createRemoteDir, CancellationToken token, IProgress<double> progress);
-		Task<bool> UploadAsync(byte[] fileData, string remotePath, FtpExists existsMode, bool createRemoteDir, CancellationToken token, IProgress<double> progress);
-		Task<bool> UploadAsync(Stream fileStream, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false);
-		Task<bool> UploadAsync(byte[] fileData, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false);
-		Task<bool> DownloadFileAsync(string localPath, string remotePath, FtpLocalExists existsMode, FtpVerify verifyOptions, CancellationToken token, IProgress<double> progress);
-		Task<bool> DownloadFileAsync(string localPath, string remotePath, FtpLocalExists existsMode = FtpLocalExists.Overwrite, FtpVerify verifyOptions = FtpVerify.None, IProgress<double> progress = null);
-		Task<bool> DownloadAsync(Stream outStream, string remotePath, long restartPosition, CancellationToken token, IProgress<double> progress = null);
-		Task<bool> DownloadAsync(Stream outStream, string remotePath);
-		Task<byte[]> DownloadAsync(string remotePath, long restartPosition, CancellationToken token, IProgress<double> progress = null);
-		Task<byte[]> DownloadAsync(string remotePath);
+		Task<int> UploadFilesAsync(IEnumerable<string> localPaths, string remoteDir, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = true, FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None, CancellationToken token = default(CancellationToken));
+		Task<int> DownloadFilesAsync(string localDir, IEnumerable<string> remotePaths, FtpLocalExists existsMode = FtpLocalExists.Overwrite, FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None, CancellationToken token = default(CancellationToken));
+		Task<bool> UploadFileAsync(string localPath, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false, FtpVerify verifyOptions = FtpVerify.None, IProgress<double> progress = null, CancellationToken token = default(CancellationToken));
+		Task<bool> UploadAsync(Stream fileStream, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false, IProgress<double> progress = null, CancellationToken token = default(CancellationToken));
+		Task<bool> UploadAsync(byte[] fileData, string remotePath, FtpExists existsMode = FtpExists.Overwrite, bool createRemoteDir = false, IProgress<double> progress = null, CancellationToken token = default(CancellationToken));
+		Task<bool> DownloadFileAsync(string localPath, string remotePath, FtpLocalExists existsMode = FtpLocalExists.Overwrite, FtpVerify verifyOptions = FtpVerify.None, IProgress<double> progress = null, CancellationToken token = default(CancellationToken));
+		Task<bool> DownloadAsync(Stream outStream, string remotePath, long restartPosition = 0, IProgress<double> progress = null, CancellationToken token = default(CancellationToken));
+		Task<byte[]> DownloadAsync(string remotePath, long restartPosition = 0, IProgress<double> progress = null, CancellationToken token = default(CancellationToken));
+
 #endif
 
 		// HASH
@@ -232,14 +225,14 @@ namespace FluentFTP {
 #if ASYNC
 		Task<FtpHashAlgorithm> GetHashAlgorithmAsync();
 		Task SetHashAlgorithmAsync(FtpHashAlgorithm type);
-		Task<FtpHash> GetHashAsync(string path);
-		Task<FtpHash> GetChecksumAsync(string path);
-		Task<string> GetMD5Async(string path);
-		Task<string> GetXCRCAsync(string path);
-		Task<string> GetXMD5Async(string path);
-		Task<string> GetXSHA1Async(string path);
-		Task<string> GetXSHA256Async(string path);
-		Task<string> GetXSHA512Async(string path);
+		Task<FtpHash> GetHashAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<FtpHash> GetChecksumAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<string> GetMD5Async(string path, CancellationToken token = default(CancellationToken));
+		Task<string> GetXCRCAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<string> GetXMD5Async(string path, CancellationToken token = default(CancellationToken));
+		Task<string> GetXSHA1Async(string path, CancellationToken token = default(CancellationToken));
+		Task<string> GetXSHA256Async(string path, CancellationToken token = default(CancellationToken));
+		Task<string> GetXSHA512Async(string path, CancellationToken token = default(CancellationToken));
 #endif
 	}
 }

--- a/FluentFTP/Proxy/FtpClientProxy.cs
+++ b/FluentFTP/Proxy/FtpClientProxy.cs
@@ -1,4 +1,5 @@
 #if ASYNC
+using System.Threading;
 using System.Threading.Tasks;
 #endif
 
@@ -26,9 +27,10 @@ namespace FluentFTP.Proxy {
 #if ASYNC
 		/// <summary> Redefine connect for FtpClient : authentication on the Proxy  </summary>
 		/// <param name="stream">The socket stream.</param>
-		protected override Task ConnectAsync(FtpSocketStream stream)
+		/// <param name="token">Cancellation token.</param>
+		protected override Task ConnectAsync(FtpSocketStream stream, CancellationToken token)
 		{
-			return stream.ConnectAsync(Proxy.Host, Proxy.Port, InternetProtocolVersions);
+			return stream.ConnectAsync(Proxy.Host, Proxy.Port, InternetProtocolVersions, token);
 		}
 #endif
 	}


### PR DESCRIPTION
Since there is no way to cancel an async Read on a Socket, this PR adds a way to cancel the read via CancellationTokens. Even so it does pass the CancellationToken to the Async Read, the Socket doesn't care about it at all. That's why we catch the CT right before the ReadAsync and link it to a new tokensource which is triggered based on ReadTimeout.

If that tokensource triggers it closes the stream and catches the Exception that might occure. Depending on the tokensource that caused the exception either a TimeoutException or a CanceldException is thrown (or if the error is not caused by a CTS, then the exception is rethrown.

The main Timeout handling code is here:
https://github.com/robinrodricks/FluentFTP/pull/377/files#diff-0ee804b19786cb587081edeb1a65dc72R504


Also this PR adds CancellationToken support for everything (I hope I didn't miss anything).
Fixes #262 

This also fixes sync calls on .NET Core by not using the async read function:
https://github.com/robinrodricks/FluentFTP/pull/377/files#diff-0ee804b19786cb587081edeb1a65dc72R478
