### PR TITLE
z/OS Parser: Big files, do not want negative file sizes

### DIFF
--- a/FluentFTP/Helpers/Parsers/FtpIBMzOSParser.cs
+++ b/FluentFTP/Helpers/Parsers/FtpIBMzOSParser.cs
@@ -116,7 +116,7 @@ namespace FluentFTP.Helpers.Parsers
 						lastModifiedStr += " 00:00";
 					}
 					var lastModified = ParseDateTime(client, lastModifiedStr);
-					var size = int.Parse(used) * 56664; // 3390 dev bytes per track
+					var size = long.Parse(used) * 56664; // 3390 dev bytes per track
 					var file = new FtpListItem(record, dsname, size, isDir, ref lastModified);
 					return file;
 				}


### PR DESCRIPTION
Discovered this one listing files under "SYS1.".

It is very minor, has no huge consequences. But for the sake of getting it right... very big files will overflow on the size calculation resulting in negative file sizes. We are talking about `ntracks * 56664` overflowing `int`. But, can happen, as I saw. 