### PR TITLE
Support z/OS and OS/400 GetListing Function

### DIFF
--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -250,8 +250,15 @@ namespace FluentFTP {
 			var isGetModified = options.HasFlag(FtpListOption.Modify);
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
-			// calc path to request
-			path = GetAbsolutePath(path);
+			// Only disable the GetAbsolutePath(path) if z/OS
+			// Note: "TEST.TST" is a "path" that does not start with a slash
+			// This could be a unix file on z/OS OR a classic CWD relative dataset
+			// Both of these work with the z/OS FTP server LIST command
+			if (path.StartsWith("/") || ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
+			{
+				// calc the absolute filepath
+				path = GetAbsolutePath(path);
+			}
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option
@@ -378,7 +385,9 @@ namespace FluentFTP {
 					//this.LogStatus(FtpTraceLevel.Verbose, "Skipped self or parent item: " + item.Name);
 				}
 			}
-			else {
+			// for z/OS, return of null actually means, just skip with no warning
+			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
+			{
 				LogStatus(FtpTraceLevel.Warn, "Failed to parse file listing: " + buf);
 			}
 			return true;
@@ -616,8 +625,15 @@ namespace FluentFTP {
 			var isGetModified = options.HasFlag(FtpListOption.Modify);
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
-			// calc path to request
-			path = await GetAbsolutePathAsync(path, token);
+			// Only disable the GetAbsolutePath(path) if z/OS
+			// Note: "TEST.TST" is a "path" that does not start with a slash
+			// This could be a unix file on z/OS OR a classic CWD relative dataset
+			// Both of these work with the z/OS FTP server LIST command
+			if (path.StartsWith("/") || ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
+			{
+				// calc the absolute filepath
+				path = await GetAbsolutePathAsync(path, token);
+			}
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option

--- a/FluentFTP/Client/FtpClient_Properties.cs
+++ b/FluentFTP/Client/FtpClient_Properties.cs
@@ -1111,6 +1111,19 @@ namespace FluentFTP {
 			get => m_stream?.RemoteEndPoint;
 		}
 
+		private FtpzOSListRealm m_zOSListingRealm;
+
+		/// <summary>
+		/// Accept any SSL certificate received from the server and skip performing
+		/// the validation using the ValidateCertificate callback.
+		/// Useful for Powershell users.
+		/// </summary>
+		public FtpzOSListRealm zOSListingRealm
+		{
+			get => m_zOSListingRealm;
+			set => m_zOSListingRealm = value;
+		}
+
 		// ADD PROPERTIES THAT NEED TO BE CLONED INTO
 		// FtpClient.CloneConnection()
 	}

--- a/FluentFTP/Enums/FtpParser.cs
+++ b/FluentFTP/Enums/FtpParser.cs
@@ -41,13 +41,18 @@ namespace FluentFTP {
 		VMS = 5,
 
 		/// <summary>
-		/// File listing parser for IBM OS400.
+		/// File listing parser for IBM z/OS
 		/// </summary>
-		IBM = 6,
+		IBMzOS = 6,
+
+		/// <summary>
+		/// File listing parser for IBM OS/400.
+		/// </summary>
+		IBMOS400 = 7,
 
 		/// <summary>
 		/// File listing parser for Tandem/Nonstop Guardian OS.
 		/// </summary>
-		NonStop = 7
+		NonStop = 8
 	}
 }

--- a/FluentFTP/Enums/FtpServer.cs
+++ b/FluentFTP/Enums/FtpServer.cs
@@ -112,6 +112,11 @@ namespace FluentFTP {
 		IBMzOSFTP,
 
 		/// <summary>
+		/// Definitely IBM OS/400 FTP server
+		/// </summary>
+		IBMOS400FTP,
+
+		/// <summary>
 		/// Definitely FritzBox FTP server
 		/// </summary>
 		FritzBox,

--- a/FluentFTP/Enums/FtpzOSListRealm.cs
+++ b/FluentFTP/Enums/FtpzOSListRealm.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace FluentFTP {
+	/// <summary>
+	/// Flags that can control how a file listing is performed. If you are unsure what to use, set it to Auto.
+	/// </summary>
+	[Flags]
+	public enum FtpzOSListRealm {
+		/// <summary>
+		/// HFS / USS 
+		/// </summary>
+		Unix = 0,
+
+		/// <summary>
+		/// z/OS classic dataset
+		/// </summary>
+		Dataset = 1,
+
+		/// <summary>
+		/// Partitioned dataset member, RECFM != U
+		/// </summary>
+		Member = 2,
+
+		/// <summary>
+		/// Partitioned dataset member, RECFM = U
+		/// </summary>
+		MemberU = 3
+	}
+}

--- a/FluentFTP/Helpers/FtpListParser.cs
+++ b/FluentFTP/Helpers/FtpListParser.cs
@@ -16,7 +16,7 @@ namespace FluentFTP.Helpers {
 		public FtpClient client;
 
 		private static List<FtpParser> parsers = new List<FtpParser> {
-			FtpParser.Unix, FtpParser.Windows, FtpParser.IBM, FtpParser.VMS, FtpParser.NonStop
+			FtpParser.Unix, FtpParser.Windows, FtpParser.VMS, FtpParser.IBMzOS, FtpParser.IBMOS400, FtpParser.NonStop
 		};
 
 		/// <summary>
@@ -72,16 +72,22 @@ namespace FluentFTP.Helpers {
 				else if (system == FtpOperatingSystem.VMS) {
 					CurrentParser = FtpParser.VMS;
 				}
-				else if (system == FtpOperatingSystem.IBMOS400 || system == FtpOperatingSystem.IBMzOS) {
-					CurrentParser = FtpParser.IBM;
+				else if (system == FtpOperatingSystem.IBMzOS) {
+					CurrentParser = FtpParser.IBMzOS;
 				}
-				else {
+				else if (system == FtpOperatingSystem.IBMOS400) {
+					CurrentParser = FtpParser.IBMOS400;
+				}
+				else
+				{
 					CurrentParser = FtpParser.Unix;
 					client.LogStatus(FtpTraceLevel.Warn, "Cannot auto-detect listing parser for system '" + system + "', using Unix parser");
 				}
 			}
 
 			DetectedParser = CurrentParser;
+
+			client.LogStatus(FtpTraceLevel.Verbose, "Listing parser set to: " + DetectedParser.ToString());
 		}
 
 		/// <summary>
@@ -126,8 +132,12 @@ namespace FluentFTP.Helpers {
 							result = FtpVMSParser.Parse(client, file);
 							break;
 
-						case FtpParser.IBM:
-							result = FtpIBMParser.Parse(client, file);
+						case FtpParser.IBMzOS:
+							result = FtpIBMzOSParser.Parse(client, file);
+							break;
+
+						case FtpParser.IBMOS400:
+							result = FtpIBMOS400Parser.Parse(client, file);
 							break;
 
 						case FtpParser.NonStop:
@@ -221,8 +231,11 @@ namespace FluentFTP.Helpers {
 				case FtpParser.VMS:
 					return FtpVMSParser.IsValid(client, files);
 
-				case FtpParser.IBM:
-					return FtpIBMParser.IsValid(client, files);
+				case FtpParser.IBMzOS:
+					return FtpIBMzOSParser.IsValid(client, files);
+
+				case FtpParser.IBMOS400:
+					return FtpIBMOS400Parser.IsValid(client, files);
 
 				case FtpParser.NonStop:
 					return FtpNonStopParser.IsValid(client, files);

--- a/FluentFTP/Helpers/Parsers/FtpIBMOS400Parser.cs
+++ b/FluentFTP/Helpers/Parsers/FtpIBMOS400Parser.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 #endif
 
 namespace FluentFTP.Helpers.Parsers {
-	internal static class FtpIBMParser {
+	internal static class FtpIBMOS400Parser {
 		private static int formatIndex = 0;
 
 		/// <summary>

--- a/FluentFTP/Helpers/Parsers/FtpIBMzOSParser.cs
+++ b/FluentFTP/Helpers/Parsers/FtpIBMzOSParser.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Globalization;
+
+#if NET45
+using System.Threading.Tasks;
+
+#endif
+
+namespace FluentFTP.Helpers.Parsers
+{
+	internal static class FtpIBMzOSParser
+	{
+		/// <summary>
+		/// Checks if the given listing is a valid IBM z/OS file listing
+		/// </summary>
+		public static bool IsValid(FtpClient client, string[] listing)
+		{
+			// Check validity by using the title line
+			// USS Realm     : "total nnnn"
+			// Dataset       : "Volume Unit    Referred Ext Used Recfm Lrecl BlkSz Dsorg Dsname"
+			// Member        : " Name     VV.MM   Created       Changed      Size  Init   Mod   Id"
+			// Member Loadlib: " Name      Size     TTR   Alias-of AC--------- Attributes--------- Amode Rmode"
+
+			return listing[0].Contains("total") ||
+		           listing[0].Contains("Volume Unit") ||
+				   listing[0].Contains("Name     VV.MM") ||
+				   listing[0].Contains("Name      Size     TTR");
+		}
+
+		/// <summary>
+		/// Parses IBM z/OS format listings
+		/// </summary>
+		/// <param name="client">The FTP client</param>
+		/// <param name="record">A line from the listing</param>
+		/// <returns>FtpListItem if the item is able to be parsed</returns>
+		public static FtpListItem Parse(FtpClient client, string record)
+		{
+			// Skip title line - all modes have one. 
+			// Also set zOSListingRealm to remember the mode we are in
+
+			// "total nnnn"
+			if (record.Contains("total"))
+			{
+				client.zOSListingRealm = FtpzOSListRealm.Unix;
+				return null;
+			}
+
+			// "Volume Unit    Referred Ext Used Recfm Lrecl BlkSz Dsorg Dsname"
+			if (record.Contains("Volume Unit"))
+			{
+				client.zOSListingRealm = FtpzOSListRealm.Dataset;
+				return null;
+			}
+
+			// " Name     VV.MM   Created       Changed      Size  Init   Mod   Id"
+			if (record.Contains("Name     VV.MM"))
+			{
+				client.zOSListingRealm = FtpzOSListRealm.Member;
+				return null;
+			}
+
+			// "Name      Size     TTR   Alias-of AC--------- Attributes--------- Amode Rmode"
+			if (record.Contains("Name      Size     TTR"))
+			{
+				client.zOSListingRealm = FtpzOSListRealm.MemberU;
+				return null;
+			}
+
+			if (client.zOSListingRealm == FtpzOSListRealm.Unix)
+			{
+				// unix mode
+				//
+				//total 320
+				//
+				return FtpUnixParser.Parse(client, record);
+			}
+
+			if (client.zOSListingRealm == FtpzOSListRealm.Dataset)
+			{
+				// PS/PO mode
+				//
+				//Volume Unit    Referred Ext Used Recfm Lrecl BlkSz Dsorg Dsname    
+				//ANSYBG 3390   2020/01/03  1   15  VB   32756 32760  PS  $.ADATA.XAA
+				//
+
+				// Ignore title line AND also ignore "VSAM", "Not Mounted" and "Error determining attributes"
+
+				if (record.Substring(51, 4).Trim() == "PO" || record.Substring(51, 4).Trim() == "PS")
+				{
+					string volume = record.Substring(0, 6);
+					string unit = record.Substring(7, 4);
+					string referred = record.Substring(14, 10).Trim();
+					string ext = record.Substring(25, 2).Trim();
+					string used = record.Substring(27, 5).Trim();
+					string recfm = record.Substring(34, 4).Trim();
+					string lrecl = record.Substring(39, 5).Trim();
+					string blksz = record.Substring(45, 5).Trim();
+					string dsorg = record.Substring(51, 4).Trim();
+					string dsname = record.Remove(0, 56).Trim().Split(' ')[0];
+					bool isDir = dsorg == "PO";
+					var lastModifiedStr = referred;
+					if (lastModifiedStr != "**NONE**")
+					{
+						lastModifiedStr += " 00:00";
+					}
+					var lastModified = ParseDateTime(client, lastModifiedStr);
+					var size = EstimateSize(used);
+					var file = new FtpListItem(record, dsname, size, isDir, ref lastModified);
+					return file;
+				}
+				return null;
+			}
+
+			if (client.zOSListingRealm == FtpzOSListRealm.Member)
+			{
+				// Member mode
+				//
+				// Name     VV.MM   Created       Changed      Size  Init   Mod   Id   
+				//$2CPF1    01.01 2001/10/18 2001/10/18 11:58    29    29     0 QFX3076
+				//
+
+				string name = record.Substring(0, 8).Trim();
+				string changed = string.Empty;
+				string records = "0";
+				// Member stats may be empty
+				if (record.TrimEnd().Length > 8)
+				{
+					string vvmm = record.Substring(10, 5).Trim();
+					string created = record.Substring(17, 10).Trim();
+					changed = record.Substring(27, 16).Trim();
+					records = record.Substring(44, 5).Trim();
+					string init = record.Substring(50, 5).Trim();
+					string mod = record.Substring(56, 5).Trim();
+					string id = record.Substring(62, 6).Trim();
+				}
+				bool isDir = false;
+				var lastModifiedStr = changed;
+				var lastModified = ParseDateTime(client, lastModifiedStr);
+				var size = EstimateSizeMEM(records);
+				var file = new FtpListItem(record, name, size, isDir, ref lastModified);
+				return file;
+			}
+
+			if (client.zOSListingRealm == FtpzOSListRealm.MemberU)
+			{
+				// Member Loadlib mode
+				//
+				// Name      Size     TTR   Alias-of AC --------- Attributes --------- Amode Rmode
+				//EAGKCPT   000058   000009          00 FO             RN RU            31    ANY
+				//EAGRTPRC  005F48   000011 EAGRTALT 00 FO             RN RU            31    ANY
+				//
+
+				string name = record.Substring(0, 8).Trim();
+				string changed = string.Empty;
+				string memsize = record.Substring(10,6);
+				string TTR = record.Substring(19, 6);
+				string Alias = record.Substring(26, 8).Trim();
+				string Attributes = record.Substring(38, 30);
+				string Amode = record.Substring(70, 2);
+				string Rmode = record.Substring(76, 3);
+				bool isDir = false;
+				var lastModifiedStr = changed;
+				var lastModified = ParseDateTime(client, lastModifiedStr);
+				var size = int.Parse(memsize, System.Globalization.NumberStyles.HexNumber);
+				var file = new FtpListItem(record, name, size, isDir, ref lastModified);
+				return file;
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		/// Parses the last modified date from IBM z/OS format listings
+		/// </summary>
+		private static DateTime ParseDateTime(FtpClient client, string lastModifiedStr)
+		{
+			var lastModified = DateTime.MinValue;
+			if (lastModifiedStr == string.Empty || lastModifiedStr == "**NONE**")
+			{
+				return lastModified;
+			}
+			lastModified = DateTime.ParseExact(lastModifiedStr, @"yyyy'/'MM'/'dd HH':'mm", client.ListingCulture.DateTimeFormat, DateTimeStyles.None);
+
+			return lastModified;
+		}
+
+		/// <summary>
+		/// This is a upper bound and an estimate of the file size.
+		/// </summary>
+		private static long EstimateSize(string used)
+		{
+			int n_used = int.Parse(used);   // # of tracks used
+
+			// Assume 3390 device
+			long bytesPerTrack = 56664;
+
+			return n_used * bytesPerTrack;
+		}
+
+		/// <summary>
+		/// Give the caller the number of records instead of a file size.
+		/// </summary>
+		private static long EstimateSizeMEM(string records)
+		{
+			int n_records = int.Parse(records);   // # of records of member
+
+			// We don't know LRECL
+			long bytesPerRecord = 1;
+
+			return n_records * bytesPerRecord;
+		}
+	}
+}

--- a/FluentFTP/Servers/Handlers/IbmOs400FtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IbmOs400FtpServer.cs
@@ -14,15 +14,15 @@ using System.Threading.Tasks;
 namespace FluentFTP.Servers.Handlers {
 
 	/// <summary>
-	/// Server-specific handling for IBMzOSFTP servers
+	/// Server-specific handling for IBMOS400FTP servers
 	/// </summary>
-	public class IbmZosFtpServer : FtpBaseServer {
+	public class IbmOs400FtpServer : FtpBaseServer {
 
 		/// <summary>
 		/// Return the FtpServer enum value corresponding to your server, or Unknown if its a custom implementation.
 		/// </summary>
 		public override FtpServer ToEnum() {
-			return FtpServer.IBMzOSFTP;
+			return FtpServer.IBMOS400FTP;
 		}
 
 		/// <summary>
@@ -30,9 +30,9 @@ namespace FluentFTP.Servers.Handlers {
 		/// </summary>
 		public override bool DetectByWelcome(string message) {
 
-			// Detect IBM z/OS server
-			// Welcome message: "220-FTPD1 IBM FTP CS V2R3 at mysite.gov, 16:51:54 on 2019-12-12."
-			if (message.Contains("IBM FTP CS")) {
+			// Detect IBM OS/400 server
+			// Welcome message: "220-QTCP at xxxxxx.xxxxx.xxx.com."
+			if (message.Contains("QTCP at")) {
 				return true;
 			}
 
@@ -43,7 +43,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// Return the default file listing parser to be used with your FTP server.
 		/// </summary>
 		public override FtpParser GetParser() {
-			return FtpParser.IBMzOS;
+			return FtpParser.IBMOS400;
 		}
 
 	}


### PR DESCRIPTION
Robin,

Here is my current take on getting GetListing(...) to work with z/OS (and OS/400, which is unchanged and just separated out from the "generic" IBM label).

Some other functions of FluentFTP will still **not** work, especially those that rely on path manipulation etc., unless you are moving in the z/OS USS realm - this is sufficiently unix-like.

I see some places where others have already fixed upload and download for native z/OS dataset names (like "`'HLQ.QUAL1.QUAL2'`"),  those very valuable fixes handle the case of a fully complete dataset specification and I have been happily uploading and downloading thanks to those.

To show the user a list of items to choose from, this PR concerns getting a sensible listing of the available dataset / files under the current directory.

I wanted to put this out there for any that might need this urgently and also would like play with it and report anything that might still need to be done.

Here is a summary of what was changed:
Separate z/OS and OS/400 (two different animals)
- Make new components for IBM z/OS, IBM OS/400 (take the code of "IBM"), remove IBM
- Fix the Welcome Message of OS/400
- Use the Welcome Message of "IBM" in IBM z/OS
- Reflect these changes in the Enums, the Servers, etc.
- Create Directory Listing Parser for zOS native realm. Simply call the standard Unix Parser for the USS Realm,  
- Minor tweaks to System and Parser recognition

As soon as you move to the native z/OS realm, you will need to "CWD" explicitly to the level where you want to do use `GetListing()` and you need to add  `FtpListOption.NoPath`. **Edit:** But I have also made a modification so that this is not needed after all.

Note that `GetListing()` _sort of_ worked already before, as you can see from the discussion in #677.

Now, in the native realm, `isDir` is set depending on **PO**, the date format is parsed and an attempt is made to "guess" the size.

Here is some example code for both realms:

**Native z/OS realm:**
```

string zosPath = "'SYS1'"; // you can also use 'SYS1.', both work

FTP_Sess.Execute("CWD " + zosPath);
FtpListItem[] list = FTP_Sess.GetListing("", FtpListOption.NoPath);
string fullName = zosPath.Trim('\'').Trim('.') + '.' + list[0].FullName.Remove(0, 1);
```
**USS (linux-like) realm:**
```
string zosPath = "/projects";

FtpListItem[] list = FTP_Sess.GetListing(zosPath);
string fullName = list[0].FullName;
```
