### PR TITLE
Getting some infinite transferSpeeds on progress delegate

### DIFF
--- a/FluentFTP/Model/FtpProgress.cs
+++ b/FluentFTP/Model/FtpProgress.cs
@@ -102,40 +102,36 @@ namespace FluentFTP {
 
 			// default values to send
 			double progressValue = -1;
-			double transferSpeed = 0;
-			var estimatedRemaingTime = TimeSpan.Zero;
+			double transferSpeed;
+			var estimatedRemainingTime = TimeSpan.Zero;
 
 			// catch any divide-by-zero errors
 			try {
-
 				// calculate raw transferSpeed (bytes per second)
 				transferSpeed = bytesProcessed / elapsedtime.TotalSeconds;
-
-				// If fileSize < 0 the below computations make no sense 
-				if (fileSize > 0) {
-
-					// calculate % based on file length vs file offset
-					// send a value between 0-100 indicating percentage complete
-					progressValue = (double)position / (double)fileSize * 100;
-
-					//calculate remaining time			
-					estimatedRemaingTime = TimeSpan.FromSeconds((fileSize - position) / transferSpeed);
-				}
 			}
 			catch (Exception) {
+				transferSpeed = double.MaxValue;
 			}
 
-			// suppress invalid values and send -1 instead
-			if (double.IsNaN(progressValue) && double.IsInfinity(progressValue)) {
-				progressValue = -1;
-			}
-			if (double.IsNaN(transferSpeed) && double.IsInfinity(transferSpeed)) {
-				transferSpeed = 0;
+			// If fileSize < 0 the below computations make no sense 
+			if (fileSize > 0) {
+				// calculate % based on file length vs file offset
+				// send a value between 0-100 indicating percentage complete
+				progressValue = (double)position / fileSize * 100;
+
+				// catch any divide-by-zero errors
+				try {
+					//calculate remaining time			
+					estimatedRemainingTime = TimeSpan.FromSeconds((fileSize - position) / transferSpeed);
+				}
+				catch (Exception) {
+					estimatedRemainingTime = TimeSpan.MaxValue;
+				}
 			}
 
-			var p = new FtpProgress(progressValue, position, transferSpeed, estimatedRemaingTime, localPath, remotePath, metaProgress);
+			var p = new FtpProgress(progressValue, position, transferSpeed, estimatedRemainingTime, localPath, remotePath, metaProgress);
 			return p;
 		}
-
 	}
 }


### PR DESCRIPTION
I was getting some sporadic errors (value is infinity, so no assign to `long` possible) in my download progress delegate.

Thus, the first thing was to use (in my own progress delegate code):

`double.IsInfinity(p.TransferSpeed) ? long.MaxValue : (long)p.TransferSpeed)`

Then I had a look at `FtpProgress.cs` and saw:

```
			if (double.IsNaN(transferSpeed) && double.IsInfinity(transferSpeed)) {
				transferSpeed = 0;
			}
```

Trouble is, I was getting `PositiveInfinity`, once in a while.

Should it not be:

```
			if (double.IsNaN(transferSpeed) || double.IsInfinity(transferSpeed)) {
				transferSpeed = 0;
			}
```

But I decided to make the checks more specific to the possible division by zero errors possible in the try section.

I also believe that `progressValue` is safe because of `if (fileSize > 0)`.

I also corrected the spelling mistake: `estimatedRemaingTime`

Please look the suggest code and review.