### PR TITLE
improve rate control for high level API

### DIFF
--- a/FluentFTP/Client/FtpClient_HighLevelDownload.cs
+++ b/FluentFTP/Client/FtpClient_HighLevelDownload.cs
@@ -620,13 +620,27 @@ namespace FluentFTP {
 								// we read until EOF instead of reading a specific number of bytes
 								var readToEnd = fileLen <= 0;
 
+								const int rateControlResolution = 100;
+								const int chunkSizeMin = 64;
+								var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;
+								var chunkSize = Math.Max(TransferChunkSize, chunkSizeMin);
+								if (rateLimitBytes > 0) {
+									// reduce chunk size to optimize rate control
+									while (chunkSize > chunkSizeMin) {
+										var chunkLenInMs = 1000L * chunkSize / rateLimitBytes;
+										if (chunkLenInMs <= rateControlResolution) {
+											break;
+										}
+										chunkSize = Math.Max(chunkSize >> 1, chunkSizeMin);
+									}
+								}
+
 								// loop till entire file downloaded
-								var buffer = new byte[TransferChunkSize];
+								var buffer = new byte[chunkSize];
 								var offset = restartPosition;
 
 								var transferStarted = DateTime.Now;
 								var sw = new Stopwatch();
-								long rateLimitBytes = DownloadRateLimit != 0 ? DownloadRateLimit * 1024 : 0;
 								while (offset < fileLen || readToEnd) {
 									try {
 										// read a chunk of bytes from the FTP stream
@@ -649,7 +663,7 @@ namespace FluentFTP {
 
 											// honor the rate limit
 											var swTime = (int) sw.ElapsedMilliseconds;
-											if (rateLimitBytes > 0 && swTime >= 1000) {
+											if (rateLimitBytes > 0) {
 												var timeShouldTake = limitCheckBytes / rateLimitBytes * 1000;
 												if (timeShouldTake > swTime) {
 #if CORE14
@@ -658,9 +672,10 @@ namespace FluentFTP {
 													Thread.Sleep((int) (timeShouldTake - swTime));
 #endif
 												}
-
-												limitCheckBytes = 0;
-												sw.Restart();
+												else if (swTime > timeShouldTake + rateControlResolution) {
+													limitCheckBytes = 0;
+													sw.Restart();
+												}
 											}
 										}
 
@@ -738,13 +753,27 @@ namespace FluentFTP {
 								// we read until EOF instead of reading a specific number of bytes
 								var readToEnd = fileLen <= 0;
 
+								const int rateControlResolution = 100;
+								const int chunkSizeMin = 64;
+								var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;
+								var chunkSize = Math.Max(TransferChunkSize, chunkSizeMin);
+								if (rateLimitBytes > 0) {
+									// reduce chunk size to optimize rate control
+									while (chunkSize > chunkSizeMin) {
+										var chunkLenInMs = 1000L * chunkSize / rateLimitBytes;
+										if (chunkLenInMs <= rateControlResolution) {
+											break;
+										}
+										chunkSize = Math.Max(chunkSize >> 1, chunkSizeMin);
+									}
+								}
+
 								// loop till entire file downloaded
-								var buffer = new byte[TransferChunkSize];
+								var buffer = new byte[chunkSize];
 								var offset = restartPosition;
 
 								var transferStarted = DateTime.Now;
 								var sw = new Stopwatch();
-								long rateLimitBytes = DownloadRateLimit != 0 ? DownloadRateLimit * 1024 : 0;
 
 								while (offset < fileLen || readToEnd) {
 									try {
@@ -768,15 +797,16 @@ namespace FluentFTP {
 
 											// honor the rate limit
 											var swTime = (int) sw.ElapsedMilliseconds;
-											if (rateLimitBytes > 0 && swTime >= 1000) {
+											if (rateLimitBytes > 0) {
 												var timeShouldTake = limitCheckBytes / rateLimitBytes * 1000;
 												if (timeShouldTake > swTime) {
 													await Task.Delay((int) (timeShouldTake - swTime), token);
 													token.ThrowIfCancellationRequested();
 												}
-
-												limitCheckBytes = 0;
-												sw.Restart();
+												else if (swTime > timeShouldTake + rateControlResolution) {
+													limitCheckBytes = 0;
+													sw.Restart();
+												}
 											}
 										}
 

--- a/FluentFTP/Client/FtpClient_HighLevelDownload.cs
+++ b/FluentFTP/Client/FtpClient_HighLevelDownload.cs
@@ -621,11 +621,11 @@ namespace FluentFTP {
 								var readToEnd = fileLen <= 0;
 
 								const int rateControlResolution = 100;
-								const int chunkSizeMin = 64;
 								var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;
-								var chunkSize = Math.Max(TransferChunkSize, chunkSizeMin);
-								if (rateLimitBytes > 0) {
+								var chunkSize = TransferChunkSize;
+								if (m_transferChunkSize == null && rateLimitBytes > 0) {
 									// reduce chunk size to optimize rate control
+									const int chunkSizeMin = 64;
 									while (chunkSize > chunkSizeMin) {
 										var chunkLenInMs = 1000L * chunkSize / rateLimitBytes;
 										if (chunkLenInMs <= rateControlResolution) {
@@ -754,11 +754,11 @@ namespace FluentFTP {
 								var readToEnd = fileLen <= 0;
 
 								const int rateControlResolution = 100;
-								const int chunkSizeMin = 64;
 								var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;
-								var chunkSize = Math.Max(TransferChunkSize, chunkSizeMin);
-								if (rateLimitBytes > 0) {
+								var chunkSize = TransferChunkSize;
+								if (m_transferChunkSize == null && rateLimitBytes > 0) {
 									// reduce chunk size to optimize rate control
+									const int chunkSizeMin = 64;
 									while (chunkSize > chunkSizeMin) {
 										var chunkLenInMs = 1000L * chunkSize / rateLimitBytes;
 										if (chunkLenInMs <= rateControlResolution) {

--- a/FluentFTP/Client/FtpClient_HighLevelDownload.cs
+++ b/FluentFTP/Client/FtpClient_HighLevelDownload.cs
@@ -645,7 +645,7 @@ namespace FluentFTP {
 									try {
 										// read a chunk of bytes from the FTP stream
 										var readBytes = 1;
-										double limitCheckBytes = 0;
+										long limitCheckBytes = 0;
 										long bytesProcessed = 0;
 
 										sw.Start();
@@ -662,9 +662,9 @@ namespace FluentFTP {
 											}
 
 											// honor the rate limit
-											var swTime = (int) sw.ElapsedMilliseconds;
+											var swTime = sw.ElapsedMilliseconds;
 											if (rateLimitBytes > 0) {
-												var timeShouldTake = limitCheckBytes / rateLimitBytes * 1000;
+												var timeShouldTake = limitCheckBytes * 1000 / rateLimitBytes;
 												if (timeShouldTake > swTime) {
 #if CORE14
 													Task.Delay((int) (timeShouldTake - swTime)).Wait();
@@ -779,7 +779,7 @@ namespace FluentFTP {
 									try {
 										// read a chunk of bytes from the FTP stream
 										var readBytes = 1;
-										double limitCheckBytes = 0;
+										long limitCheckBytes = 0;
 										long bytesProcessed = 0;
 
 										sw.Start();
@@ -796,9 +796,9 @@ namespace FluentFTP {
 											}
 
 											// honor the rate limit
-											var swTime = (int) sw.ElapsedMilliseconds;
+											var swTime = sw.ElapsedMilliseconds;
 											if (rateLimitBytes > 0) {
-												var timeShouldTake = limitCheckBytes / rateLimitBytes * 1000;
+												var timeShouldTake = limitCheckBytes * 1000 / rateLimitBytes;
 												if (timeShouldTake > swTime) {
 													await Task.Delay((int) (timeShouldTake - swTime), token);
 													token.ThrowIfCancellationRequested();

--- a/FluentFTP/Client/FtpClient_HighLevelUpload.cs
+++ b/FluentFTP/Client/FtpClient_HighLevelUpload.cs
@@ -714,7 +714,7 @@ namespace FluentFTP {
 						try {
 							// read a chunk of bytes from the file
 							int readBytes;
-							double limitCheckBytes = 0;
+							long limitCheckBytes = 0;
 							long bytesProcessed = 0;
 
 							sw.Start();
@@ -732,9 +732,9 @@ namespace FluentFTP {
 								}
 
 								// honor the speed limit
-								var swTime = (int) sw.ElapsedMilliseconds;
+								var swTime = sw.ElapsedMilliseconds;
 								if (rateLimitBytes > 0) {
-									var timeShouldTake = limitCheckBytes / rateLimitBytes * 1000;
+									var timeShouldTake = limitCheckBytes * 1000 / rateLimitBytes;
 									if (timeShouldTake > swTime) {
 #if CORE14
 										Task.Delay((int) (timeShouldTake - swTime)).Wait();
@@ -923,7 +923,7 @@ namespace FluentFTP {
 						try {
 							// read a chunk of bytes from the file
 							int readBytes;
-							double limitCheckBytes = 0;
+							long limitCheckBytes = 0;
 							long bytesProcessed = 0;
 
 							sw.Start();
@@ -941,9 +941,9 @@ namespace FluentFTP {
 								}
 
 								// honor the rate limit
-								var swTime = (int) sw.ElapsedMilliseconds;
+								var swTime = sw.ElapsedMilliseconds;
 								if (rateLimitBytes > 0) {
-									var timeShouldTake = limitCheckBytes / rateLimitBytes * 1000;
+									var timeShouldTake = limitCheckBytes * 1000 / rateLimitBytes;
 									if (timeShouldTake > swTime) {
 										await Task.Delay((int) (timeShouldTake - swTime), token);
 										token.ThrowIfCancellationRequested();

--- a/FluentFTP/Client/FtpClient_HighLevelUpload.cs
+++ b/FluentFTP/Client/FtpClient_HighLevelUpload.cs
@@ -684,11 +684,11 @@ namespace FluentFTP {
 					}
 
 					const int rateControlResolution = 100;
-					const int chunkSizeMin = 64;
 					var rateLimitBytes = UploadRateLimit != 0 ? (long)UploadRateLimit * 1024 : 0;
-					var chunkSize = Math.Max(TransferChunkSize, chunkSizeMin);
-					if (rateLimitBytes > 0) {
+					var chunkSize = TransferChunkSize;
+					if (m_transferChunkSize == null && rateLimitBytes > 0) {
 						// reduce chunk size to optimize rate control
+						const int chunkSizeMin = 64;
 						while (chunkSize > chunkSizeMin) {
 							var chunkLenInMs = 1000L * chunkSize / rateLimitBytes;
 							if (chunkLenInMs <= rateControlResolution) {
@@ -893,11 +893,11 @@ namespace FluentFTP {
 					}
 
 					const int rateControlResolution = 100;
-					const int chunkSizeMin = 64;
 					var rateLimitBytes = UploadRateLimit != 0 ? (long)UploadRateLimit * 1024 : 0;
-					var chunkSize = Math.Max(TransferChunkSize, chunkSizeMin);
-					if (rateLimitBytes > 0) {
+					var chunkSize = TransferChunkSize;
+					if (m_transferChunkSize == null && rateLimitBytes > 0) {
 						// reduce chunk size to optimize rate control
+						const int chunkSizeMin = 64;
 						while (chunkSize > chunkSizeMin) {
 							var chunkLenInMs = 1000L * chunkSize / rateLimitBytes;
 							if (chunkLenInMs <= rateControlResolution) {

--- a/FluentFTP/Client/FtpClient_Properties.cs
+++ b/FluentFTP/Client/FtpClient_Properties.cs
@@ -644,7 +644,7 @@ namespace FluentFTP {
 		}
 
 
-		private int m_transferChunkSize = 65536;
+		private int? m_transferChunkSize;
 
 		/// <summary>
 		/// Gets or sets the number of bytes transferred in a single chunk (a single FTP command).
@@ -652,7 +652,7 @@ namespace FluentFTP {
 		/// to transfer large files in multiple chunks.
 		/// </summary>
 		public int TransferChunkSize {
-			get => m_transferChunkSize;
+			get => m_transferChunkSize ?? 65536;
 			set => m_transferChunkSize = value;
 		}
 


### PR DESCRIPTION
The original rate control is too rough for me, so I improved the rate control of the high level API.
Note that transferChunkSize may be changed internally to optimize the low rate limit.