### PR TITLE
SetDataType DIRECTLY before the RETR

### DIFF
--- a/FluentFTP/Client/FtpClient_Stream.cs
+++ b/FluentFTP/Client/FtpClient_Stream.cs
@@ -1231,9 +1231,9 @@ namespace FluentFTP {
 					client = this;
 				}
 
-				client.SetDataType(type);
-
 				length = checkIfFileExists ? client.GetFileSize(path) : 0;
+
+				client.SetDataType(type);
 				stream = client.OpenDataStream("RETR " + path, restart);
 #if !CORE14
 			}
@@ -1286,8 +1286,9 @@ namespace FluentFTP {
 				client = this;
 			}
 
-			await client.SetDataTypeAsync(type, token);
 			length = checkIfFileExists ? await client.GetFileSizeAsync(path, -1, token) : 0;
+
+			await client.SetDataTypeAsync(type, token);
 			stream = await client.OpenDataStreamAsync("RETR " + path, restart, token);
 
 			if (stream != null) {


### PR DESCRIPTION
This PR is a reiteration of #805, concerns `OpenRead(...)`

I closed that to research some other problems and to isolate a number of other things to look at, but am putting this back in now.

SInce the changes for z/OS, the `GetFileSize(...)` which is performed prior to the `RETR` will (in case of z/OS) perform a `GetListing(...)` to determine the file size. But this will issue a `SetDataType(...)` for `TYPE I`. This will counter the `SetDataType(...)` for `ASCII` that a user might have requested.

This is not an old problem. It was introduced by the z/OS changes (and only happens for z/OS servers).

It means that a z/OS server cannot be told to perform an `ASCII` transfer unless this is merged.