### PR TITLE
Correct .FullName when path is "" in CalculateFullFtpPath (RemotePaths.cs)

### DIFF
--- a/FluentFTP/Helpers/RemotePaths.cs
+++ b/FluentFTP/Helpers/RemotePaths.cs
@@ -168,7 +168,6 @@ namespace FluentFTP.Helpers {
 				return;
 			}
 
-
 			// ONLY IF DIR PATH PROVIDED
 
 			// if this is a vax/openvms file listing
@@ -182,6 +181,11 @@ namespace FluentFTP.Helpers {
 				// remove globbing/wildcard from path
 				if (path.GetFtpFileName().Contains("*")) {
 					path = path.GetFtpDirectoryName();
+				}
+
+				if (path.Length == 0)
+				{
+					path = client.GetWorkingDirectory();
 				}
 
 				if (item.Name != null) {
@@ -199,7 +203,6 @@ namespace FluentFTP.Helpers {
 					}
 				}
 
-
 				// if a link target is set and it doesn't include an absolute path
 				// then try to resolve it.
 				if (item.LinkTarget != null && !item.LinkTarget.StartsWith("/")) {
@@ -212,7 +215,5 @@ namespace FluentFTP.Helpers {
 				}
 			}
 		}
-
-
 	}
 }


### PR DESCRIPTION
### **Do not merge** - the final PR is #788

This documentation PR (and the next one) are about fixing `.FullName` on a `GetListing(...)` output. 

As a first step to have `.FullName` be set correctly on IBM z/OS, where quite often `GetListing("", FtpListOption.NoPath)` is the preferred method to use:

For a unix system (**but also in IBM z/OS**), doing a `GetListing(""....)` with  `FtpListOption.NoPath)` will result in an incorrect `.FullName`, although you will get listing entries depending on the CurrentWorkingDirectory.

So this small change will correct that for **all unix systems** (old not serious bug) but also for **IBM z/OS** (which caused this bug to be discovered).

The fix **only** affects `.FullName` for unix style filesystems. It **is not** related to only IBM z/OS. But testing FluentFTP for IBM z/OS showed up the need to address this.

Note: Why is this _not serious_ for **normal unix** systems: Who on earth would do a `GetListing("")` with an empty path? Well, only someone who **needs** to do `FtpListOption.NoPath)` and a preceeding `SetWorkingDirectory()` for some special reason, And by using this, he sadly must accept that `.FullName` is wrong and then do some coding of his own to correct that. But IBM z/OS Users do this quite often, even if they might not need that in the Unix realm, so...


