### PR TITLE
Catch CWD in Execute to invalidate cwd cache

### DIFF
--- a/FluentFTP/Client/FtpClient_FolderManagement.cs
+++ b/FluentFTP/Client/FtpClient_FolderManagement.cs
@@ -646,7 +646,8 @@ namespace FluentFTP {
 				}
 
 				// invalidate the cached path
-				_LastWorkingDir = null;
+				// This is redundant, Execute(...) will see the CWD and do this
+				//_LastWorkingDir = null;
 
 #if !CORE14
 			}
@@ -680,7 +681,8 @@ namespace FluentFTP {
 			}
 
 			// invalidate the cached path
-			_LastWorkingDir = null;
+			// This is redundant, Execute(...) will see the CWD and do this
+			//_LastWorkingDir = null;
 		}
 
 

--- a/FluentFTP/Client/FtpClient_Stream.cs
+++ b/FluentFTP/Client/FtpClient_Stream.cs
@@ -72,6 +72,11 @@ namespace FluentFTP {
 					commandTxt = "PASS ***";
 				}
 
+				// A CWD will invalidate the cached value.
+				if (command.StartsWith("CWD ", StringComparison.Ordinal)) {
+					_LastWorkingDir = null;
+				}
+
 				LogLine(FtpTraceLevel.Info, "Command:  " + commandTxt);
 
 				// send command to FTP server


### PR DESCRIPTION
In the `GetWorkingDirectory()` and `SetWorkingDirectory()` API function code logic, there is a `_LastWorkingDir` that acts as "cache" to avoid repeated `PWD` commands to the server. This is set to `null` when a connect takes place. Also set to `null` when a `SetWorkingDirectory()` is done.

So far so good.

But the `Execute(....)` API function could also perform a CWD. This is "coming from outside" and plays havoc on the internal cwd cache. This is especially if z/OS users CWD like crazy to do their thing and then expect GetCurrentDirectory to tell the truth.

Thus, I propose setting `_LastWorkingDir` to `null` in the execute routine if the command is a CWD. This makes the `null` setting in `SetWorkingDirectory()` redundant since it calls `Execute(CWD...)`. 

In a nutshell, **anyone, from wherever**, who changes the current directory, should invalidate this cache.

** Note: given a successfull CWD, why not set the cache to the new value instead of nulling it?** Subject for further investigation someday.