### PR TITLE
Fix GetListing() regression caused by PR #764 - many untrue parse fail warnings

### DIFF
--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -389,7 +389,7 @@ namespace FluentFTP {
 				}
 			}
 			// for z/OS, return of null actually means, just skip with no warning
-			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
+			else if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
 			{
 				LogStatus(FtpTraceLevel.Warn, "Failed to parse file listing: " + buf);
 			}


### PR DESCRIPTION
**urgent**

GetListing() works but PR 764 causes very many unneccessary parse fail warnings.

An `else` keyword somehow disappeared on the commit/push sequence.