### PR TITLE
Fix 'ValidateCertificateRevocation' property not being used in async version

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1164,7 +1164,7 @@ namespace FluentFTP {
 
 				auth_start = DateTime.Now;
 				try {
-					await m_sslStream.AuthenticateAsClientAsync(targethost, clientCerts, sslProtocols, true);
+					await m_sslStream.AuthenticateAsClientAsync(targethost, clientCerts, sslProtocols, Client.ValidateCertificateRevocation);
 				}
 				catch (IOException ex) {
 					if (ex.InnerException is Win32Exception) {


### PR DESCRIPTION
Use of hard-coded 'checkCertificateRevocation' parameter value to SslStream's 'AuthenticateAsClientAsync' method was replaced with the 'ValidateCertificateRevocation' property as a fix for #493, but async version of the code was omitted.