### PR TITLE
isVMS is never set. Delete? Or query it the right way?

### DIFF
--- a/FluentFTP/Helpers/FtpListParser.cs
+++ b/FluentFTP/Helpers/FtpListParser.cs
@@ -163,7 +163,7 @@ namespace FluentFTP.Helpers {
 				}
 
 				// calc absolute file paths
-				result.CalculateFullFtpPath(client, path, false);
+				result.CalculateFullFtpPath(client, path);
 			}
 
 			return result;

--- a/FluentFTP/Helpers/RemotePaths.cs
+++ b/FluentFTP/Helpers/RemotePaths.cs
@@ -156,7 +156,7 @@ namespace FluentFTP.Helpers {
 		/// <summary>
 		/// Get the full path of a given FTP Listing entry
 		/// </summary>
-		public static void CalculateFullFtpPath(this FtpListItem item, FtpClient client, string path, bool isVMS) {
+		public static void CalculateFullFtpPath(this FtpListItem item, FtpClient client, string path) {
 			// EXIT IF NO DIR PATH PROVIDED
 			if (path == null) {
 				// check if the path is absolute
@@ -173,7 +173,11 @@ namespace FluentFTP.Helpers {
 
 			// if this is a vax/openvms file listing
 			// there are no slashes in the path name
-			if (isVMS) {
+			if (client.ServerType == FtpServer.OpenVMS &&
+			    client.ServerOS == FtpOperatingSystem.VMS)
+			{
+				// if this is a vax/openvms file listing
+				// there are no slashes in the path name
 				item.FullName = path + item.Name;
 			}
 			else {


### PR DESCRIPTION
### **Do not merge** - the final PR is #788

This is the **second** documentation PR for `.FullName` fixup. 

The code checks for `isVMS`. 

If you follow the def and the usage, it is never set.

I understand how this might have happened in modifying the code and believe, instead of removing it, one should use the check for the `ServerOS` and so on.

