### PR TITLE
IsRoot() API function

### DIFF
--- a/FluentFTP/Client/FtpClient_FolderManagement.cs
+++ b/FluentFTP/Client/FtpClient_FolderManagement.cs
@@ -796,6 +796,9 @@ namespace FluentFTP {
 			}
 
 			// If it is not a "/" root, it could perhaps be a z/OS root (like 'SYS1.')
+			// Note: If on z/OS you have somehow managed to CWD "over" th top, i.e.
+			// PWD returns "''" - you would need to CWD to some HLQ that only you can
+			// imagine. There is no way to list the available top level HLQs.
 			if (ServerType == FtpServer.IBMzOSFTP &&
 				ServerOS == FtpOperatingSystem.IBMzOS &&
 				_LastWorkingDir.Split('.').Length - 1 == 1)
@@ -826,6 +829,9 @@ namespace FluentFTP {
 			}
 
 			// If it is not a "/" root, it could perhaps be a z/OS root (like 'SYS1.')
+			// Note: If on z/OS you have somehow managed to CWD "over" th top, i.e.
+			// PWD returns "''" - you would need to CWD to some HLQ that only you can
+			// imagine. There is no way to list the available top level HLQs.
 			if (ServerType == FtpServer.IBMzOSFTP &&
 				ServerOS == FtpOperatingSystem.IBMzOS &&
 				_LastWorkingDir.Split('.').Length - 1 == 1)

--- a/FluentFTP/Client/FtpClient_FolderManagement.cs
+++ b/FluentFTP/Client/FtpClient_FolderManagement.cs
@@ -774,5 +774,69 @@ namespace FluentFTP {
 #endif
 
 		#endregion
+
+		#region IsRoot
+
+		/// <summary>
+		/// Is the current working directory the root?
+		/// </summary>
+		/// <returns>true if root.</returns>
+		public bool IsRoot()
+		{
+
+			// this case occurs immediately after connection and after the working dir has changed
+			if (_LastWorkingDir == null)
+			{
+				ReadCurrentWorkingDirectory();
+			}
+
+			if (_LastWorkingDir.IsFtpRootDirectory())
+			{
+				return true;
+			}
+
+			// If it is not a "/" root, it could perhaps be a z/OS root (like 'SYS1.')
+			if (ServerType == FtpServer.IBMzOSFTP &&
+				ServerOS == FtpOperatingSystem.IBMzOS &&
+				_LastWorkingDir.Split('.').Length - 1 == 1)
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Is the current working directory the root?
+		/// </summary>
+		/// <returns>true if root.</returns>
+		public async Task<bool> IsRootAsync(CancellationToken token = default(CancellationToken))
+		{
+
+			// this case occurs immediately after connection and after the working dir has changed
+			if (_LastWorkingDir == null)
+			{
+				await ReadCurrentWorkingDirectoryAsync(token);
+			}
+
+			if (_LastWorkingDir.IsFtpRootDirectory())
+			{
+				return true;
+			}
+
+			// If it is not a "/" root, it could perhaps be a z/OS root (like 'SYS1.')
+			if (ServerType == FtpServer.IBMzOSFTP &&
+				ServerOS == FtpOperatingSystem.IBMzOS &&
+				_LastWorkingDir.Split('.').Length - 1 == 1)
+			{
+				return true;
+			}
+
+			return false;
+		}
+#endif
+		#endregion
+
 	}
 }


### PR DESCRIPTION
This is a new API function.

When writing a nice FTP Client GUI for file system navigation, one comes across the problem of "goto parent directory button disable when already at root", so you need a root check.

Basically, for unix like filesystem, the check for  the current working directory being the root is so trivial that this API function seems redundant. The FluentFTP internal root check function checks for unix like files systems by checking for:

```
		public static bool IsFtpRootDirectory(this string ftppath) {
			return ftppath == "." || ftppath == "./" || ftppath == "/";
		}
``` 

But on a z/OS FTP server, you might be at the "root" (i.e. the top) of the file system, and the CWD is (for example) `'SYS1.'`

So, depending on the current server type and os type, further checks are needed.

Right now, this API function will check the unix like root first and then proceed to do further checks. For the moment with only z/OS being the "other" FTP server, this strategy is sufficient. 