### PR TITLE
BUG FIX: Set Data Type DIRECTLY before the RETR, z/OS ASCII transfer fails

### DIFF
--- a/FluentFTP/Client/FtpClient_Stream.cs
+++ b/FluentFTP/Client/FtpClient_Stream.cs
@@ -1231,9 +1231,8 @@ namespace FluentFTP {
 					client = this;
 				}
 
-				client.SetDataType(type);
-
 				length = checkIfFileExists ? client.GetFileSize(path) : 0;
+				client.SetDataType(type);
 				stream = client.OpenDataStream("RETR " + path, restart);
 #if !CORE14
 			}
@@ -1286,8 +1285,8 @@ namespace FluentFTP {
 				client = this;
 			}
 
-			await client.SetDataTypeAsync(type, token);
 			length = checkIfFileExists ? await client.GetFileSizeAsync(path, -1, token) : 0;
+			await client.SetDataTypeAsync(type, token);
 			stream = await client.OpenDataStreamAsync("RETR " + path, restart, token);
 
 			if (stream != null) {


### PR DESCRIPTION
`length = checkIfFileExists ? client.GetFileSize(path) : 0;` can, in some cases, cause a `SetDataType(...)` for BINARY. This can happen for z/OS, where the `FileExists` and the `GetFileSize` functionality relies on getting a file listing, which in turn sets BINARY.

I propose:

If the `SetDataType` asks for `ASCII`, this will be overturned be a `BINARY` from the `GetListing(...)`, **unless the `SetDataType` is placed DIRECTLY before the RETR command. So this is the safest place for the `SetDataType`**.

Question: So much size-getting. Was gotten before, why again (see #806)? Needs to be investigated...