### PR TITLE
#82 - Implement No Auth SOCkS proxy 

### DIFF
--- a/FluentFTP.Tests/Tests.cs
+++ b/FluentFTP.Tests/Tests.cs
@@ -28,6 +28,9 @@ namespace Tests {
 		private const string m_user = "";
 		private const string m_pass = "";
 
+		private const string m_proxy_host = "";
+		private const int m_proxy_port = 0;
+
 		private static readonly int[] connectionTypes = new[] {
 			(int) FtpDataConnectionType.EPSV,
 			(int) FtpDataConnectionType.EPRT,
@@ -1294,6 +1297,25 @@ namespace Tests {
 			using (var cl = NewFtpClient_Inacessible2()) {
 				var profile = cl.AutoConnect();
 			}*/
+		}
+
+		[Fact]
+		public void TestSocksProxy()
+		{
+			using (var cl = new FtpClientSocks5Proxy(new ProxyInfo()
+			{
+				Credentials = null,
+				Host = m_proxy_host,
+				Port = m_proxy_port
+			})
+			{
+				Host = m_host,
+				Credentials = new NetworkCredential(m_user, m_pass)
+			})
+			{
+				var items = cl.GetListing("/");
+				Console.WriteLine(items.Length);
+			}
 		}
 
 #if ASYNC

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -111,6 +111,30 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net50'">
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Release' And '$(TargetFramework)'=='net45'">
     <Exec Command="copy /Y &quot;$(ProjectDir)bin\Release\net45\FluentFTP.dll&quot; &quot;$(SolutionDir)Powershell\FluentFTP.dll&quot;" />
   </Target>

--- a/FluentFTP/Proxy/FtpClientSocks5Proxy.cs
+++ b/FluentFTP/Proxy/FtpClientSocks5Proxy.cs
@@ -1,0 +1,48 @@
+﻿using System.Net;
+using FluentFTP.Proxy.Socks;
+#if ASYNC
+
+using System.Threading;
+using System.Threading.Tasks;
+
+#endif
+
+
+namespace FluentFTP.Proxy
+{
+	public class FtpClientSocks5Proxy : FtpClientProxy
+	{
+		public FtpClientSocks5Proxy(ProxyInfo proxy) : base(proxy)
+		{
+		}
+
+		protected override void Connect(FtpSocketStream stream)
+		{
+			base.Connect(stream);
+			var proxy = new SocksProxy(Host, Port, stream);
+			proxy.Negotiate();
+			proxy.Authenticate();
+			proxy.Connect();
+		}
+
+		protected override void Connect(FtpSocketStream stream, string host, int port, FtpIpVersion ipVersions)
+		{
+			base.Connect(stream);
+			var proxy = new SocksProxy(Host, port, stream);
+			proxy.Negotiate();
+			proxy.Authenticate();
+			proxy.Connect();
+		}
+		
+#if ASYNC
+		protected override async Task ConnectAsync(FtpSocketStream stream, CancellationToken cancellationToken)
+		{
+			await base.ConnectAsync(stream, cancellationToken);
+			var proxy = new SocksProxy(Host, Port, stream);
+			await proxy.NegotiateAsync();
+			await proxy.AuthenticateAsync();
+			await proxy.ConnectAsync();
+		}
+#endif
+	}
+}

--- a/FluentFTP/Proxy/Socks/SocksEnums.cs
+++ b/FluentFTP/Proxy/Socks/SocksEnums.cs
@@ -1,0 +1,41 @@
+public enum SocksAuthType
+{
+	NoAuthRequired = 0x00,
+	GSSAPI = 0x01,
+	UsernamePassword = 0x02,
+	NoAcceptableMethods = 0xFF
+}
+
+public enum SocksReply
+{
+	Succeeded = 0x00,
+	GeneralSOCKSServerFailure = 0x01,
+	NotAllowedByRuleset = 0x02,
+	NetworkUnreachable = 0x03,
+	HostUnreachable = 0x04,
+	ConnectionRefused = 0x05,
+	TTLExpired = 0x06,
+	CommandNotSupported = 0x07,
+	AddressTypeNotSupported = 0x08
+}
+
+internal enum SocksRequestAddressType
+{
+	Unknown = 0x00,
+	IPv4 = 0x01,
+	FQDN = 0x03,
+	IPv6 = 0x04
+}
+
+internal enum SocksRequestCommand : byte
+{
+	Connect = 0x01,
+	Bind = 0x02,
+	UdpAssociate = 0x03
+}
+
+internal enum SocksVersion
+{
+	Four = 0x04,
+	Five = 0x05
+}

--- a/FluentFTP/Proxy/Socks/SocksProxy.cs
+++ b/FluentFTP/Proxy/Socks/SocksProxy.cs
@@ -19,7 +19,6 @@ namespace FluentFTP.Proxy.Socks
 		private readonly int _destinationPort;
 		private readonly FtpSocketStream _socketStream;
 		private SocksAuthType? _authType;
-		private SocksReply _reply;
 
 		public SocksProxy(string destinationHost, int destinationPort, FtpSocketStream socketStream)
 		{
@@ -64,6 +63,8 @@ namespace FluentFTP.Proxy.Socks
 			var requestBuffer = GetConnectRequest();
 			_socketStream.Write(requestBuffer, 0, requestBuffer.Length);
 
+			SocksReply reply;
+			
 			// The server evaluates the request, and returns a reply.
 			// - First we read VER, REP, RSV & ATYP
 			var received = _socketStream.Read(_buffer, 0, 4);
@@ -71,8 +72,8 @@ namespace FluentFTP.Proxy.Socks
 			{
 				if (received >= 2)
 				{
-					_reply = (SocksReply)_buffer[1];
-					HandleProxyCommandError(_reply);
+					reply = (SocksReply)_buffer[1];
+					HandleProxyCommandError(reply);
 				}
 
 				_socketStream.Close();
@@ -80,11 +81,11 @@ namespace FluentFTP.Proxy.Socks
 			}
 
 			// - Now we check if the reply was positive.
-			_reply = (SocksReply)_buffer[1];
+			reply = (SocksReply)_buffer[1];
 
-			if (_reply != SocksReply.Succeeded)
+			if (reply != SocksReply.Succeeded)
 			{
-				HandleProxyCommandError(_reply);
+				HandleProxyCommandError(reply);
 			}
 
 			// - Consume rest of the SOCKS5 protocol so the next read will give application data.
@@ -243,6 +244,8 @@ namespace FluentFTP.Proxy.Socks
 			var requestBuffer = GetConnectRequest();
 			await _socketStream.WriteAsync(requestBuffer, 0, requestBuffer.Length);
 
+			SocksReply reply;
+
 			// The server evaluates the request, and returns a reply.
 			// - First we read VER, REP, RSV & ATYP
 			var received = await _socketStream.ReadAsync(_buffer, 0, 4);
@@ -250,8 +253,8 @@ namespace FluentFTP.Proxy.Socks
 			{
 				if (received >= 2)
 				{
-					_reply = (SocksReply)_buffer[1];
-					HandleProxyCommandError(_reply);
+					reply = (SocksReply)_buffer[1];
+					HandleProxyCommandError(reply);
 				}
 
 				_socketStream.Close();
@@ -259,11 +262,11 @@ namespace FluentFTP.Proxy.Socks
 			}
 
 			// - Now we check if the reply was positive.
-			_reply = (SocksReply)_buffer[1];
+			reply = (SocksReply)_buffer[1];
 
-			if (_reply != SocksReply.Succeeded)
+			if (reply != SocksReply.Succeeded)
 			{
-				HandleProxyCommandError(_reply);
+				HandleProxyCommandError(reply);
 			}
 
 			// - Consume rest of the SOCKS5 protocol so the next read will give application data.

--- a/FluentFTP/Proxy/Socks/SocksProxy.cs
+++ b/FluentFTP/Proxy/Socks/SocksProxy.cs
@@ -1,0 +1,341 @@
+﻿using System;
+using System.Net;
+using System.Text;
+
+#if ASYNC
+using System.Threading.Tasks;
+#endif
+
+namespace FluentFTP.Proxy.Socks
+{
+	/// <summary>
+	///     This class is not reusable.
+	///     You have to create a new instance for each connection / attempt.
+	/// </summary>
+	public class SocksProxy
+	{
+		private readonly byte[] _buffer;
+		private readonly string _destinationHost;
+		private readonly int _destinationPort;
+		private readonly FtpSocketStream _socketStream;
+		private SocksAuthType? _authType;
+		private SocksReply _reply;
+
+		public SocksProxy(string destinationHost, int destinationPort, FtpSocketStream socketStream)
+		{
+			_buffer = new byte[512];
+			_destinationHost = destinationHost;
+			_destinationPort = destinationPort;
+			_socketStream = socketStream;
+		}
+
+		public void Negotiate()
+		{
+			// The client connects to the server,
+			// and sends a version identifier / method selection message.
+			var methodsBuffer = new byte[]
+			{
+				(byte)SocksVersion.Five, // VER
+				0x01, // NMETHODS
+				(byte)SocksAuthType.NoAuthRequired // Methods
+			};
+
+			_socketStream.Write(methodsBuffer, 0, methodsBuffer.Length);
+
+			// The server selects from one of the methods given in METHODS,
+			// and sends a METHOD selection message:
+			var receivedBytes = _socketStream.Read(_buffer, 0, 2);
+			if (receivedBytes != 2)
+			{
+				_socketStream.Close();
+				throw new SocksProxyException($"Negotiation Response had an invalid length of {receivedBytes}");
+			}
+
+			_authType = (SocksAuthType)_buffer[1];
+		}
+
+		public void Authenticate()
+		{
+			AuthenticateInternal();
+		}
+
+		public void Connect()
+		{
+			var requestBuffer = GetConnectRequest();
+			_socketStream.Write(requestBuffer, 0, requestBuffer.Length);
+
+			// The server evaluates the request, and returns a reply.
+			// - First we read VER, REP, RSV & ATYP
+			var received = _socketStream.Read(_buffer, 0, 4);
+			if (received != 4)
+			{
+				if (received >= 2)
+				{
+					_reply = (SocksReply)_buffer[1];
+					HandleProxyCommandError(_reply);
+				}
+
+				_socketStream.Close();
+				throw new SocksProxyException($"Connect Reply has Invalid Length {received}. Expecting 4.");
+			}
+
+			// - Now we check if the reply was positive.
+			_reply = (SocksReply)_buffer[1];
+
+			if (_reply != SocksReply.Succeeded)
+			{
+				HandleProxyCommandError(_reply);
+			}
+
+			// - Consume rest of the SOCKS5 protocol so the next read will give application data.
+			var atyp = (SocksRequestAddressType)_buffer[3];
+			int atypSize;
+			int read;
+
+			switch (atyp)
+			{
+				case SocksRequestAddressType.IPv4:
+					atypSize = 6;
+					read = _socketStream.Read(_buffer, 0, atypSize);
+					break;
+				case SocksRequestAddressType.IPv6:
+					atypSize = 18;
+					read = _socketStream.Read(_buffer, 0, atypSize);
+					break;
+				case SocksRequestAddressType.FQDN:
+					atypSize = 1;
+					_socketStream.Read(_buffer, 0, atypSize);
+					atypSize = _buffer[0] + 2;
+					read = _socketStream.Read(_buffer, 0, atypSize);
+					break;
+				default:
+					_socketStream.Close();
+					throw new SocksProxyException("Unknown Socks Request Address Type", new ArgumentOutOfRangeException());
+			}
+
+			if (read != atypSize)
+			{
+				_socketStream.Close();
+				throw new SocksProxyException($"Unexpected Response size from Request Type Data. Expected {atypSize} received {read}");
+			}
+		}
+
+
+		private void AuthenticateInternal()
+		{
+			if (!_authType.HasValue)
+			{
+				_socketStream.Close();
+				throw new SocksProxyException("Invalid Auth Type Declared, see inner exception for details.", new ArgumentException("No SOCKS5 auth method has been set."));
+			}
+
+			// The client and server then enter a method-specific sub-negotiation.
+			switch (_authType.Value)
+			{
+				case SocksAuthType.NoAuthRequired:
+					break;
+
+				case SocksAuthType.GSSAPI:
+					_socketStream.Close();
+					throw new SocksProxyException("Invalid Auth Type Declared, see inner exception for details.", new NotSupportedException("GSSAPI is not implemented."));
+
+				case SocksAuthType.UsernamePassword:
+					_socketStream.Close();
+					throw new SocksProxyException("Invalid Auth Type Declared, see inner exception for details.",
+						new NotSupportedException("UsernamePassword is not implemented."));
+
+				// If the selected METHOD is X'FF', none of the methods listed by the
+				// client are acceptable, and the client MUST close the connection
+				case SocksAuthType.NoAcceptableMethods:
+					_socketStream.Close();
+					throw new SocksProxyException("Invalid Auth Type Declared, see inner exception for details.",
+						new MissingMethodException("METHOD is X'FF' No Client requested methods are acceptable. Closing the connection."));
+
+				default:
+					_socketStream.Close();
+					throw new SocksProxyException("Invalid Auth Type Declared, see inner exception for details.",
+						new ArgumentOutOfRangeException());
+			}
+		}
+
+		private byte[] GetConnectRequest()
+		{
+			// Once the method-dependent sub negotiation has completed,
+			// the client sends the request details.
+			bool issHostname = !IPAddress.TryParse(_destinationHost, out var ip);
+
+			var dstAddress = issHostname
+				? Encoding.ASCII.GetBytes(_destinationHost)
+				: ip.GetAddressBytes();
+
+			var requestBuffer = issHostname
+				? new byte[7 + dstAddress.Length]
+				: new byte[6 + dstAddress.Length];
+
+			requestBuffer[0] = (byte)SocksVersion.Five;
+			requestBuffer[1] = (byte)SocksRequestCommand.Connect;
+
+			if (issHostname)
+			{
+				requestBuffer[3] = (byte)SocksRequestAddressType.FQDN;
+				requestBuffer[4] = (byte)dstAddress.Length;
+
+				for (var i = 0; i < dstAddress.Length; i++)
+				{
+					requestBuffer[5 + i] = dstAddress[i];
+				}
+
+				requestBuffer[5 + dstAddress.Length] = (byte)(_destinationPort >> 8);
+				requestBuffer[6 + dstAddress.Length] = (byte)_destinationPort;
+			}
+			else
+			{
+				requestBuffer[3] = dstAddress.Length == 4
+					? (byte)SocksRequestAddressType.IPv4
+					: (byte)SocksRequestAddressType.IPv6;
+
+				for (var i = 0; i < dstAddress.Length; i++)
+				{
+					requestBuffer[4 + i] = dstAddress[i];
+				}
+
+				requestBuffer[4 + dstAddress.Length] = (byte)(_destinationPort >> 8);
+				requestBuffer[5 + dstAddress.Length] = (byte)_destinationPort;
+			}
+
+			return requestBuffer;
+		}
+
+#if ASYNC
+		public async Task NegotiateAsync()
+		{
+			// The client connects to the server,
+			// and sends a version identifier / method selection message.
+			var methodsBuffer = new byte[]
+			{
+				(byte)SocksVersion.Five, // VER
+				0x01, // NMETHODS
+				(byte)SocksAuthType.NoAuthRequired // Methods
+			};
+
+			await _socketStream.WriteAsync(methodsBuffer, 0, methodsBuffer.Length);
+
+			// The server selects from one of the methods given in METHODS,
+			// and sends a METHOD selection message:
+			var receivedBytes = await _socketStream.ReadAsync(_buffer, 0, 2);
+			if (receivedBytes != 2)
+			{
+				_socketStream.Close();
+				throw new SocksProxyException($"Negotiation Response had an invalid length of {receivedBytes}");
+			}
+
+			_authType = (SocksAuthType)_buffer[1];
+		}
+
+		public Task AuthenticateAsync()
+		{
+			AuthenticateInternal();
+			return Task.FromResult(0);
+		}
+
+		public async Task ConnectAsync()
+		{
+			var requestBuffer = GetConnectRequest();
+			await _socketStream.WriteAsync(requestBuffer, 0, requestBuffer.Length);
+
+			// The server evaluates the request, and returns a reply.
+			// - First we read VER, REP, RSV & ATYP
+			var received = await _socketStream.ReadAsync(_buffer, 0, 4);
+			if (received != 4)
+			{
+				if (received >= 2)
+				{
+					_reply = (SocksReply)_buffer[1];
+					HandleProxyCommandError(_reply);
+				}
+
+				_socketStream.Close();
+				throw new SocksProxyException($"Connect Reply has Invalid Length {received}. Expecting 4.");
+			}
+
+			// - Now we check if the reply was positive.
+			_reply = (SocksReply)_buffer[1];
+
+			if (_reply != SocksReply.Succeeded)
+			{
+				HandleProxyCommandError(_reply);
+			}
+
+			// - Consume rest of the SOCKS5 protocol so the next read will give application data.
+			var atyp = (SocksRequestAddressType)_buffer[3];
+			int atypSize;
+			int read;
+
+			switch (atyp)
+			{
+				case SocksRequestAddressType.IPv4:
+					atypSize = 6;
+					read = await _socketStream.ReadAsync(_buffer, 0, atypSize);
+					break;
+				case SocksRequestAddressType.IPv6:
+					atypSize = 18;
+					read = await _socketStream.ReadAsync(_buffer, 0, atypSize);
+					break;
+				case SocksRequestAddressType.FQDN:
+					atypSize = 1;
+					await _socketStream.ReadAsync(_buffer, 0, atypSize);
+
+					atypSize = _buffer[0] + 2;
+					read = await _socketStream.ReadAsync(_buffer, 0, atypSize);
+					break;
+				default:
+					_socketStream.Close();
+					throw new SocksProxyException("Unknown Socks Request Address Type", new ArgumentOutOfRangeException());
+			}
+
+			if (read != atypSize)
+			{
+				_socketStream.Close();
+				throw new SocksProxyException($"Unexpected Response size from Request Type Data. Expected {atypSize} received {read}");
+			}
+		}
+#endif
+		private void HandleProxyCommandError(SocksReply replyCode)
+		{
+			string proxyErrorText;
+			switch (replyCode)
+			{
+				case SocksReply.GeneralSOCKSServerFailure:
+					proxyErrorText = "a general socks destination failure occurred";
+					break;
+				case SocksReply.NotAllowedByRuleset:
+					proxyErrorText = "the connection is not allowed by proxy destination rule set";
+					break;
+				case SocksReply.NetworkUnreachable:
+					proxyErrorText = "the network was unreachable";
+					break;
+				case SocksReply.HostUnreachable:
+					proxyErrorText = "the host was unreachable";
+					break;
+				case SocksReply.ConnectionRefused:
+					proxyErrorText = "the connection was refused by the remote network";
+					break;
+				case SocksReply.TTLExpired:
+					proxyErrorText = "the time to live (TTL) has expired";
+					break;
+				case SocksReply.CommandNotSupported:
+					proxyErrorText = "the command issued by the proxy client is not supported by the proxy destination";
+					break;
+				case SocksReply.AddressTypeNotSupported:
+					proxyErrorText = "the address type specified is not supported";
+					break;
+				default:
+					proxyErrorText = $"an unknown SOCKS reply with the code value '{replyCode}' was received";
+					break;
+			}
+
+			_socketStream.Close();
+			throw new SocksProxyException($"Proxy error: {proxyErrorText} for destination host {_destinationHost} port number {_destinationPort}.");
+		}
+	}
+}

--- a/FluentFTP/Proxy/Socks/SocksProxyException.cs
+++ b/FluentFTP/Proxy/Socks/SocksProxyException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace FluentFTP.Proxy.Socks
+{
+	public class SocksProxyException : Exception
+	{
+		public SocksProxyException()
+		{
+		}
+
+		public SocksProxyException(string message)
+			: base(message)
+		{
+		}
+
+		public SocksProxyException(string message, Exception inner)
+			: base(message, inner)
+		{
+		}
+	}
+}


### PR DESCRIPTION
#82 Adding unauthenticated SOCKS5 proxy support.

Changes include adding an implementation of a SOCKS proxy following the RFC : https://datatracker.ietf.org/doc/html/rfc1928

Tested against VSFTPD using Dante as a SOCKS proxy, both locally and against an Azure installation, where the FTP was running on a local address.

Commands to spin up a local copy for testing:

`docker run -d --restart=always -p 9020:20 -p 9021:21 -p 9100-9110:9100-9110 -e FTP_USER=ftp -e FTP_PASS=ftp -e PASV_ADDRESS=172.18.144.1 -e PASV_MIN_PORT=9100 -e PASV_MAX_PORT=9110 -v /data/ftp:/home/vsftpd fauria/vsftpd`

`docker run -d -p 1080:1080 wernight/dante`

Example usage can be found in the test project.
