### PR TITLE
Download/Upload/Stream refactor

### DIFF
--- a/FluentFTP/Client/FtpClient_FileUpload.cs
+++ b/FluentFTP/Client/FtpClient_FileUpload.cs
@@ -673,14 +673,11 @@ namespace FluentFTP {
 
 			try {
 				long localPosition = 0, remotePosition = 0, remoteFileLen = 0;
-				var checkRemoteFileSize = false;
 
 				// check if the file exists, and skip, overwrite or append
 				if (existsMode == FtpRemoteExists.NoCheck) {
-					checkRemoteFileSize = false;
 				}
 				else if (existsMode == FtpRemoteExists.ResumeNoCheck || existsMode == FtpRemoteExists.AddToEndNoCheck) {
-					checkRemoteFileSize = true;
 
 					// start from the end of the remote file, or if failed to read the length then start from the beginning
 					remoteFileLen = remotePosition = GetFileSize(remotePath, 0);
@@ -764,10 +761,10 @@ namespace FluentFTP {
 
 				// open a file connection
 				if (remotePosition == 0 && existsMode != FtpRemoteExists.ResumeNoCheck && existsMode != FtpRemoteExists.AddToEndNoCheck) {
-					upStream = OpenWrite(remotePath, UploadDataType, checkRemoteFileSize);
+					upStream = OpenWrite(remotePath, UploadDataType, remoteFileLen);
 				}
 				else {
-					upStream = OpenAppend(remotePath, UploadDataType, checkRemoteFileSize);
+					upStream = OpenAppend(remotePath, UploadDataType, remoteFileLen);
 				}
 
 				// calculate chunk size and rate limiting
@@ -960,14 +957,11 @@ namespace FluentFTP {
 
 			try {
 				long localPosition = 0, remotePosition = 0, remoteFileLen = 0;
-				var checkRemoteFileSize = false;
 
 				// check if the file exists, and skip, overwrite or append
 				if (existsMode == FtpRemoteExists.NoCheck) {
-					checkRemoteFileSize = false;
 				}
 				else if (existsMode == FtpRemoteExists.ResumeNoCheck || existsMode == FtpRemoteExists.AddToEndNoCheck) {
-					checkRemoteFileSize = true;
 
 					// start from the end of the remote file, or if failed to read the length then start from the beginning
 					remoteFileLen = remotePosition = await GetFileSizeAsync(remotePath, 0, token);
@@ -1055,10 +1049,10 @@ namespace FluentFTP {
 
 				// open a file connection
 				if (remotePosition == 0 && existsMode != FtpRemoteExists.ResumeNoCheck && existsMode != FtpRemoteExists.AddToEndNoCheck) {
-					upStream = await OpenWriteAsync(remotePath, UploadDataType, checkRemoteFileSize, token);
+					upStream = await OpenWriteAsync(remotePath, UploadDataType, remoteFileLen, token);
 				}
 				else {
-					upStream = await OpenAppendAsync(remotePath, UploadDataType, checkRemoteFileSize, token);
+					upStream = await OpenAppendAsync(remotePath, UploadDataType, remoteFileLen, token);
 				}
 
 				// calculate chunk size and rate limiting
@@ -1251,7 +1245,7 @@ namespace FluentFTP {
 				upStream.Dispose();
 
 				// create and return a new stream starting at the current remotePosition
-				upStream = OpenAppend(remotePath, UploadDataType, true);
+				upStream = OpenAppend(remotePath, UploadDataType, 0);
 				upStream.Position = remotePosition;
 				return true;
 			}
@@ -1270,7 +1264,7 @@ namespace FluentFTP {
 				upStream.Dispose();
 
 				// create and return a new stream starting at the current remotePosition
-				var returnStream = await OpenAppendAsync(remotePath, UploadDataType, true);
+				var returnStream = await OpenAppendAsync(remotePath, UploadDataType, 0);
 				returnStream.Position = remotePosition;
 				return Tuple.Create(true, returnStream);
 			}

--- a/FluentFTP/Client/IFtpClient.cs
+++ b/FluentFTP/Client/IFtpClient.cs
@@ -204,31 +204,26 @@ namespace FluentFTP {
 		// LOW LEVEL
 
 		Stream OpenRead(string path);
-		Stream OpenRead(string path, FtpDataType type);
-		Stream OpenRead(string path, FtpDataType type, bool checkIfFileExists);
-		Stream OpenRead(string path, FtpDataType type, long restart);
 		Stream OpenRead(string path, long restart);
-		Stream OpenRead(string path, long restart, bool checkIfFileExists);
-		Stream OpenRead(string path, FtpDataType type, long restart, bool checkIfFileExists);
+		Stream OpenRead(string path, FtpDataType type, long restart);
+		Stream OpenRead(string path, FtpDataType type, long restart, long fileLen);
 		Stream OpenWrite(string path);
 		Stream OpenWrite(string path, FtpDataType type);
-		Stream OpenWrite(string path, FtpDataType type, bool checkIfFileExists);
+		Stream OpenWrite(string path, FtpDataType type, long fileLen);
 		Stream OpenAppend(string path);
 		Stream OpenAppend(string path, FtpDataType type);
-		Stream OpenAppend(string path, FtpDataType type, bool checkIfFileExists);
+		Stream OpenAppend(string path, FtpDataType type, long fileLen);
 
 #if ASYNC
-		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart, bool checkIfFileExists, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart, long fileLen, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenReadAsync(string path, FtpDataType type, long restart, CancellationToken token = default(CancellationToken));
-		Task<Stream> OpenReadAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenReadAsync(string path, long restart, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenReadAsync(string path, CancellationToken token = default(CancellationToken));
-		Task<Stream> OpenWriteAsync(string path, FtpDataType type, bool checkIfFileExists, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenAppendAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
+		Task<Stream> OpenWriteAsync(string path, FtpDataType type, long fileLen, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenWriteAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenWriteAsync(string path, CancellationToken token = default(CancellationToken));
-		Task<Stream> OpenAppendAsync(string path, FtpDataType type, bool checkIfFileExists, CancellationToken token = default(CancellationToken));
-		Task<Stream> OpenAppendAsync(string path, FtpDataType type, CancellationToken token = default(CancellationToken));
-
+		Task<Stream> OpenAppendAsync(string path, FtpDataType type, long fileLen, CancellationToken token = default(CancellationToken));
 		Task<Stream> OpenAppendAsync(string path, CancellationToken token = default(CancellationToken));
 #endif
 


### PR DESCRIPTION
I wondered how to PR this, it is impossible to separate into smaller pieces, so please have a good look at the following and let's discuss. It is the last of my changes, nothing more in the pipeline, but I have left the worst one for the last. Big bad ugly PR's are more a thing for the maintainer than for a contributer :-)) BTW: This is not IBM z/OS specific, but I am currently actually using it to improve the users experience with my FTP client.

This replaces PR #817 which I closed in order to create a "tidier" and more complete PR.

### In order to get progress information **even on ASCII download transfers** and **to reduce the number of redundant calls to `GetFileSize(...)`** I needed to do the following:

**In `DownloadFileInternal(...)`:**

Separate the decision to _get the file size_ from the decision of when to _read to the end_.

Thus:

get the file length (unless already known = supplied by caller) if progress is required, regardless of ASCII or Binary. If file length is "already known", just use that. If no progress is requested, and there is no file length, `OpenRead(...)` will do it internally.
Pass the file length (which might be zero, this replaces the original bool true) to `OpenRead(....)` and modify that function to understand that information.

set the _read to end_ decision, when there is no file length, or when ASCII transfer or when IBM z/OS.

**In `OpenRead(...)`:**

Refactor and remove uneeded function overloads.

Reflect all relevant removals and changes to `IFtpClient.cs`.

Add new master function prototype which takes the file length (and remove `bool checkIfFileExists`)

Since all callers of `OpenRead(...)` other than `DownloadFileInternal(...)` use true for the now redundant parameter `checkIfFileExists`, it can be removed. The needed information is already self-contained in the new parameter `fileLen`. This combines the previous information `fileLen > 0` - the entire file length is now passed to `OpenRead(...)`.

The previous logic was strange anyway: Why should a file length greater that zero cause ANOTHER `GetFileSize(...)`. The known file size was already gotten once, so why again? It is only done in the code to set the stream length.

Essentialy the same logic was applied to `OpenWrite(...)` and `OpenAppend(...)` but the needed changes were much less complex. I also expanded PR #814 to cover these two functions - although in theory this problem can really only happen in `OpenAppend(...)`.