### PR TITLE
#399 Use specific "auth failed" exception

### DIFF
--- a/FluentFTP/Client/FtpClient_Connection.cs
+++ b/FluentFTP/Client/FtpClient_Connection.cs
@@ -1610,16 +1610,20 @@ namespace FluentFTP {
 		/// that the login procedure can be changed to support, for example,
 		/// a FTP proxy.
 		/// </summary>
+		/// <exception cref="FtpAuthenticationException">On authentication failures</exception>
+		/// <remarks>
+		/// To handle authentication failures without retries, catch FtpAuthenticationException.
+		/// </remarks>
 		protected virtual void Authenticate(string userName, string password) {
 			FtpReply reply;
 
 			if (!(reply = Execute("USER " + userName)).Success) {
-				throw new FtpCommandException(reply);
+				throw new FtpAuthenticationException(reply);
 			}
 
 			if (reply.Type == FtpResponseType.PositiveIntermediate &&
 				!(reply = Execute("PASS " + password)).Success) {
-				throw new FtpCommandException(reply);
+				throw new FtpAuthenticationException(reply);
 			}
 		}
 
@@ -1629,17 +1633,21 @@ namespace FluentFTP {
         /// that the login procedure can be changed to support, for example,
         /// a FTP proxy.
         /// </summary>
+		/// <exception cref="FtpAuthenticationException">On authentication failures</exception>
+		/// <remarks>
+		/// To handle authentication failures without retries, catch FtpAuthenticationException.
+		/// </remarks>
         protected virtual async Task AuthenticateAsync(string userName, string password, CancellationToken token)
         {
             FtpReply reply;
 
             if (!(reply = await ExecuteAsync("USER " + userName, token)).Success){
-                throw new FtpCommandException(reply);
+                throw new FtpAuthenticationException(reply);
 			}
 
             if (reply.Type == FtpResponseType.PositiveIntermediate
                 && !(reply = await ExecuteAsync("PASS " + password, token)).Success){
-                throw new FtpCommandException(reply);
+                throw new FtpAuthenticationException(reply);
 			}
         }
 #endif

--- a/FluentFTP/Helpers/FtpExceptions.cs
+++ b/FluentFTP/Helpers/FtpExceptions.cs
@@ -96,6 +96,35 @@ namespace FluentFTP {
 	}
 
 	/// <summary>
+	/// Exception triggered on authentication failures
+	/// </summary>
+#if !CORE
+	[Serializable]
+#endif
+	public class FtpAuthenticationException : FtpCommandException
+	{
+		/// <summary>
+		/// Initializes a new instance of a FtpAuthenticationException
+		/// </summary>
+		/// <param name="code">Status code</param>
+		/// <param name="message">Associated message</param>
+		public FtpAuthenticationException(string code, string message) : base(code, message) { }
+
+		/// <summary>
+		/// Initializes a new instance of a FtpAuthenticationException
+		/// </summary>
+		/// <param name="reply">The FtpReply to build the exception from</param>
+		public FtpAuthenticationException(FtpReply reply) : base(reply) { }
+
+#if !CORE
+		/// <summary>
+		/// Must be implemented so every Serializer can Deserialize the Exception
+		/// </summary>
+		protected FtpAuthenticationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
+	}
+
+	/// <summary>
 	/// Exception is thrown when encryption could not be negotiated by the server
 	/// </summary>
 #if !CORE


### PR DESCRIPTION
Issue 399, use a sub-class of the old exception for authentication errors. That way it is possible to catch and not retry them. Opted for quick solution to get this in place fast.