### PR TITLE
Getting some infinite transfer speeds. Put the division exception handling into the catch phrase

### DIFF
--- a/FluentFTP/Model/FtpProgress.cs
+++ b/FluentFTP/Model/FtpProgress.cs
@@ -102,8 +102,8 @@ namespace FluentFTP {
 
 			// default values to send
 			double progressValue = -1;
-			double transferSpeed = 0;
-			var estimatedRemaingTime = TimeSpan.Zero;
+			double transferSpeed;
+			var estimatedRemainingTime = TimeSpan.Zero;
 
 			// catch any divide-by-zero errors
 			try {
@@ -119,21 +119,17 @@ namespace FluentFTP {
 					progressValue = (double)position / (double)fileSize * 100;
 
 					//calculate remaining time			
-					estimatedRemaingTime = TimeSpan.FromSeconds((fileSize - position) / transferSpeed);
+					estimatedRemainingTime = TimeSpan.FromSeconds((fileSize - position) / transferSpeed);
 				}
 			}
-			catch (Exception) {
+			catch (Exception)
+			{
+				// Can only be a division that went wrong (div by zero or overflow)
+				transferSpeed = double.MaxValue;
+				estimatedRemainingTime = TimeSpan.Zero;
 			}
 
-			// suppress invalid values and send -1 instead
-			if (double.IsNaN(progressValue) && double.IsInfinity(progressValue)) {
-				progressValue = -1;
-			}
-			if (double.IsNaN(transferSpeed) && double.IsInfinity(transferSpeed)) {
-				transferSpeed = 0;
-			}
-
-			var p = new FtpProgress(progressValue, position, transferSpeed, estimatedRemaingTime, localPath, remotePath, metaProgress);
+			var p = new FtpProgress(progressValue, position, transferSpeed, estimatedRemainingTime, localPath, remotePath, metaProgress);
 			return p;
 		}
 


### PR DESCRIPTION
I was getting some sporadic errors in my download progress delegate.

Thus, the first thing was to use (in my own progress delegate code):

`double.IsInfinity(p.TransferSpeed) ? long.MaxValue : (long)p.TransferSpeed)`

Then I had a look at `FtpProgress.cs` and saw:

```
			if (double.IsNaN(transferSpeed) && double.IsInfinity(transferSpeed)) {
				transferSpeed = 0;
			}
```

Trouble is, I was getting `PositiveInfinity`, once in a while.

Should it not be:

```
			if (double.IsNaN(transferSpeed) || double.IsInfinity(transferSpeed)) {
				transferSpeed = 0;
			}
```

I also believe that `progressValue` is safe because of `if (fileSize > 0)`.

Regardless, my suggestion would be this PR, please look at it and decide.

I also corrected the spelling mistake: `estimatedRemaingTime`
