### PR TITLE
FtpListOption.ForceList is not being honored

### DIFF
--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -423,7 +423,7 @@ namespace FluentFTP {
 			}
 			else {
 				// use machine listing if supported by the server
-				if ((!isForceList || ListingParser == FtpParser.Machine) && HasFeature(FtpCapability.MLSD)) {
+				if (!isForceList && ListingParser == FtpParser.Machine && HasFeature(FtpCapability.MLSD)) {
 					listcmd = "MLSD";
 					machineList = true;
 				}


### PR DESCRIPTION
When connected to a FEAT MLST / MLSD server, the parser is set to "machine".

If you now specify FtpListOptions.ForceList, one would expect this to **take precedence** over the "machine" setting of the parser.

You absolutely need this if you are interested in seeing entries that are _links_ - these are not supported by the MLSD "machine" parser, for understandable reasons (see [this](https://www.rfc-editor.org/errata/eid1500) to realise that MLST might be very nice and fast, easier to parse, but sadly it currently does not support link entries in a standardized way.