### PR TITLE
fix ReadStaleData causing infinite loop

### DIFF
--- a/FluentFTP/Client/FtpClient_Utils.cs
+++ b/FluentFTP/Client/FtpClient_Utils.cs
@@ -207,6 +207,9 @@ namespace FluentFTP {
 					if (traceData) {
 						LogStatus(FtpTraceLevel.Verbose, "The stale data was: " + staleData);
 					}
+					if(string.IsNullOrEmpty(staleData)) {
+						closeStream = false;
+					}
 				}
 
 				if (closeStream) {


### PR DESCRIPTION
Encountered an infinite loop when connecting.

Debugging shows that the ReadStaleData function was closing the connection, resulting in a connection attempt being made (from Execute()), which repeats endlessly.

For the particular FTP server I was connecting to it appears that the only stale data was the newline character.

ReadStaleData actually already trims off the newline characters when building the string to log out, so we can easily check if that string in empty in order to determine if we really need to close the stream for that "stale" data.

Once that change was made, connections to the server were successful.
