### PR TITLE
GetzOSListRealm() API function

### DIFF
--- a/FluentFTP/Enums/FtpzOSListRealm.cs
+++ b/FluentFTP/Enums/FtpzOSListRealm.cs
@@ -7,6 +7,11 @@ namespace FluentFTP {
 	[Flags]
 	public enum FtpzOSListRealm {
 		/// <summary>
+		/// Not z/OS
+		/// </summary>
+		Invalid = -1,
+
+		/// <summary>
 		/// HFS / USS 
 		/// </summary>
 		Unix = 0,


### PR DESCRIPTION
This is a new API function.

When writing a nice FTP Client GUI for file system navigation in z/OS, one comes across the problem of "What is the z/OS realm of the filesystem path described by the current working directory".

For a unix like filesystem, the realm is of course unix and such a function is not needed.

But for a z/OS, a specialised function can make things easier.

The currrent working directory on z/OS either begins with a `/`, which tells us: realm is HFS.

Otherwise, it must be one of the z/OS (aka MVS) realms. But which one?

Short of doing a LIST command (which would be one way to do this), this makes use of a nice z/OS FTP server feature: When you `CWD` to an arbitrary path, if that path denotes a partitioned dataset, your are told that this is the case. And even more interesting: If it then also happens to be a RECFM=U PDS, your are **also** told that it is (probably) a load library.

This means you can determine the realm of a z/OS path **WITHOUT** performing a LIST.

An alternative in terms of coding this would be to perform a LIST on the path and to analyze the results, perhaps by calling the dirlist parser.  But such a LIST might be huge, so that approach should be avoided.