### PR TITLE
Support IAsyncEnumerable on .NET Standard 2.0+

### DIFF
--- a/FluentFTP/Client/FtpClient_FileProperties.cs
+++ b/FluentFTP/Client/FtpClient_FileProperties.cs
@@ -8,8 +8,8 @@ using System.Threading;
 #endif
 #if ASYNC
 using System.Threading.Tasks;
-
 #endif
+using System.Linq;
 
 namespace FluentFTP {
 	public partial class FtpClient : IFtpClient, IDisposable {
@@ -155,9 +155,11 @@ namespace FluentFTP {
 			if (item.LinkTarget == null) {
 				throw new FtpException("The link target was null. Please check this before trying to dereference the link.");
 			}
-
+#if ASYNCPLUS
+			var listing = await GetListingAsync(item.LinkTarget.GetFtpDirectoryName(), FtpListOption.ForceList, token).ToArrayAsync();
+#else
 			var listing = await GetListingAsync(item.LinkTarget.GetFtpDirectoryName(), FtpListOption.ForceList, token);
-
+#endif
 			foreach (FtpListItem obj in listing) {
 				if (item.LinkTarget == obj.FullName) {
 					if (obj.Type == FtpFileSystemObjectType.Link) {
@@ -212,7 +214,7 @@ namespace FluentFTP {
 		}
 #endif
 
-		#endregion
+#endregion
 
 		#region Get File Size
 

--- a/FluentFTP/Client/FtpClient_FolderDownload.cs
+++ b/FluentFTP/Client/FtpClient_FolderDownload.cs
@@ -8,6 +8,7 @@ using System.Threading;
 #if (CORE || NET45)
 using System.Threading.Tasks;
 #endif
+using System.Linq;
 
 namespace FluentFTP {
 	public partial class FtpClient : IDisposable {
@@ -139,7 +140,11 @@ namespace FluentFTP {
 			localFolder.EnsureDirectory();
 
 			// get all the files in the remote directory
+#if ASYNCPLUS
+			var listing = await GetListingAsync(remoteFolder, FtpListOption.Recursive | FtpListOption.Size, token).ToArrayAsync();
+#else
 			var listing = await GetListingAsync(remoteFolder, FtpListOption.Recursive | FtpListOption.Size, token);
+#endif
 
 			// break if task is cancelled
 			token.ThrowIfCancellationRequested();

--- a/FluentFTP/Client/FtpClient_FolderManagement.cs
+++ b/FluentFTP/Client/FtpClient_FolderManagement.cs
@@ -260,10 +260,18 @@ namespace FluentFTP {
 				// only if GetListing was called with recursive option.
 				FtpListItem[] itemList;
 				if (recurse) {
+#if ASYNCPLUS
+					itemList = await GetListingAsync(path, options, token).ToArrayAsync();
+#else
 					itemList = await GetListingAsync(path, options, token);
+#endif
 				}
 				else {
+#if ASYNCPLUS
+					itemList = await GetListingAsync(path, options, token).OrderByDescending(x => x.FullName.Count(c => c.Equals('/'))).ThenBy(x => x.Type).ToArrayAsync();
+#else
 					itemList = (await GetListingAsync(path, options, token)).OrderByDescending(x => x.FullName.Count(c => c.Equals('/'))).ThenBy(x => x.Type).ToArray();
+#endif
 				}
 
 				// delete the item based on the type
@@ -299,7 +307,7 @@ namespace FluentFTP {
 		}
 #endif
 
-		#endregion
+#endregion
 
 		#region Directory Exists
 

--- a/FluentFTP/Client/IFtpClient.cs
+++ b/FluentFTP/Client/IFtpClient.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -184,11 +185,17 @@ namespace FluentFTP {
 
 #if ASYNC
 		Task<FtpListItem> GetObjectInfoAsync(string path, bool dateModified = false, CancellationToken token = default(CancellationToken));
+
+#if ASYNCPLUS
+		IAsyncEnumerable<FtpListItem> GetListingAsync(string path, FtpListOption options, CancellationToken token = default(CancellationToken), CancellationToken enumToken = default(CancellationToken));
+		IAsyncEnumerable<FtpListItem> GetListingAsync(string path, CancellationToken token = default(CancellationToken), CancellationToken enumToken = default(CancellationToken));
+		IAsyncEnumerable<FtpListItem> GetListingAsync(CancellationToken token = default(CancellationToken), CancellationToken enumToken = default(CancellationToken));
+#else
 		Task<FtpListItem[]> GetListingAsync(string path, FtpListOption options, CancellationToken token = default(CancellationToken));
 		Task<FtpListItem[]> GetListingAsync(string path, CancellationToken token = default(CancellationToken));
 		Task<FtpListItem[]> GetListingAsync(CancellationToken token = default(CancellationToken));
+#endif
 		Task<string[]> GetNameListingAsync(string path, CancellationToken token = default(CancellationToken));
-
 		Task<string[]> GetNameListingAsync(CancellationToken token = default(CancellationToken));
 #endif
 

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -33,6 +33,11 @@
     <DefineConstants>$(DefineConstants);NET45PLUS</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1' Or '$(TargetFramework)'=='net50'">
+    <DefineConstants>$(DefineConstants);ASYNCPLUS</DefineConstants>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
   <PropertyGroup>
     <PackageId>FluentFTP</PackageId>
     <Title>FluentFTP</Title>
@@ -69,6 +74,14 @@
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' Or '$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'">
     <PackageReference Include="System.Net.Security" Version="4.3.2.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(DefineConstants.Contains('ASYNCPLUS')) And '$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(DefineConstants.Contains('ASYNCPLUS'))">
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Support IAsyncEnumerable on .NET Standard 2.0+, so users no longer need to wait the complete listing operation to finish.

Example usage:

```csharp
using System;
using FluentFTP;

var ftpClient = new FtpClient("ftp://ftp.aist-nara.ac.jp");
await ftpClient.AutoConnectAsync();
await foreach (var i in ftpClient.GetListingAsync("/", FtpListOption.Recursive))
{
	Console.WriteLine(i.FullName);
}
```