### PR TITLE
Re-use of client instance to server with different capabilities

### DIFF
--- a/FluentFTP/Client/FtpClient_Connection.cs
+++ b/FluentFTP/Client/FtpClient_Connection.cs
@@ -437,6 +437,11 @@ namespace FluentFTP {
 
 				// if this is a clone these values should have already been loaded
 				// so save some bandwidth and CPU time and skip executing this again.
+				// otherwise clear the capabilities in case connection is reused to 
+				// a different server 
+				if (!m_isClone && m_checkCapabilities) {
+					m_capabilities.Clear();
+				}
 				bool assumeCaps = false;
 				if (m_capabilities.IsBlank() && m_checkCapabilities) {
 					if ((reply = Execute("FEAT")).Success && reply.InfoMessages != null) {
@@ -608,6 +613,11 @@ namespace FluentFTP {
 
 			// if this is a clone these values should have already been loaded
 			// so save some bandwidth and CPU time and skip executing this again.
+			// otherwise clear the capabilities in case connection is reused to 
+			// a different server 
+			if (!m_isClone && m_checkCapabilities) {
+				m_capabilities.Clear();
+			}
 			bool assumeCaps = false;
 			if (m_capabilities.IsBlank() && m_checkCapabilities) {
 				if ((reply = await ExecuteAsync("FEAT", token)).Success && reply.InfoMessages != null) {


### PR DESCRIPTION
Re-using a client instance to connect to a server with different capabilites is possible but the `FEAT` command is not performed on the new connection. This causes problems when the new server has **LESS** features than the previous server. Unless it is a cloned connection.

Simple solution is to clear the capabilites list if it is not a clone.