### PR TITLE
Fixed IBM zOS MVS File uploading

### DIFF
--- a/FluentFTP/Client/FtpClient_FileUpload.cs
+++ b/FluentFTP/Client/FtpClient_FileUpload.cs
@@ -97,17 +97,10 @@ namespace FluentFTP {
 				var remotePath = "";
 
 				if (isPDS) {
-					remotePath = remoteDir;
-
-					// make sure path doesn't end with a dot before appending "(filename)"
-					if (remotePath[remotePath.Length - 2] == '.') {
-						remotePath = remotePath.Remove(remotePath.Length - 2, 1);
-					}
-
-					// Append "(filename)" before closing single quote
-					remotePath = remotePath.Insert(remotePath.Length - 1, "(");
-					remotePath = remotePath.Insert(remotePath.Length - 1, fileName);
-					remotePath = remotePath.Insert(remotePath.Length - 1, ")");
+					// STOR cmd is intelligent enough to determine the full path
+					// and if it needs to append the ".filename" or "(filename)"
+					// addition to the remote path internally for Dsorgs.
+					remotePath = fileName;
 				}
 				else {
 					remotePath = remoteDir + fileName;


### PR DESCRIPTION
An issue with my previous implementation is that it is assuming you are always trying to upload to a PO (Physical Organization) and would throw the error "Unable to upload, use MVS naming convention" when trying to upload to other locations.. So I only fixed half the problem.

By just sending the filename into the STOR command rather than with the full file path, the STOR command is intelligent enough to determine if the target location is a Physical Organization and append the (filename) convention to upload to a Partitioned Data Set. It also can append the .filename convention if it is a Physical Sequential location and upload it like a normal file rather than a PDS.