### PR TITLE
Close (Dispose) AsyncWaitHandles to stop handle leak (in .NET Framework 4.5 build)

### DIFF
--- a/FluentFTP/Client/FtpClient_Stream.cs
+++ b/FluentFTP/Client/FtpClient_Stream.cs
@@ -699,6 +699,7 @@ namespace FluentFTP {
 			stream.EndAccept(args, m_dataConnectionConnectTimeout);
 #else
 			ar.AsyncWaitHandle.WaitOne(m_dataConnectionConnectTimeout);
+			ar.AsyncWaitHandle.Close();
 			if (!ar.IsCompleted) {
 				stream.Close();
 				throw new TimeoutException("Timed out waiting for the server to connect to the active data socket.");
@@ -817,6 +818,7 @@ namespace FluentFTP {
 			stream.EndAccept(args, m_dataConnectionConnectTimeout);
 #else
 			ar.AsyncWaitHandle.WaitOne(m_dataConnectionConnectTimeout);
+			ar.AsyncWaitHandle.Close();
 			if (!ar.IsCompleted) {
 				stream.Close();
 				throw new TimeoutException("Timed out waiting for the server to connect to the active data socket.");

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -473,7 +473,9 @@ namespace FluentFTP {
 			return BaseStream.Read(buffer, offset, count);
 #else
 			ar = BaseStream.BeginRead(buffer, offset, count, null, null);
-			if (!ar.AsyncWaitHandle.WaitOne(m_readTimeout, true)) {
+			bool success = ar.AsyncWaitHandle.WaitOne(m_readTimeout, true);
+			ar.AsyncWaitHandle.Close();
+			if (!success) {
 				Close();
 				throw new TimeoutException("Timed out trying to read data from the socket stream!");
 			}
@@ -873,7 +875,9 @@ namespace FluentFTP {
 				break;
 #else
 				ar = m_socket.BeginConnect(addresses[i], port, null, null);
-				if (!ar.AsyncWaitHandle.WaitOne(m_connectTimeout, true)) {
+				bool success = ar.AsyncWaitHandle.WaitOne(m_connectTimeout, true);
+				ar.AsyncWaitHandle.Close();
+				if (!success) {
 					Close();
 
 					// check to see if we're out of addresses, and throw a TimeoutException


### PR DESCRIPTION
Hi robinrodricks -

There's a handle leak that occurs each time I call FluentFTP.FtpClient.Connect(). (I'm also calling Disconnect() and Dispose(), after each Connect().) It leaks a few hundred handles each time, and these leaked handles accumulate over time, until my app stops working. (I don't need to get a file list, or to download a file, to get this leak; I only need to Connect().)

It only leaks handles when it's able to connect to the FTP server (if the FTP server is down it won't leak handles). I tested using FileZilla FTP server, locally, with loopback IP address 127.0.0.1, and also using a remote FTP server. (Also, I ran my app (the FTP client) on two different computers, and I turned off my firewall, to make sure it wasn't interfering.) The handle leaks still occurred.

These changes seem to plug the handle leaking, or at least the big leaks; I don't know if there's some smaller ones out there that I didn't get, or if there's code that I'm not using that's also leaking.

Please review these changes and merge them into your master branch?

Thanks!