### PR TITLE
Fix Regression #751 due to IBM z/OS changes

### DIFF
--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -263,7 +263,7 @@ namespace FluentFTP {
 			// Note: "TEST.TST" is a "path" that does not start with a slash
 			// This could be a unix file on z/OS OR a classic CWD relative dataset
 			// Both of these work with the z/OS FTP server LIST command
-			if (path.StartsWith("/") || ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
+			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path == null || path.StartsWith("/"))
 			{
 				// calc the absolute filepath
 				path = GetAbsolutePath(path);
@@ -638,7 +638,7 @@ namespace FluentFTP {
 			// Note: "TEST.TST" is a "path" that does not start with a slash
 			// This could be a unix file on z/OS OR a classic CWD relative dataset
 			// Both of these work with the z/OS FTP server LIST command
-			if (path.StartsWith("/") || ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
+			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path == null || path.StartsWith("/"))
 			{
 				// calc the absolute filepath
 				path = await GetAbsolutePathAsync(path, token);
@@ -1171,7 +1171,7 @@ namespace FluentFTP {
 
 			var listing = new List<string>();
 
-			if (path.StartsWith("/") || ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
+			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path == null || path.StartsWith("/"))
 			{
 				// calc path to request
 				path = GetAbsolutePath(path);
@@ -1283,7 +1283,7 @@ namespace FluentFTP {
 
 			var listing = new List<string>();
 
-			if (path.StartsWith("/") || ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
+			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path == null || path.StartsWith("/"))
 			{
 				// calc path to request
 				path = await GetAbsolutePathAsync(path, token);


### PR DESCRIPTION
Recently updated issue #751 describes the case where `path` can be `null`, thus causing an exception to be thrown.

So, rearranging the OR clause and adding a `null` check to fix this.