### PR TITLE
Minor fixes in examples

### DIFF
--- a/FluentFTP.Examples/AsyncConnect.cs
+++ b/FluentFTP.Examples/AsyncConnect.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Runtime.InteropServices.ComTypes;
-using System.Text;
+﻿using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentFTP;

--- a/FluentFTP.Examples/BeginConnect.cs
+++ b/FluentFTP.Examples/BeginConnect.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginConnectExample {
@@ -17,7 +17,7 @@ namespace Examples {
 
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
-				conn.BeginConnect(new AsyncCallback(ConnectCallback), conn);
+				conn.BeginConnect(ConnectCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginCreateDirectory.cs
+++ b/FluentFTP.Examples/BeginCreateDirectory.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Threading;
-using System.IO;
 using System.Net;
+using System.Threading;
 using FluentFTP;
 
 namespace Examples {
@@ -20,7 +19,7 @@ namespace Examples {
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.DeleteDirectory("/test");
 				conn.BeginCreateDirectory("/test/path/that/should/be/created", true,
-					new AsyncCallback(CreateDirectoryCallback), conn);
+					CreateDirectoryCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginDeleteDirectory.cs
+++ b/FluentFTP.Examples/BeginDeleteDirectory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal class BeginDeleteDirectoryExample {
@@ -18,7 +18,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.CreateDirectory("/some/test/directory");
-				conn.BeginDeleteDirectory("/some", new AsyncCallback(DeleteDirectoryCallback), conn);
+				conn.BeginDeleteDirectory("/some", DeleteDirectoryCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginDeleteFile.cs
+++ b/FluentFTP.Examples/BeginDeleteFile.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginDeleteFileExample {
@@ -17,7 +17,7 @@ namespace Examples {
 
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
-				conn.BeginDeleteFile("/path/to/file", new AsyncCallback(DeleteFileCallback), conn);
+				conn.BeginDeleteFile("/path/to/file", DeleteFileCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginDereferenceLink.cs
+++ b/FluentFTP.Examples/BeginDereferenceLink.cs
@@ -5,9 +5,9 @@ using FluentFTP;
 
 namespace Examples {
 	/// <summary>
-	/// This example illustrates how to dereference a symbolic link asyncrhonously. The
-	/// code bollow takes a FtpListItem object and checks if it is a symbolic link and
-	/// that the LinkTarget property has been initalized before executing the method. Not
+	/// This example illustrates how to dereference a symbolic link asynchronously. The
+	/// code bellow takes a FtpListItem object and checks if it is a symbolic link and
+	/// that the LinkTarget property has been initialized before executing the method. Not
 	/// doing so can result in a FtpException being thrown.
 	/// 
 	/// Also see the DerefenceLink() example! There is lots of information
@@ -29,7 +29,7 @@ namespace Examples {
 				conn.Connect();
 
 				if (item.Type == FtpFileSystemObjectType.Link && item.LinkTarget != null) {
-					conn.BeginDereferenceLink(item, new AsyncCallback(DereferenceLinkCallback), conn);
+					conn.BeginDereferenceLink(item, DereferenceLinkCallback, conn);
 					m_reset.WaitOne();
 				}
 

--- a/FluentFTP.Examples/BeginDirectoryExists.cs
+++ b/FluentFTP.Examples/BeginDirectoryExists.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginDirectoryExistsExample {
@@ -17,7 +17,7 @@ namespace Examples {
 
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
-				conn.BeginDirectoryExists("/path/to/directory", new AsyncCallback(DirectoryExistsCallback), conn);
+				conn.BeginDirectoryExists("/path/to/directory", DirectoryExistsCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();
@@ -32,7 +32,7 @@ namespace Examples {
 					throw new InvalidOperationException("The FtpControlConnection object is null!");
 				}
 
-				Console.WriteLine("Directory Exiss: " + conn.EndDirectoryExists(ar));
+				Console.WriteLine("Directory exists: " + conn.EndDirectoryExists(ar));
 			}
 			catch (Exception ex) {
 				Console.WriteLine(ex.ToString());

--- a/FluentFTP.Examples/BeginDisconnect.cs
+++ b/FluentFTP.Examples/BeginDisconnect.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginDisconnectExample {
@@ -18,7 +18,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.Connect();
-				conn.BeginDisconnect(new AsyncCallback(BeginDisconnectCallback), conn);
+				conn.BeginDisconnect(BeginDisconnectCallback, conn);
 
 				m_reset.WaitOne();
 			}

--- a/FluentFTP.Examples/BeginExecute.cs
+++ b/FluentFTP.Examples/BeginExecute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginExecuteExample {
@@ -18,7 +18,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.Connect();
-				conn.BeginExecute("SYST", new AsyncCallback(BeginExecuteCallback), conn);
+				conn.BeginExecute("SYST", BeginExecuteCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginFileExists.cs
+++ b/FluentFTP.Examples/BeginFileExists.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginFileExistsExample {
@@ -18,7 +18,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.Connect();
-				conn.BeginFileExists("foobar", new AsyncCallback(BeginFileExistsCallback), conn);
+				conn.BeginFileExists("foobar", BeginFileExistsCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginGetFileSize.cs
+++ b/FluentFTP.Examples/BeginGetFileSize.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginGetFileSizeExample {
@@ -18,7 +18,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.Connect();
-				conn.BeginGetFileSize("foobar", new AsyncCallback(BeginGetFileSizeCallback), conn);
+				conn.BeginGetFileSize("foobar", BeginGetFileSizeCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginGetListing.cs
+++ b/FluentFTP.Examples/BeginGetListing.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	// Also see the GetListing() example for more details
@@ -20,7 +20,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.Connect();
-				conn.BeginGetListing(new AsyncCallback(GetListingCallback), conn);
+				conn.BeginGetListing(GetListingCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginGetModifiedTime.cs
+++ b/FluentFTP.Examples/BeginGetModifiedTime.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginGetModifiedTimeExample {
@@ -18,7 +18,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.Connect();
-				conn.BeginGetModifiedTime("foobar", FtpDate.UTC, new AsyncCallback(BeginGetModifiedTimeCallback), conn);
+				conn.BeginGetModifiedTime("foobar", FtpDate.UTC, BeginGetModifiedTimeCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginGetNameListing.cs
+++ b/FluentFTP.Examples/BeginGetNameListing.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginGetNameListingExample {
@@ -17,7 +17,7 @@ namespace Examples {
 
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
-				conn.BeginGetNameListing(new AsyncCallback(EndGetNameListing), conn);
+				conn.BeginGetNameListing(EndGetNameListing, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginGetWorkingDirectory.cs
+++ b/FluentFTP.Examples/BeginGetWorkingDirectory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginGetWorkingDirectoryExample {
@@ -18,7 +18,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.Connect();
-				conn.BeginGetWorkingDirectory(new AsyncCallback(BeginGetWorkingDirectoryCallback), conn);
+				conn.BeginGetWorkingDirectory(BeginGetWorkingDirectoryCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginOpenAppend.cs
+++ b/FluentFTP.Examples/BeginOpenAppend.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Net;
-using FluentFTP;
 using System.IO;
+using System.Net;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginOpenAppendExample {
@@ -18,8 +18,7 @@ namespace Examples {
 
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
-				conn.BeginOpenAppend("/path/to/file",
-					new AsyncCallback(BeginOpenAppendCallback), conn);
+				conn.BeginOpenAppend("/path/to/file", BeginOpenAppendCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginOpenRead.cs
+++ b/FluentFTP.Examples/BeginOpenRead.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
-using System.IO;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginOpenReadExample {
@@ -18,8 +17,7 @@ namespace Examples {
 
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
-				conn.BeginOpenRead("/path/to/file",
-					new AsyncCallback(BeginOpenReadCallback), conn);
+				conn.BeginOpenRead("/path/to/file", BeginOpenReadCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginOpenWrite.cs
+++ b/FluentFTP.Examples/BeginOpenWrite.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Net;
-using FluentFTP;
 using System.IO;
+using System.Net;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginOpenWriteExample {
@@ -18,8 +18,7 @@ namespace Examples {
 
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
-				conn.BeginOpenWrite("/path/to/file",
-					new AsyncCallback(BeginOpenWriteCallback), conn);
+				conn.BeginOpenWrite("/path/to/file", BeginOpenWriteCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginRename.cs
+++ b/FluentFTP.Examples/BeginRename.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginRenameExample {
@@ -18,7 +18,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 				conn.BeginRename("/source/object", "/new/path/and/name",
-					new AsyncCallback(BeginRenameCallback), conn);
+					BeginRenameCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/BeginSetWorkingDirectory.cs
+++ b/FluentFTP.Examples/BeginSetWorkingDirectory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Threading;
+using FluentFTP;
 
 namespace Examples {
 	internal static class BeginSetWorkingDirectoryExample {
@@ -17,7 +17,7 @@ namespace Examples {
 
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
-				conn.BeginSetWorkingDirectory("/", new AsyncCallback(BeginSetWorkingDirectoryCallback), conn);
+				conn.BeginSetWorkingDirectory("/", BeginSetWorkingDirectoryCallback, conn);
 
 				m_reset.WaitOne();
 				conn.Disconnect();

--- a/FluentFTP.Examples/Connect.cs
+++ b/FluentFTP.Examples/Connect.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using FluentFTP;
 
 namespace Examples {

--- a/FluentFTP.Examples/CreateDirectory.cs
+++ b/FluentFTP.Examples/CreateDirectory.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using FluentFTP;
-using System.IO;
 
 namespace Examples {
 	internal static class CreateDirectoryExample {

--- a/FluentFTP.Examples/CustomParser.cs
+++ b/FluentFTP.Examples/CustomParser.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using FluentFTP;
-using System.Globalization;
-using System.Collections.Generic;
 
 namespace Examples {
 	/// <summary>

--- a/FluentFTP.Examples/DereferenceLink.cs
+++ b/FluentFTP.Examples/DereferenceLink.cs
@@ -18,12 +18,12 @@ namespace Examples {
 				client.Credentials = new NetworkCredential("user", "pass");
 				client.Host = "somehost";
 
-				// This propety controls the depth of recursion that
+				// This property controls the depth of recursion that
 				// can be done before giving up on resolving the link.
 				// You can set the value to -1 for infinite depth 
 				// however you are strongly discourage from doing so.
 				// The default value is 20, the following line is
-				// only to illustrate the existance of the property.
+				// only to illustrate the existence of the property.
 				// It's also possible to override this value as one
 				// of the overloaded arguments to the DereferenceLink() method.
 				client.MaximumDereferenceCount = 20;

--- a/FluentFTP.Examples/Extensions.cs
+++ b/FluentFTP.Examples/Extensions.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Examples {
 	internal static class Extensions {
 		public static string FormatBytes(this long val) {

--- a/FluentFTP.Examples/GetListing.cs
+++ b/FluentFTP.Examples/GetListing.cs
@@ -20,7 +20,7 @@ namespace Examples {
 
 						case FtpFileSystemObjectType.Link:
 
-							// derefernece symbolic links
+							// dereference symbolic links
 							if (item.LinkTarget != null) {
 								// see the DereferenceLink() example
 								// for more details about resolving links.

--- a/FluentFTP.Examples/Rename.cs
+++ b/FluentFTP.Examples/Rename.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using FluentFTP;
-using System.IO;
 
 namespace Examples {
 	internal static class RenameExample {
@@ -10,7 +8,7 @@ namespace Examples {
 				conn.Host = "localhost";
 				conn.Credentials = new NetworkCredential("ftptest", "ftptest");
 
-				// renaming a directory is dependant on the server! if you attempt it
+				// renaming a directory is dependent on the server! if you attempt it
 				// and it fails it's not because FluentFTP has a bug!
 				conn.Rename("/full/or/relative/path/to/src", "/full/or/relative/path/to/dest");
 			}

--- a/FluentFTP.Examples/SetEncryptionProtocols.cs
+++ b/FluentFTP.Examples/SetEncryptionProtocols.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
-using FluentFTP;
 using System.Security.Authentication;
+using FluentFTP;
 
 namespace Examples {
 	internal static class SetEncryptionProtocolsExample {

--- a/FluentFTP.Examples/SetWorkingDirectory.cs
+++ b/FluentFTP.Examples/SetWorkingDirectory.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using FluentFTP;
-using System.IO;
 
 namespace Examples {
 	internal static class SetWorkingDirectoryExample {

--- a/FluentFTP/Helpers/FtpListParser.cs
+++ b/FluentFTP/Helpers/FtpListParser.cs
@@ -75,7 +75,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Try to auto-detect which parser is suitable given a system string.
 		/// </summary>
-		public void Init(FtpOperatingSystem system, FtpParser defaultParser) {
+		public void Init(FtpOperatingSystem system, FtpParser defaultParser = FtpParser.Auto) {
 			ParserConfirmed = false;
 
 			if (system == FtpOperatingSystem.Windows) {


### PR DESCRIPTION
 - Fix typos
 - Remove unused namespaces
 - Sort used namespaces
 - Remove unnecessary delegate creations
 - Fix Tests project build error