### PR TITLE
Verification of the MD5 Hash when file name contains spaces.

### DIFF
--- a/FluentFTP/Client/FtpClient_Hash.cs
+++ b/FluentFTP/Client/FtpClient_Hash.cs
@@ -569,8 +569,12 @@ namespace FluentFTP {
 			}
 
 			response = reply.Message;
-			if (response.StartsWith(path)) {
-				response = response.Remove(0, path.Length).Trim();
+			foreach (var responsePrefix in new[] { path, $@"""{path}""" })
+			{
+				if (!response.StartsWith(responsePrefix)) continue;
+
+				response = response.Remove(0, responsePrefix.Length).Trim();
+				break;
 			}
 
 			return response;

--- a/FluentFTP/Client/FtpClient_Hash.cs
+++ b/FluentFTP/Client/FtpClient_Hash.cs
@@ -571,7 +571,9 @@ namespace FluentFTP {
 			response = reply.Message;
 			foreach (var responsePrefix in new[] { path, $@"""{path}""" })
 			{
-				if (!response.StartsWith(responsePrefix)) continue;
+				if (!response.StartsWith(responsePrefix)) {
+					continue;
+				}
 
 				response = response.Remove(0, responsePrefix.Length).Trim();
 				break;


### PR DESCRIPTION
This pull requests solves the issue submitted in [Ticket #478 (Cannot verify MD5 hash when file name contains spaces when using egnyte.com)](https://github.com/robinrodricks/FluentFTP/issues/478). 

As per https://tools.ietf.org/html/draft-twine-ftpmd5-00#section-3.1, the MD5 Command Output is expected to be in a following format:
`251 [FilePath] E67DED2886048D308532042B777D53CF`

If the file path contains spaces (e.g. `file 1.xlsx`), the response might be represented in a following way:
`251 "/shared/import/file 1.xlsx" 48317576D6CA6C93641CCB06487AF457`. In such case, the response parsing of the MD5 Command is not taking into account the additional quotes around the `[FilePath]`, hence the HashVerification process fails prematurely. 

Changes in this pull request take into account the additional quotes around `[FilePath]` treating following MD5 Command responses as equally valid:
`251 "/shared/import/file 1.xlsx" 48317576D6CA6C93641CCB06487AF457`,
`251 /shared/import/file 1.xlsx 48317576D6CA6C93641CCB06487AF457`.


