### PR TITLE
Some ArgumentExceptions take `paramName` as the first parameter

### DIFF
--- a/FluentFTP/Client/FtpClient_Connection.cs
+++ b/FluentFTP/Client/FtpClient_Connection.cs
@@ -43,7 +43,7 @@ namespace FluentFTP {
 		/// Creates a new instance of an FTP Client, with the given host.
 		/// </summary>
 		public FtpClient(string host) {
-			Host = host ?? throw new ArgumentNullException("Host must be provided");
+			Host = host ?? throw new ArgumentNullException(nameof(host), "Host must be provided");
 			m_listParser = new FtpListParser(this);
 		}
 
@@ -51,8 +51,8 @@ namespace FluentFTP {
 		/// Creates a new instance of an FTP Client, with the given host and credentials.
 		/// </summary>
 		public FtpClient(string host, NetworkCredential credentials) {
-			Host = host ?? throw new ArgumentNullException("Host must be provided");
-			Credentials = credentials ?? throw new ArgumentNullException("Credentials must be provided");
+			Host = host ?? throw new ArgumentNullException(nameof(host), "Host must be provided");
+			Credentials = credentials ?? throw new ArgumentNullException(nameof(credentials), "Credentials must be provided");
 			m_listParser = new FtpListParser(this);
 		}
 
@@ -60,9 +60,9 @@ namespace FluentFTP {
 		/// Creates a new instance of an FTP Client, with the given host, port and credentials.
 		/// </summary>
 		public FtpClient(string host, int port, NetworkCredential credentials) {
-			Host = host ?? throw new ArgumentNullException("Host must be provided");
+			Host = host ?? throw new ArgumentNullException(nameof(host), "Host must be provided");
 			Port = port;
-			Credentials = credentials ?? throw new ArgumentNullException("Credentials must be provided");
+			Credentials = credentials ?? throw new ArgumentNullException(nameof(credentials), "Credentials must be provided");
 			m_listParser = new FtpListParser(this);
 		}
 
@@ -169,7 +169,7 @@ namespace FluentFTP {
 		/// <param name="host"></param>
 		private static string ValidateHost(Uri host) {
 			if (host == null) {
-				throw new ArgumentNullException("Host is required");
+				throw new ArgumentNullException(nameof(host), "Host is required");
 			}
 #if !CORE
 			if (host.Scheme != Uri.UriSchemeFtp) {

--- a/FluentFTP/Client/FtpClient_FXPFileTransfer.cs
+++ b/FluentFTP/Client/FtpClient_FXPFileTransfer.cs
@@ -81,15 +81,15 @@ namespace FluentFTP {
 
 		private void VerifyTransferFileParams(string sourcePath, FtpClient remoteClient, string remotePath, FtpRemoteExists existsMode) {
 			if (remoteClient is null) {
-				throw new ArgumentNullException("Destination FXP FtpClient cannot be null!", "remoteClient");
+				throw new ArgumentNullException(nameof(remoteClient), "Destination FXP FtpClient cannot be null!");
 			}
 
 			if (sourcePath.IsBlank()) {
-				throw new ArgumentNullException("FtpListItem must be specified!", "sourceFtpFileItem");
+				throw new ArgumentNullException(nameof(sourcePath), "FtpListItem must be specified!");
 			}
 
 			if (remotePath.IsBlank()) {
-				throw new ArgumentException("Required parameter is null or blank.", "remotePath");
+				throw new ArgumentException("Required parameter is null or blank.", nameof(remotePath));
 			}
 
 			if (!remoteClient.IsConnected) {
@@ -101,7 +101,7 @@ namespace FluentFTP {
 			}
 
 			if (existsMode == FtpRemoteExists.AddToEnd || existsMode == FtpRemoteExists.AddToEndNoCheck) {
-				throw new ArgumentException("FXP file transfer does not currently support AddToEnd or AddToEndNoCheck modes. Use another value for existsMode.", "existsMode");
+				throw new ArgumentException("FXP file transfer does not currently support AddToEnd or AddToEndNoCheck modes. Use another value for existsMode.", nameof(existsMode));
 			}
 		}
 

--- a/FluentFTP/Client/FtpClient_FXPVerification.cs
+++ b/FluentFTP/Client/FtpClient_FXPVerification.cs
@@ -19,15 +19,15 @@ namespace FluentFTP {
 			
 			// verify args
 			if (sourcePath.IsBlank()) {
-				throw new ArgumentException("Required parameter is null or blank.", "localPath");
+				throw new ArgumentException("Required parameter is null or blank.", nameof(sourcePath));
 			}
 
 			if (remotePath.IsBlank()) {
-				throw new ArgumentException("Required parameter is null or blank.", "remotePath");
+				throw new ArgumentException("Required parameter is null or blank.", nameof(remotePath));
 			}
 
 			if (fxpDestinationClient is null) {
-				throw new ArgumentNullException("Destination FXP FtpClient cannot be null!", "fxpDestinationClient");
+				throw new ArgumentNullException(nameof(fxpDestinationClient), "Destination FXP FtpClient cannot be null!");
 			}
 
 			// check if any algorithm is supported by both servers
@@ -61,15 +61,15 @@ namespace FluentFTP {
 			
 			// verify args
 			if (sourcePath.IsBlank()) {
-				throw new ArgumentException("Required parameter is null or blank.", "localPath");
+				throw new ArgumentException("Required parameter is null or blank.", nameof(sourcePath));
 			}
 
 			if (remotePath.IsBlank()) {
-				throw new ArgumentException("Required parameter is null or blank.", "remotePath");
+				throw new ArgumentException("Required parameter is null or blank.", nameof(remotePath));
 			}
 
 			if (fxpDestinationClient is null) {
-				throw new ArgumentNullException("Destination FXP FtpClient cannot be null!", "fxpDestinationClient");
+				throw new ArgumentNullException(nameof(fxpDestinationClient), "Destination FXP FtpClient cannot be null!");
 			}
 
 			// check if any algorithm is supported by both servers

--- a/FluentFTP/Client/FtpClient_Properties.cs
+++ b/FluentFTP/Client/FtpClient_Properties.cs
@@ -828,7 +828,7 @@ namespace FluentFTP {
 			get => m_serverTimeZone;
 			set {
 				if (value < -14 || value > 14) {
-					throw new ArgumentOutOfRangeException("TimeZone must be within -14 to +14 to represent UTC-14 to UTC+14");
+					throw new ArgumentOutOfRangeException(nameof(value), "TimeZone must be within -14 to +14 to represent UTC-14 to UTC+14");
 				}
 				m_serverTimeZone = value;
 
@@ -857,7 +857,7 @@ namespace FluentFTP {
 			get => m_localTimeZone;
 			set {
 				if (value < -14 || value > 14) {
-					throw new ArgumentOutOfRangeException("LocalTimeZone must be within -14 to +14 to represent UTC-14 to UTC+14");
+					throw new ArgumentOutOfRangeException(nameof(value), "LocalTimeZone must be within -14 to +14 to represent UTC-14 to UTC+14");
 				}
 				m_localTimeZone = value;
 


### PR DESCRIPTION
Some places the arguments to `ArgumentNullException` and `ArgumentOutOfRangeException` where incorrect.

The constructors are defined as follow:
* `public ArgumentNullException (string paramName)`
* `public ArgumentNullException (string paramName, string message)`
* `public ArgumentOutOfRangeException(string paramName)`
* `public ArgumentOutOfRangeException(string paramName, string message)`