### PR TITLE
Fix for non-routable IP regex

### DIFF
--- a/FluentFTP/Client/FtpClient_LowLevel.cs
+++ b/FluentFTP/Client/FtpClient_LowLevel.cs
@@ -376,7 +376,7 @@ namespace FluentFTP {
 				// Fix #409 for BlueCoat proxy connections. This code replaces the name of the proxy with the name of the FTP server and then nothing works.
 				if (!IsProxy()) {
 					//use host ip if server advertises a non-routable IP
-					m = Regex.Match(host, @"(^10\.)|(^172\.1[6-9]\.)|(^172\\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)|(^127\.0\.0\.1)|(^0\.0\.0\.0)");
+					m = Regex.Match(host, @"(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)|(^127\.0\.0\.1)|(^0\.0\.0\.0)");
 
 					if (m.Success) {
 						host = m_host;
@@ -508,7 +508,7 @@ namespace FluentFTP {
 				// Fix #409 for BlueCoat proxy connections. This code replaces the name of the proxy with the name of the FTP server and then nothing works.
 				if (!IsProxy()) {
 					//use host ip if server advertises a non-routable IP
-					m = Regex.Match(host, @"(^10\.)|(^172\.1[6-9]\.)|(^172\\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)|(^127\.0\.0\.1)|(^0\.0\.0\.0)");
+					m = Regex.Match(host, @"(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)|(^127\.0\.0\.1)|(^0\.0\.0\.0)");
 
 					if (m.Success) {
 						host = m_host;


### PR DESCRIPTION
The 172.2 pattern has an extra \ causing the fallback to host ip not to occur