### PR TITLE
CalculateFullFtpPath final Code + Wiki update

### DIFF
--- a/FluentFTP/Helpers/RemotePaths.cs
+++ b/FluentFTP/Helpers/RemotePaths.cs
@@ -156,11 +156,14 @@ namespace FluentFTP.Helpers {
 		/// <summary>
 		/// Get the full path of a given FTP Listing entry
 		/// </summary>
-		public static void CalculateFullFtpPath(this FtpListItem item, FtpClient client, string path, bool isVMS) {
+		public static void CalculateFullFtpPath(this FtpListItem item, FtpClient client, string path)
+		{
 			// EXIT IF NO DIR PATH PROVIDED
-			if (path == null) {
+			if (path == null)
+			{
 				// check if the path is absolute
-				if (IsAbsolutePath(item.Name)) {
+				if (IsAbsolutePath(item.Name))
+				{
 					item.FullName = item.Name;
 					item.Name = item.Name.GetFtpFileName();
 				}
@@ -168,51 +171,125 @@ namespace FluentFTP.Helpers {
 				return;
 			}
 
-
 			// ONLY IF DIR PATH PROVIDED
+			if (client.ServerType == FtpServer.IBMzOSFTP &&
+				client.ServerOS == FtpOperatingSystem.IBMzOS &&
+				client.zOSListingRealm != FtpZOSListRealm.Unix)
+			{
+				// The user might be using GetListing("", FtpListOption.NoPath)
+				// or he might be using    GetListing("not_fully_qualified_zOS path")
+				// or he might be using    GetListing("'fully_qualified_zOS path'") (note the single quotes)
 
-			// if this is a vax/openvms file listing
-			// there are no slashes in the path name
-			if (isVMS) {
+				// The following examples in the comments assume a current working
+				// directory of 'GEEK.'.
+
+				// If it is not a FtpZOSListRealm.Dataset, it must be FtpZOSListRealm.Member*
+
+				// Is caller using FtpListOption.NoPath and CWD to the right place?
+				if (path.Length == 0)
+				{
+					if (client.zOSListingRealm == FtpZOSListRealm.Dataset)
+					{
+						// Path: ""
+						// Fullname: 'GEEK.PROJECTS.LOADLIB'
+						item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + item.Name + "\'";
+					}
+					else
+					{
+						// Path: ""
+						// Fullname: 'GEEK.PROJECTS.LOADLIB(MYPROG)'
+						item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + "(" + item.Name + ")\'";
+					}
+				}
+				// Caller is not using FtpListOption.NoPath, so the fullname can be built
+				// depending on the listing realm
+				else if (path[0] == '\'')
+				{
+					if (client.zOSListingRealm == FtpZOSListRealm.Dataset)
+					{
+						// Path: "'GEEK.PROJECTS.LOADLIB'"
+						// Fullname: 'GEEK.PROJECTS.LOADLIB'
+						item.FullName = item.Name;
+					}
+					else
+					{
+						// Path: "'GEEK.PROJECTS.LOADLIB(*)'"
+						// Fullname: 'GEEK.PROJECTS.LOADLIB(MYPROG)'
+						item.FullName = path.Substring(0, path.Length - 4) + "(" + item.Name + ")\'";
+					}
+				}
+				else
+				{
+					if (client.zOSListingRealm == FtpZOSListRealm.Dataset)
+					{
+						// Path: "PROJECTS.LOADLIB"
+						// Fullname: 'GEEK.PROJECTS.LOADLIB'
+						item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + item.Name + '\'';
+					}
+					else
+					{
+						// Path: "PROJECTS.LOADLIB(*)"
+						// Fullname: 'GEEK.PROJECTS.LOADLIB(MYPROG)'
+						item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + path.Substring(0, path.Length - 3) + "(" + item.Name + ")\'";
+					}
+				}
+				return;
+			}
+			else if (client.ServerType == FtpServer.OpenVMS &&
+					 client.ServerOS == FtpOperatingSystem.VMS)
+			{
+				// if this is a vax/openvms file listing
+				// there are no slashes in the path name
 				item.FullName = path + item.Name;
 			}
-			else {
+			else
+			{
 				//this.client.LogStatus(item.Name);
 
 				// remove globbing/wildcard from path
-				if (path.GetFtpFileName().Contains("*")) {
+				if (path.GetFtpFileName().Contains("*"))
+				{
 					path = path.GetFtpDirectoryName();
 				}
 
-				if (item.Name != null) {
+				if (path.Length == 0)
+				{
+					path = client.GetWorkingDirectory();
+				}
+
+				if (item.Name != null)
+				{
 					// absolute path? then ignore the path input to this method.
-					if (IsAbsolutePath(item.Name)) {
+					if (IsAbsolutePath(item.Name))
+					{
 						item.FullName = item.Name;
 						item.Name = item.Name.GetFtpFileName();
 					}
-					else if (path != null) {
+					else if (path != null)
+					{
 						item.FullName = path.GetFtpPath(item.Name); //.GetFtpPathWithoutGlob();
 					}
-					else {
+					else
+					{
 						client.LogStatus(FtpTraceLevel.Warn, "Couldn't determine the full path of this object: " +
 															 Environment.NewLine + item.ToString());
 					}
 				}
 
-
 				// if a link target is set and it doesn't include an absolute path
 				// then try to resolve it.
-				if (item.LinkTarget != null && !item.LinkTarget.StartsWith("/")) {
-					if (item.LinkTarget.StartsWith("./")) {
+				if (item.LinkTarget != null && !item.LinkTarget.StartsWith("/"))
+				{
+					if (item.LinkTarget.StartsWith("./"))
+					{
 						item.LinkTarget = path.GetFtpPath(item.LinkTarget.Remove(0, 2)).Trim();
 					}
-					else {
+					else
+					{
 						item.LinkTarget = path.GetFtpPath(item.LinkTarget).Trim();
 					}
 				}
 			}
 		}
-
-
 	}
 }


### PR DESCRIPTION
### **Consolidates the IBM z/OS fixes for `.FullName` with the preparatory (don't merge) PR's #786, #787 + Wiki change (see comment below)**

Together with the (small) code changes for #786 and #787, there is a quite large block of code needed for IBM z/OS, to calculate `.FullName` in `GetListing(....)` entries for the different scenarios of using `GetListing(...)` with or without `FtpListOption.NoPath` in the different `zOSListingRealm`s.

So this PR contains the needed code for the **whole** fix. The previous PR's (#786, #787) are solely to explain the "collateral" damage when trying to  fixup `CalculateFullFtpPath()`.

It contains the smaller amounts of code for #786, #787 **plus** this large block of IBM z/OS code, which 
 looks like this:
```
			if (client.ServerType == FtpServer.IBMzOSFTP &&
				client.ServerOS == FtpOperatingSystem.IBMzOS &&
				client.zOSListingRealm != FtpZOSListRealm.Unix)
			{
				// The user might be using GetListing("", FtpListOption.NoPath)
				// or he might be using    GetListing("not_fully_qualified_zOS path")
				// or he might be using    GetListing("'fully_qualified_zOS path'") (note the single quotes)

				// The following examples in the comments assume a current working
				// directory of 'GEEK.'.

				// If it is not a FtpZOSListRealm.Dataset, it must be FtpZOSListRealm.Member*

				// Is caller using FtpListOption.NoPath and CWD to the right place?
				if (path.Length == 0)
				{
					if (client.zOSListingRealm == FtpZOSListRealm.Dataset)
					{
						// Path: ""
						// Fullname: 'GEEK.PROJECTS.LOADLIB'
						item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + item.Name + "\'";
					}
					else
					{
						// Path: ""
						// Fullname: 'GEEK.PROJECTS.LOADLIB(MYPROG)'
						item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + "(" + item.Name + ")\'";
					}
				}
				// Caller is not using FtpListOption.NoPath, so the fullname can be built
				// depending on the listing realm
				else if (path[0] == '\'')
				{
					if (client.zOSListingRealm == FtpZOSListRealm.Dataset)
					{
						// Path: "'GEEK.PROJECTS.LOADLIB'"
						// Fullname: 'GEEK.PROJECTS.LOADLIB'
						item.FullName = item.Name;
					}
					else
					{
						// Path: "'GEEK.PROJECTS.LOADLIB(*)'"
						// Fullname: 'GEEK.PROJECTS.LOADLIB(MYPROG)'
						item.FullName = path.Substring(0, path.Length - 4) + "(" + item.Name + ")\'";
					}
				}
				else
				{
					if (client.zOSListingRealm == FtpZOSListRealm.Dataset)
					{
						// Path: "PROJECTS.LOADLIB"
						// Fullname: 'GEEK.PROJECTS.LOADLIB'
						item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + item.Name + '\'';
					}
					else
					{
						// Path: "PROJECTS.LOADLIB(*)"
						// Fullname: 'GEEK.PROJECTS.LOADLIB(MYPROG)'
						item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + path.Substring(0, path.Length - 3) + "(" + item.Name + ")\'";
					}
				}
				return;
			}
```

There are 3 scenarios to check with a check for a PDS in each of them.