### PR TITLE
Streams not disposed in case of an IOException

### DIFF
--- a/FluentFTP/Client/FtpClient_FileDownload.cs
+++ b/FluentFTP/Client/FtpClient_FileDownload.cs
@@ -830,10 +830,6 @@ namespace FluentFTP {
 
 				return true;
 			}
-			catch (IOException ex1) {
-				LogStatus(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
-				return false;
-			}
 			catch (Exception ex1) {
 
 				// close stream before throwing error
@@ -851,6 +847,11 @@ namespace FluentFTP {
 					}
 					catch (Exception) {
 					}
+				}
+
+				if (ex1 is IOException) {
+					LogStatus(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
+					return false;
 				}
 
 				// absorb "file does not exist" exceptions and simply return false
@@ -1064,10 +1065,6 @@ namespace FluentFTP {
 
 				return true;
 			}
-			catch (IOException ex1) {
-				LogStatus(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
-				return false;
-			}
 			catch (Exception ex1) {
 
 				// close stream before throwing error
@@ -1085,6 +1082,11 @@ namespace FluentFTP {
 					}
 					catch (Exception) {
 					}
+				}
+
+				if (ex1 is IOException) {
+					LogStatus(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
+					return false;
 				}
 
 				if (ex1 is OperationCanceledException) {

--- a/FluentFTP/Client/FtpClient_FileUpload.cs
+++ b/FluentFTP/Client/FtpClient_FileUpload.cs
@@ -923,10 +923,6 @@ namespace FluentFTP {
 
 				return FtpStatus.Success;
 			}
-			catch (IOException ex1) {
-				LogStatus(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
-				return FtpStatus.Failed;
-			}
 			catch (Exception ex1) {
 				// close stream before throwing error
 				try {
@@ -935,6 +931,11 @@ namespace FluentFTP {
 					}
 				}
 				catch (Exception) {
+				}
+
+				if (ex1 is IOException) {
+					LogStatus(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
+					return FtpStatus.Failed;
 				}
 
 				// catch errors during upload, 
@@ -1214,10 +1215,6 @@ namespace FluentFTP {
 
 				return FtpStatus.Success;
 			}
-			catch (IOException ex1) {
-				LogStatus(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
-				return FtpStatus.Failed;
-			}
 			catch (Exception ex1) {
 				// close stream before throwing error
 				try {
@@ -1226,6 +1223,11 @@ namespace FluentFTP {
 					}
 				}
 				catch (Exception) {
+				}
+				
+				if (ex1 is IOException ) {
+					LogStatus(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
+					return FtpStatus.Failed;
 				}
 
 				if (ex1 is OperationCanceledException) {


### PR DESCRIPTION
An IOException as a result of a connection interruption resulted in the data streams not being closed