### PR TITLE
z/OS FTP Server SYST command replies differently depending on realm

### DIFF
--- a/FluentFTP/Servers/FtpServerSpecificHandler.cs
+++ b/FluentFTP/Servers/FtpServerSpecificHandler.cs
@@ -134,6 +134,13 @@ namespace FluentFTP.Servers {
 				// Windows OS
 				serverOS = FtpOperatingSystem.Windows;
 			}
+			else if (system.Contains("Z/OS"))
+			{
+				// IBM z/OS
+				// Syst message: "215 MVS is the operating system of this server. FTP Server is running on z/OS."
+				// Syst message: "215 UNIX is the operating system of this server. FTP Server is running on z/OS.
+				serverOS = FtpOperatingSystem.IBMzOS;
+			}
 			else if (system.Contains("UNIX") || system.Contains("AIX")) {
 				// Unix OS
 				serverOS = FtpOperatingSystem.Unix;
@@ -145,11 +152,6 @@ namespace FluentFTP.Servers {
 			else if (system.Contains("OS/400")) {
 				// IBM OS/400
 				serverOS = FtpOperatingSystem.IBMOS400;
-			}
-			else if (system.Contains("Z/OS")) {
-				// IBM OS/400
-				// Syst message: "215 MVS is the operating system of this server. FTP Server is running on z/OS."
-				serverOS = FtpOperatingSystem.IBMzOS;
 			}
 			else if (system.Contains("SUNOS")) {
 				// SUN OS

--- a/FluentFTP/Servers/FtpServerSpecificHandler.cs
+++ b/FluentFTP/Servers/FtpServerSpecificHandler.cs
@@ -138,7 +138,7 @@ namespace FluentFTP.Servers {
 			{
 				// IBM z/OS
 				// Syst message: "215 MVS is the operating system of this server. FTP Server is running on z/OS."
-				// Syst message: "215 UNIX is the operating system of this server. FTP Server is running on z/OS.
+				// Syst message: "215 UNIX is the operating system of this server. FTP Server is running on z/OS."
 				serverOS = FtpOperatingSystem.IBMzOS;
 			}
 			else if (system.Contains("UNIX") || system.Contains("AIX")) {


### PR DESCRIPTION
This PR concerns `DetectFtpOSBySyst(...)`:

Someone reported that after connecting to his z/OS CS FTP server, he cannot access the z/OS realm.

It turns out FluentFTP recognizes the system as being "UNIX".

Research showed up the following:

There is a parameter for the IBM z/OS CS FTP server called "STARTUPDIRECTORY" (see [here](https://www.ibm.com/docs/en/zos/2.4.0?topic=protocol-startdirectory-ftp-server-statement#strtdir)).

It was set to "HFS", which causes the `SYST` command to respond like this:

`215 UNIX is the operating system of this server. FTP Server is running on z/OS.`

Up to now we have only been expecting:

`215 MVS is the operating system of this server. FTP Server is running on z/OS.`

Both of these texts contain the needed "`Z/OS`" (ToUppered...), but the `if` clauses trigger on the "`UNIX`" some lines further up. Therefore, a re-ordering of these statements is needed to solve that problem.