### PR TITLE
z/OS: Consolidation and some further (small) changes

### DIFF
--- a/FluentFTP/Client/FtpClient_FileDownload.cs
+++ b/FluentFTP/Client/FtpClient_FileDownload.cs
@@ -678,7 +678,7 @@ namespace FluentFTP {
 
 				// if the server has not provided a length for this file
 				// we read until EOF instead of reading a specific number of bytes
-				var readToEnd = fileLen <= 0;
+				var readToEnd = fileLen <= 0 || (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS);
 
 				const int rateControlResolution = 100;
 				var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;
@@ -911,7 +911,7 @@ namespace FluentFTP {
 
 				// if the server has not provided a length for this file
 				// we read until EOF instead of reading a specific number of bytes
-				var readToEnd = fileLen <= 0;
+				var readToEnd = fileLen <= 0 || (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS);
 
 				const int rateControlResolution = 100;
 				var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;

--- a/FluentFTP/Client/FtpClient_FileProperties.cs
+++ b/FluentFTP/Client/FtpClient_FileProperties.cs
@@ -179,6 +179,10 @@ namespace FluentFTP {
 
 			LogFunc(nameof(GetFileSize), new object[] { path });
 
+			if (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS)	{
+				return GetZOSFileSize(path);
+			}
+
 			if (!HasFeature(FtpCapability.SIZE)) {
 				return defaultValue;
 			}
@@ -247,6 +251,10 @@ namespace FluentFTP {
 			path = path.GetFtpPath();
 
 			LogFunc(nameof(GetFileSizeAsync), new object[] { path, defaultValue });
+
+			if (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS)	{
+				return await GetZOSFileSizeAsync(path, token);
+			}
 
 			if (!HasFeature(FtpCapability.SIZE)) {
 				return defaultValue;

--- a/FluentFTP/Client/FtpClient_IBMzOS.cs
+++ b/FluentFTP/Client/FtpClient_IBMzOS.cs
@@ -141,25 +141,25 @@ namespace FluentFTP {
 		/// <summary>
 		/// Get z/OS file size
 		/// </summary>
+		/// <param name="path">The full path of th file whose size you want to retrieve</param>
+		/// <remarks>
+		/// Make sure you are in the right realm (z/OS or HFS) before doing this
+		/// </remarks>
 		/// <returns>The size of the file</returns>
-		public long GetZOSFileSize(string path) {
-			string oldPath = "";
-			string cwdPath = path;
-			string[] preFix = path.Split('(');
-			if (preFix.Length > 1) // PDS Member
-			{
-				cwdPath = preFix[0] + '\'';
-				oldPath = GetWorkingDirectory();
-				SetWorkingDirectory(cwdPath);
-			}
+		public long GetZOSFileSize(string path)
+		{
+			// prevent automatic parser detection switching to unix on HFS paths
 			ListingParser = FtpParser.IBMzOS;
+
 			FtpListItem[] entries = GetListing(path);
+
+			// no entries or more than one: path is NOT for a single dataset or file
 			if (entries.Length != 1) return -1;
+
+			// if the path is for a SINGLE dataset or file, there will be only one entry
 			FtpListItem entry = entries[0];
 
-			if (preFix.Length > 1) {
-				SetWorkingDirectory(oldPath);
-			}
+			// z/OS list parser will have determined that size
 			return entry.Size;
 		}
 
@@ -167,34 +167,26 @@ namespace FluentFTP {
 		/// <summary>
 		/// Get z/OS file size
 		/// </summary>
+		/// <param name="path">The full path of th file whose size you want to retrieve</param>
+		/// <remarks>
+		/// Make sure you are in the right realm (z/OS or HFS) before doing this
+		/// </remarks>
 		/// <returns>The size of the file</returns>
 		public async Task<long> GetZOSFileSizeAsync(string path, CancellationToken token = default(CancellationToken))
 		{
-			string oldPath = "";     
-			string cwdPath = path;
-			string[] preFix = path.Split('(');
-			if (preFix.Length > 1) // PDS Member
-			{
-				cwdPath = preFix[0] + '\'';
-				oldPath = await GetWorkingDirectoryAsync(token);
-				await SetWorkingDirectoryAsync(cwdPath, token);
-			}
+			// prevent automatic parser detection switching to unix on HFS paths
 			ListingParser = FtpParser.IBMzOS;
+
 			FtpListItem[] entries = await GetListingAsync(path, token);
+            // no entries or more than one: path is NOT for a single dataset or file
+
 			if (entries.Length != 1) return -1;
+			// if the path is for a SINGLE dataset or file, there will be only one entry
+
 			FtpListItem entry = entries[0];
+			// z/OS list parser will have determined that size
 
-			if (preFix.Length > 1)
-			{
-				await SetWorkingDirectoryAsync(oldPath, token);
-			}
 			return entry.Size;
-
 		}
-#endif
-
-
-		#endregion
-
 	}
 }

--- a/FluentFTP/Model/FtpProgress.cs
+++ b/FluentFTP/Model/FtpProgress.cs
@@ -126,10 +126,10 @@ namespace FluentFTP {
 			}
 
 			// suppress invalid values and send -1 instead
-			if (double.IsNaN(progressValue) && double.IsInfinity(progressValue)) {
+			if (double.IsNaN(progressValue) || double.IsInfinity(progressValue)) {
 				progressValue = -1;
 			}
-			if (double.IsNaN(transferSpeed) && double.IsInfinity(transferSpeed)) {
+			if (double.IsNaN(transferSpeed) || double.IsInfinity(transferSpeed)) {
 				transferSpeed = 0;
 			}
 


### PR DESCRIPTION
Thanks to the previous merges, here are (more or less) the last changes:

----
`FtpClient_FileProperties.cs`
If a z/OS server reports "SIZE" capability, things go wrong in case of z/OS realm datasets. Because other than in the HFS realm, no size is available. On the other hand, if it does not report the "SIZE" capability, we can **still** obtain a size due to the previous changes we made. So let's do it ourselves... ==> ignore SIZE capability, even if the z/OS FTP server is thus configured.

...but this then means:

`FtpClient_FileDownload.cs`
Since we have a size now (however we acquired it) on z/OS files (whichever realm), but this size is **not** accurate (see wiki), we need to `readToEnd` = `true` ==> this means **act** like `fileLen` is zero.

----
`FtpClient_IBMzOS.cs`
Since the last change, the z/OS parser himself knows how to handle setting the path for a XDSS command on a partitioned dataset (by removing the parens and their content). So we can really simplify this API function. The `GetZOSFileSize()` API function could even be removed and its code moved into `GetFileSize()` and the wiki updated. Please indicate if you would prefer that. Right now, the `GetFileSize()` API function will internally call `GetZOSFileSize()` on zOS servers, making the code look cleaner. The `ListingParser = FtpParser.IBMzOS` prevents automatic parser detection switching to unix on z/OS HFS files. 
```
			FtpListItem[] entries = GetListing(path);
			if (entries.Length != 1) return -1;
			FtpListItem entry = entries[0];
```
This snippet "misuses" `GetListing(`path)` to provide a single entry and to get the size from that. 

----
`FtpProgress.cs`
`Nan` and `Infinity`: A (double) value can be **either** `NaN` **or** `PositiveInfinity/NegativeInfinity` but not both at the same time. I also would have at first thought that an infinity representation should also be flagged as "not a number", but duh... [see this](https://docs.microsoft.com/en-us/dotnet/api/system.double.nan?redirectedfrom=MSDN&view=net-6.0)
I think the logic of this progress function can be simplified/improved. I will see if I find time...
