### PR TITLE
Fix unwanted Modified date overwrite.

### DIFF
--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -170,7 +170,10 @@ namespace FluentFTP {
 
 			// Get the accurate date modified using another MDTM command
 			if (result != null && dateModified && HasFeature(FtpCapability.MDTM)) {
-				result.Modified = await GetModifiedTimeAsync(path, token);
+				var alternativeModifiedDate = await GetModifiedTimeAsync(path, token);
+				if (alternativeModifiedDate != default) {
+					result.Modified = alternativeModifiedDate;
+				}
 			}
 
 			return result;


### PR DESCRIPTION
This change prevents the Modified date of a FtpListItem being overwritten if the consecutive MDTM command fails.