### PR TITLE
Change virtual to override for GetParser

### DIFF
--- a/FluentFTP/Servers/Handlers/NonStopTandemServer.cs
+++ b/FluentFTP/Servers/Handlers/NonStopTandemServer.cs
@@ -43,7 +43,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// <summary>
 		/// Return the default file listing parser to be used with your FTP server.
 		/// </summary>
-		public virtual FtpParser GetParser() {
+		public override FtpParser GetParser() {
 			return FtpParser.NonStop;
 		}
 

--- a/FluentFTP/Servers/Handlers/OpenVmsServer.cs
+++ b/FluentFTP/Servers/Handlers/OpenVmsServer.cs
@@ -87,7 +87,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// <summary>
 		/// Return the default file listing parser to be used with your FTP server.
 		/// </summary>
-		public virtual FtpParser GetParser() {
+		public override FtpParser GetParser() {
 			return FtpParser.VMS;
 		}
 

--- a/FluentFTP/Servers/Handlers/WindowsCeServer.cs
+++ b/FluentFTP/Servers/Handlers/WindowsCeServer.cs
@@ -43,7 +43,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// <summary>
 		/// Return the default file listing parser to be used with your FTP server.
 		/// </summary>
-		public virtual FtpParser GetParser() {
+		public override FtpParser GetParser() {
 			return FtpParser.Windows;
 		}
 

--- a/FluentFTP/Servers/Handlers/WindowsIisServer.cs
+++ b/FluentFTP/Servers/Handlers/WindowsIisServer.cs
@@ -42,7 +42,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// <summary>
 		/// Return the default file listing parser to be used with your FTP server.
 		/// </summary>
-		public virtual FtpParser GetParser() {
+		public override FtpParser GetParser() {
 			return FtpParser.Windows;
 		}
 


### PR DESCRIPTION
Child classes of `FtpBaseServer` does not properly override `GetParser` using `override`.
The implication is that the value of `FtpBaseServer.GetParser()` is returned if the child class is casted to `FtpBaseServer`.

Here's an [example](
https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEUCuA7AHwAEAmARgFgAoa0gAiLIHZqBvauzhkkjr9qlyF0AClACWeDDCgAKPDADudAGrioGHAEMANgHEYGEVqgBnGbICUlgNx9hoiVIsLlAeQBuMiQBMYBoxNzOWs7QS4AX2p7BjIkBhRHSWk5ADEMAAcAIS1zAGUZLyg6YKLLGIEHTkYATllSmQA6AIAVAE8MmCtGgDktAFsYOgBqOgAiEHGRhqhmw2MzC1CYqKpV6hg8HH66dIyF4LYYnPM0GIBhAAtxHR9qdap6PZOYAqgio/DqgGY6D3VNLpdpkDjI6AFQSE6ABeAB8wP2QSaLzCD3oag02n08yRxUmz1yr0KMk+QiIv3+mKBe0h4JxiyhcIRkMaVxuPlR0UeJDonm84j8ENxdHxmRebw+VEqXHJdAgRV8QxpwqFDKsMPhyoZrOut1RQA===) that shows the problem.
![image](https://user-images.githubusercontent.com/919634/152792331-312ca043-547b-40bd-a079-56561c582d7f.png)