### PR TITLE
File_Download / OpenRead Refactor

### DIFF
--- a/FluentFTP/Client/IFtpClient.cs
+++ b/FluentFTP/Client/IFtpClient.cs
@@ -204,12 +204,9 @@ namespace FluentFTP {
 		// LOW LEVEL
 
 		Stream OpenRead(string path);
-		Stream OpenRead(string path, FtpDataType type);
-		Stream OpenRead(string path, FtpDataType type, bool checkIfFileExists);
-		Stream OpenRead(string path, FtpDataType type, long restart);
 		Stream OpenRead(string path, long restart);
-		Stream OpenRead(string path, long restart, bool checkIfFileExists);
-		Stream OpenRead(string path, FtpDataType type, long restart, bool checkIfFileExists);
+		Stream OpenRead(string path, FtpDataType type, long restart);
+		Stream OpenRead(string path, FtpDataType type, long restart, long fileLen);
 		Stream OpenWrite(string path);
 		Stream OpenWrite(string path, FtpDataType type);
 		Stream OpenWrite(string path, FtpDataType type, bool checkIfFileExists);
@@ -218,17 +215,15 @@ namespace FluentFTP {
 		Stream OpenAppend(string path, FtpDataType type, bool checkIfFileExists);
 
 #if ASYNC
-		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart, bool checkIfFileExists, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart, long fileLen, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart, CancellationToken token = default(CancellationToken));
-		Task<Stream> OpenReadAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenReadAsync(string path, long restart, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenReadAsync(string path, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenAppendAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenWriteAsync(string path, FtpDataType type, bool checkIfFileExists, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenWriteAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenWriteAsync(string path, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenAppendAsync(string path, FtpDataType type, bool checkIfFileExists, CancellationToken token = default(CancellationToken));
-		Task<Stream> OpenAppendAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
-
 		Task<Stream> OpenAppendAsync(string path, CancellationToken token = default(CancellationToken));
 #endif
 


### PR DESCRIPTION
In order to get progress information on ASCII transfers and to reduce the number of redundant calls to `GetFileSize(...)` I needed to do the following:

Oh, and I think you are not going to like this, maybe. Big bad ugly PR's are more a thing for the maintainer than for contributer :-)) BTW: This is not IBM z/OS specific.

In `DownloadFileInternal(...)`:
Separate the decision to get the file size from the decision of when to read to the end.

Thus: 
- get the file length (unless already known = supplied by caller) if progress is required, regardless of ASCII or Binary. If file length is "already known", just use that. If no progress is requested, and there is no file length, `OpenRead(...)` will do it internally.
- pass the file length (which might be zero) to `OpenRead(....)` and modify that function to understand that information.
- set the read to end decision, when there is no file length, or when ASCII transfer or when IBM z/OS.

In `OpenRead(...)`:
Refactor and remove uneeded function overloads.
Reflect all relevant removals and changes to `IFtpClient.cs`.
Add new _master_ function prototype which takes the file length (and remove `checkIfFileExists`)

Since all callers of `OpenRead(...)` other than `DownloadFileInternal(...)` use `true` for the now redundant parameter `checkIfFileExists`, it can be removed. The needed information is already self-contained in the new parameter `fileLen`. This combines the previous information `fileLen > 0` - the entire `fileLen` is now passed to `OpenRead(...)`. 

The previous logic was strange anyway: Why should a file length greater that zero cause **ANOTHER** `GetFileSize(...)`. The known file size was already gotten once, so why again? It is only done in the code to set the stream length.

