### PR TITLE
Issue_723 - Possible wrong IP on command EPSV

### DIFF
--- a/FluentFTP/Client/FtpClient_Stream.cs
+++ b/FluentFTP/Client/FtpClient_Stream.cs
@@ -630,8 +630,16 @@ namespace FluentFTP {
 					throw new FtpException("Failed to get the EPSV port from: " + reply.Message);
 				}
 			}
+			// If ESPV is responded with Entering Extended Passive. The IP must remain the same.
+			/* Example:
+			Command: EPSV
+			Response: 229 Entering Extended Passive Mode(|||10016|)
 
-			host = m_host;
+			If we set the host to ftp.host.com and ftp.host.com has multiple ip's we may end up with the wrong ip.
+			Making sure that we use the same IP.
+			host = m_host; 
+			*/
+			host = SocketRemoteEndPoint.Address.ToString();
 			port = int.Parse(m.Groups["port"].Value);
 		}
 


### PR DESCRIPTION
I think I found the problem in my case. Azure Web App have multiple IP's for the same host and the list always failed when the IP changed suddenly from one to another:

See [Incorrect directory listing on "Failed to connect to host" exception](https://github.com/robinrodricks/FluentFTP/issues/723)