### PR TITLE
Better handling of not-accepted certificates on autoconnect

### DIFF
--- a/FluentFTP/Client/FtpClient_AutoConnection.cs
+++ b/FluentFTP/Client/FtpClient_AutoConnection.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Security.Authentication;
 using FluentFTP.Proxy;
 using SysSslProtocols = System.Security.Authentication.SslProtocols;
 using FluentFTP.Servers;
@@ -141,6 +142,13 @@ namespace FluentFTP {
 							}
 						}
 						catch (Exception ex) {
+
+#if !CORE14
+							if (ex is AuthenticationException)
+							{
+								throw new FtpInvalidCertificateException();
+							}
+#endif
 
 							// since the connection failed, disconnect and retry
 							conn.Disconnect();
@@ -293,6 +301,13 @@ namespace FluentFTP {
 						}
 					}
 					catch (Exception ex) {
+
+#if !CORE14
+						if (ex is AuthenticationException)
+						{
+							throw new FtpInvalidCertificateException();
+						}
+#endif
 
 						// since the connection failed, disconnect and retry
 						await conn.DisconnectAsync();

--- a/FluentFTP/Exceptions/FtpInvalidCertificateException.cs
+++ b/FluentFTP/Exceptions/FtpInvalidCertificateException.cs
@@ -1,0 +1,40 @@
+﻿using System;
+#if !CORE
+using System.Runtime.Serialization;
+#endif
+
+namespace FluentFTP {
+
+	/// <summary>
+	/// Exception is thrown when TLS/SSL encryption could not be negotiated by the FTP server.
+	/// </summary>
+#if !CORE
+	[Serializable]
+#endif
+	public class FtpInvalidCertificateException : FtpException {
+		/// <summary>
+		/// Default constructor
+		/// </summary>
+		public FtpInvalidCertificateException()
+			: base("FTPS security could not be established on the server. The certificate was not accepted.") {
+			
+		}
+
+		/// <summary>
+		/// Custom error message
+		/// </summary>
+		/// <param name="message">Error message</param>
+		public FtpInvalidCertificateException(string message)
+			: base(message) {
+		}
+
+#if !CORE
+		/// <summary>
+		/// Must be implemented so every Serializer can Deserialize the Exception
+		/// </summary>
+		protected FtpInvalidCertificateException(SerializationInfo info, StreamingContext context) : base(info, context) {
+		}
+
+#endif
+	}
+}


### PR DESCRIPTION
This one is hard to explain:

If:

You use autoconnect

and

You decide to use the `OnValidateCertificate` delegate

and

You decide to **REJECT** the certificate...

the current logic will notice the failure and attempt a disconnect, which will attempt a "QUIT" execution, which will percolate an outstanding exception, which makes everything following this very unclean.

I feel that a successful connection that fails due to a rejected certificate should terminate the sequence of connections attempts, and furthermore, do this in a more graceful fashion.

My 2 cents on this, so I submit this for review and discussion.

As with all other PRs I am using these ASIS for a z/OS - Unix FTP navigator.

