### PR TITLE
Checking for FtpOperatingSystem.IBMzOS is redundant

### DIFF
--- a/FluentFTP/Client/FtpClient_Connection.cs
+++ b/FluentFTP/Client/FtpClient_Connection.cs
@@ -516,8 +516,7 @@ namespace FluentFTP {
 				// FIX : #318 always set the type when we create a new connection
 				ForceSetDataType = true;
 
-				if (ServerType == FtpServer.IBMzOSFTP &&
-					ServerOS == FtpOperatingSystem.IBMzOS)
+				if (ServerType == FtpServer.IBMzOSFTP)
 				{
 					if (!(reply = Execute("SITE DATASETMODE")).Success)
 					{
@@ -704,8 +703,7 @@ namespace FluentFTP {
 			// FIX : #318 always set the type when we create a new connection
 			ForceSetDataType = true;
 
-			if (ServerType == FtpServer.IBMzOSFTP &&
-				ServerOS == FtpOperatingSystem.IBMzOS)
+			if (ServerType == FtpServer.IBMzOSFTP)
 			{
 				if (!(reply = await ExecuteAsync("SITE DATASETMODE", token)).Success)
 				{

--- a/FluentFTP/Client/FtpClient_FileDownload.cs
+++ b/FluentFTP/Client/FtpClient_FileDownload.cs
@@ -678,7 +678,7 @@ namespace FluentFTP {
 
 				// if the server has not provided a length for this file
 				// we read until EOF instead of reading a specific number of bytes
-				var readToEnd = fileLen <= 0 || (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS);
+				var readToEnd = fileLen <= 0 || (ServerType == FtpServer.IBMzOSFTP);
 
 				const int rateControlResolution = 100;
 				var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;
@@ -912,7 +912,7 @@ namespace FluentFTP {
 
 				// if the server has not provided a length for this file
 				// we read until EOF instead of reading a specific number of bytes
-				var readToEnd = fileLen <= 0 || (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS);
+				var readToEnd = fileLen <= 0 || (ServerType == FtpServer.IBMzOSFTP);
 
 				const int rateControlResolution = 100;
 				var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;

--- a/FluentFTP/Client/FtpClient_FileManagement.cs
+++ b/FluentFTP/Client/FtpClient_FileManagement.cs
@@ -106,12 +106,12 @@ namespace FluentFTP {
 
 				// z/OS Notes:
 				// In the following code, this checks for special z/OS handling:
-				// ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS
+				// ServerType == FtpServer.IBMzOSFTP
 				// A check for path.StartsWith("/") tells us, even if it is z/OS, we can use the 
 				// normal unix logic
 
 				// If z/OS: Do not GetAbsolutePath(), unless we have a leading slash
-				if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path.StartsWith("/")) {
+				if (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/")) {
 					// calc the absolute filepath
 					path = GetAbsolutePath(path);
 				}
@@ -119,7 +119,7 @@ namespace FluentFTP {
 				// since FTP does not include a specific command to check if a file exists
 				// here we check if file exists by attempting to get its filesize (SIZE)
 				// If z/OS: Do not do SIZE, unless we have a leading slash
-				if (HasFeature(FtpCapability.SIZE) && (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path.StartsWith("/"))) {
+				if (HasFeature(FtpCapability.SIZE) && (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/"))) {
 
 					// Fix #328: get filesize in ASCII or Binary mode as required by server
 					var sizeReply = new FtpSizeReply();
@@ -134,7 +134,7 @@ namespace FluentFTP {
 
 				// check if file exists by attempting to get its date modified (MDTM)
 				// If z/OS: Do not do MDTM, unless we have a leading slash
-				if (HasFeature(FtpCapability.MDTM) && (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path.StartsWith("/"))) {
+				if (HasFeature(FtpCapability.MDTM) && (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/"))) {
 					var reply = Execute("MDTM " + path);
 					var ch = reply.Code[0];
 					if (ch == '2') {
@@ -146,7 +146,7 @@ namespace FluentFTP {
 				}
 
 				// If z/OS: different handling, unless we have a leading slash
-				if (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS && !path.StartsWith("/")) {
+				if (ServerType == FtpServer.IBMzOSFTP && !path.StartsWith("/")) {
 					var fileList = GetNameListing(path);
 					return fileList.Count() > 0;
 				}
@@ -204,12 +204,12 @@ namespace FluentFTP {
 
 			// z/OS Notes:
 			// In the following code, this checks for special z/OS handling:
-			// ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS
+			// ServerType == FtpServer.IBMzOSFTP
 			// A check for path.StartsWith("/") tells us, even if it is z/OS, we can use the 
 			// normal unix logic
 
 			// Do not need GetAbsolutePath(path) if z/OS
-			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path.StartsWith("/")) {
+			if (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/")) {
 				// calc the absolute filepath
 				path = await GetAbsolutePathAsync(path, token);
 			}
@@ -217,7 +217,7 @@ namespace FluentFTP {
 			// since FTP does not include a specific command to check if a file exists
 			// here we check if file exists by attempting to get its filesize (SIZE)
 			// If z/OS: Do not do SIZE, unless we have a leading slash
-			if (HasFeature(FtpCapability.SIZE) && (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path.StartsWith("/"))) {
+			if (HasFeature(FtpCapability.SIZE) && (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/"))) {
 
 				// Fix #328: get filesize in ASCII or Binary mode as required by server
 				FtpSizeReply sizeReply = new FtpSizeReply();
@@ -232,7 +232,7 @@ namespace FluentFTP {
 
 			// check if file exists by attempting to get its date modified (MDTM)
 			// If z/OS: Do not do MDTM, unless we have a leading slash
-			if (HasFeature(FtpCapability.MDTM) && (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path.StartsWith("/"))) {
+			if (HasFeature(FtpCapability.MDTM) && (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/"))) {
 				FtpReply reply = await ExecuteAsync("MDTM " + path, token);
 				var ch = reply.Code[0];
 				if (ch == '2') {
@@ -245,7 +245,7 @@ namespace FluentFTP {
 			}
 
 			// If z/OS: different handling, unless we have a leading slash
-			if (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS && !path.StartsWith("/")) {
+			if (ServerType == FtpServer.IBMzOSFTP && !path.StartsWith("/")) {
 				var fileList = await GetNameListingAsync(path, token);
 				return fileList.Count() > 0;
 			}

--- a/FluentFTP/Client/FtpClient_FileProperties.cs
+++ b/FluentFTP/Client/FtpClient_FileProperties.cs
@@ -179,7 +179,7 @@ namespace FluentFTP {
 
 			LogFunc(nameof(GetFileSize), new object[] { path });
 
-			if (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS)	{
+			if (ServerType == FtpServer.IBMzOSFTP)	{
 				return GetZOSFileSize(path);
 			}
 
@@ -252,7 +252,7 @@ namespace FluentFTP {
 
 			LogFunc(nameof(GetFileSizeAsync), new object[] { path, defaultValue });
 
-			if (ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS)	{
+			if (ServerType == FtpServer.IBMzOSFTP)	{
 				return await GetZOSFileSizeAsync(path, token);
 			}
 

--- a/FluentFTP/Client/FtpClient_FileUpload.cs
+++ b/FluentFTP/Client/FtpClient_FileUpload.cs
@@ -68,7 +68,7 @@ namespace FluentFTP {
 
 			// ensure ends with slash if remote is not PDS (MVS Dataset)
 			bool isPDS = false;
-			if (remoteDir.StartsWith("'") && ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS) {
+			if (remoteDir.StartsWith("'") && ServerType == FtpServer.IBMzOSFTP) {
 				isPDS = true;
 			}
 			else {

--- a/FluentFTP/Client/FtpClient_FolderManagement.cs
+++ b/FluentFTP/Client/FtpClient_FolderManagement.cs
@@ -799,7 +799,6 @@ namespace FluentFTP {
 			// PWD returns "''" - you would need to CWD to some HLQ that only you can
 			// imagine. There is no way to list the available top level HLQs.
 			if (ServerType == FtpServer.IBMzOSFTP &&
-				ServerOS == FtpOperatingSystem.IBMzOS &&
 				_LastWorkingDir.Split('.').Length - 1 == 1) {
 				return true;
 			}
@@ -831,7 +830,6 @@ namespace FluentFTP {
 			// PWD returns "''" - you would need to CWD to some HLQ that only you can
 			// imagine. There is no way to list the available top level HLQs.
 			if (ServerType == FtpServer.IBMzOSFTP &&
-				ServerOS == FtpOperatingSystem.IBMzOS &&
 				_LastWorkingDir.Split('.').Length - 1 == 1)
 			{
 				return true;

--- a/FluentFTP/Client/FtpClient_IBMzOS.cs
+++ b/FluentFTP/Client/FtpClient_IBMzOS.cs
@@ -44,8 +44,7 @@ namespace FluentFTP {
 				ReadCurrentWorkingDirectory();
 			}
 
-			if (ServerType != FtpServer.IBMzOSFTP ||
-				ServerOS != FtpOperatingSystem.IBMzOS) {
+			if (ServerType != FtpServer.IBMzOSFTP) {
 				return FtpZOSListRealm.Invalid;
 			}
 
@@ -97,8 +96,7 @@ namespace FluentFTP {
 				await ReadCurrentWorkingDirectoryAsync(token);
 			}
 
-			if (ServerType != FtpServer.IBMzOSFTP ||
-				ServerOS != FtpOperatingSystem.IBMzOS)			{
+			if (ServerType != FtpServer.IBMzOSFTP)			{
 				return FtpZOSListRealm.Invalid;
 			}
 

--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -263,7 +263,7 @@ namespace FluentFTP {
 			// Note: "TEST.TST" is a "path" that does not start with a slash
 			// This could be a unix file on z/OS OR a classic CWD relative dataset
 			// Both of these work with the z/OS FTP server LIST command
-			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path == null || path.StartsWith("/"))
+			if (ServerType != FtpServer.IBMzOSFTP || path == null || path.StartsWith("/"))
 			{
 				// calc the absolute filepath
 				path = GetAbsolutePath(path);
@@ -395,7 +395,7 @@ namespace FluentFTP {
 				}
 			}
 			// for z/OS, return of null actually means, just skip with no warning
-			else if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS)
+			else if (ServerType != FtpServer.IBMzOSFTP)
 			{
 				LogStatus(FtpTraceLevel.Warn, "Failed to parse file listing: " + buf);
 			}
@@ -638,7 +638,7 @@ namespace FluentFTP {
 			// Note: "TEST.TST" is a "path" that does not start with a slash
 			// This could be a unix file on z/OS OR a classic CWD relative dataset
 			// Both of these work with the z/OS FTP server LIST command
-			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path == null || path.StartsWith("/"))
+			if (ServerType != FtpServer.IBMzOSFTP || path == null || path.StartsWith("/"))
 			{
 				// calc the absolute filepath
 				path = await GetAbsolutePathAsync(path, token);
@@ -1171,7 +1171,7 @@ namespace FluentFTP {
 
 			var listing = new List<string>();
 
-			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path == null || path.StartsWith("/"))
+			if (ServerType != FtpServer.IBMzOSFTP || path == null || path.StartsWith("/"))
 			{
 				// calc path to request
 				path = GetAbsolutePath(path);
@@ -1283,7 +1283,7 @@ namespace FluentFTP {
 
 			var listing = new List<string>();
 
-			if (ServerType != FtpServer.IBMzOSFTP || ServerOS != FtpOperatingSystem.IBMzOS || path == null || path.StartsWith("/"))
+			if (ServerType != FtpServer.IBMzOSFTP || path == null || path.StartsWith("/"))
 			{
 				// calc path to request
 				path = await GetAbsolutePathAsync(path, token);

--- a/FluentFTP/Client/FtpClient_Utils.cs
+++ b/FluentFTP/Client/FtpClient_Utils.cs
@@ -108,7 +108,7 @@ namespace FluentFTP {
 				var pwd = GetWorkingDirectory();
 				if (pwd != null && pwd.Trim().Length > 0 && path != pwd) {
 					// Check if PDS (MVS Dataset) file system
-					if (pwd.StartsWith("'") && ServerType == FtpServer.IBMzOSFTP && ServerOS == FtpOperatingSystem.IBMzOS) {
+					if (pwd.StartsWith("'") && ServerType == FtpServer.IBMzOSFTP) {
 						// PDS that has single quotes is already fully qualified
 						return pwd;
 					}

--- a/FluentFTP/Helpers/RemotePaths.cs
+++ b/FluentFTP/Helpers/RemotePaths.cs
@@ -173,7 +173,6 @@ namespace FluentFTP.Helpers {
 
 			// ONLY IF DIR PATH PROVIDED
 			if (client.ServerType == FtpServer.IBMzOSFTP &&
-				client.ServerOS == FtpOperatingSystem.IBMzOS &&
 				client.zOSListingRealm != FtpZOSListRealm.Unix)
 			{
 				// The user might be using GetListing("", FtpListOption.NoPath)


### PR DESCRIPTION
Trying to clean up some of my previous z/OS contributions.

Checking for `ServerType == FtpServer.IBMzOSFTP` **and** `ServerOS == FtpOperatingSystem.IBMzOS` is totally redundant.

A check for `ServerType == FtpServer.IBMzOSFTP` is sufficient.