### PR TITLE
Use Task factory methods instead of going `async`

### DIFF
--- a/FluentFTP/Client/FtpClient_Hash.cs
+++ b/FluentFTP/Client/FtpClient_Hash.cs
@@ -561,40 +561,41 @@ namespace FluentFTP {
 
 #if ASYNC
 		[ObsoleteAttribute("Use GetChecksum instead and pass the algorithm type that you need. Or use CompareFile.", true)]
-		public async Task<FtpHashAlgorithm> GetHashAlgorithmAsync(CancellationToken token = default(CancellationToken)) {
-			return FtpHashAlgorithm.NONE;
+		public Task<FtpHashAlgorithm> GetHashAlgorithmAsync(CancellationToken token = default(CancellationToken)) {
+			return Task.FromResult(FtpHashAlgorithm.NONE);
 		}
 		[ObsoleteAttribute("Use GetChecksum instead and pass the algorithm type that you need. Or use CompareFile.", true)]
-		public async Task SetHashAlgorithmAsync(FtpHashAlgorithm algorithm, CancellationToken token = default(CancellationToken)) {
+		public Task SetHashAlgorithmAsync(FtpHashAlgorithm algorithm, CancellationToken token = default(CancellationToken)) {
+			return Task.CompletedTask;
 		}
 		[ObsoleteAttribute("Use GetChecksum instead and pass the algorithm type that you need. Or use CompareFile.", true)]
-		public async Task<FtpHash> GetHashAsync(string path, CancellationToken token = default(CancellationToken)) {
-			return null;
+		public Task<FtpHash> GetHashAsync(string path, CancellationToken token = default(CancellationToken)) {
+			return Task.FromResult<FtpHash>(null);
 		}
 
 		[ObsoleteAttribute("Use GetChecksum instead and set the algorithm to MD5. Or use CompareFile.", true)]
-		public async Task<string> GetMD5Async(string path, CancellationToken token = default(CancellationToken)) {
-			return null;
+		public Task<string> GetMD5Async(string path, CancellationToken token = default(CancellationToken)) {
+			return Task.FromResult<string>(null);
 		}
 		[ObsoleteAttribute("Use GetChecksum instead and set the algorithm to CRC. Or use CompareFile.", true)]
-		public async Task<string> GetXCRCAsync(string path, CancellationToken token = default(CancellationToken)) {
-			return null;
+		public Task<string> GetXCRCAsync(string path, CancellationToken token = default(CancellationToken)) {
+			return Task.FromResult<string>(null);
 		}
 		[ObsoleteAttribute("Use GetChecksum instead and set the algorithm to MD5. Or use CompareFile.", true)]
-		public async Task<string> GetXMD5Async(string path, CancellationToken token = default(CancellationToken)) {
-			return null;
+		public Task<string> GetXMD5Async(string path, CancellationToken token = default(CancellationToken)) {
+			return Task.FromResult<string>(null);
 		}
 		[ObsoleteAttribute("Use GetChecksum instead and set the algorithm to SHA1. Or use CompareFile.", true)]
-		public async Task<string> GetXSHA1Async(string path, CancellationToken token = default(CancellationToken)) {
-			return null;
+		public Task<string> GetXSHA1Async(string path, CancellationToken token = default(CancellationToken)) {
+			return Task.FromResult<string>(null);
 		}
 		[ObsoleteAttribute("Use GetChecksum instead and set the algorithm to SHA256. Or use CompareFile.", true)]
-		public async Task<string> GetXSHA256Async(string path, CancellationToken token = default(CancellationToken)) {
-			return null;
+		public Task<string> GetXSHA256Async(string path, CancellationToken token = default(CancellationToken)) {
+			return Task.FromResult<string>(null);
 		}
 		[ObsoleteAttribute("Use GetChecksum instead and set the algorithm to SHA512. Or use CompareFile.", true)]
-		public async Task<string> GetXSHA512Async(string path, CancellationToken token = default(CancellationToken)) {
-			return null;
+		public Task<string> GetXSHA512Async(string path, CancellationToken token = default(CancellationToken)) {
+			return Task.FromResult<string>(null);
 		}
 #endif
 

--- a/FluentFTP/Servers/FtpBaseServer.cs
+++ b/FluentFTP/Servers/FtpBaseServer.cs
@@ -80,8 +80,8 @@ namespace FluentFTP.Servers {
 		/// Perform async server-specific delete directory commands here.
 		/// Return true if you executed a server-specific command.
 		/// </summary>
-		public virtual async Task<bool> DeleteDirectoryAsync(FtpClient client, string path, string ftppath, bool deleteContents, FtpListOption options, CancellationToken token) {
-			return false;
+		public virtual Task<bool> DeleteDirectoryAsync(FtpClient client, string path, string ftppath, bool deleteContents, FtpListOption options, CancellationToken token) {
+			return Task.FromResult(false);
 		}
 #endif
 
@@ -98,8 +98,8 @@ namespace FluentFTP.Servers {
 		/// Perform async server-specific create directory commands here.
 		/// Return true if you executed a server-specific command.
 		/// </summary>
-		public virtual async Task<bool> CreateDirectoryAsync(FtpClient client, string path, string ftppath, bool force, CancellationToken token) {
-			return false;
+		public virtual Task<bool> CreateDirectoryAsync(FtpClient client, string path, string ftppath, bool force, CancellationToken token) {
+			return Task.FromResult(false);
 		}
 #endif
 
@@ -116,8 +116,8 @@ namespace FluentFTP.Servers {
 		/// Perform server-specific post-connection commands here.
 		/// Return true if you executed a server-specific command.
 		/// </summary>
-		public virtual async Task AfterConnectedAsync(FtpClient client, CancellationToken token) {
-
+		public virtual Task AfterConnectedAsync(FtpClient client, CancellationToken token) {
+			return Task.CompletedTask;
 		}
 #endif
 		/// <summary>
@@ -139,8 +139,8 @@ namespace FluentFTP.Servers {
 		/// Perform server-specific file size fetching commands here.
 		/// Return the file size in bytes.
 		/// </summary>
-		public virtual async Task<long> GetFileSizeAsync(FtpClient client, string path, CancellationToken token) {
-			return 0;
+		public virtual Task<long> GetFileSizeAsync(FtpClient client, string path, CancellationToken token) {
+			return Task.FromResult(0L);
 		}
 #endif
 		/// <summary>

--- a/FluentFTP/Streams/FtpFileStream.cs
+++ b/FluentFTP/Streams/FtpFileStream.cs
@@ -152,8 +152,8 @@ namespace FluentFTP.Streams {
 		/// <summary>
 		/// If the stream is a MemoryStream, completes the quick download by writing the file to disk.
 		/// </summary>
-		public static async Task CompleteQuickFileWriteAsync(Stream fileStream, string localPath, CancellationToken token) {
-
+		public static Task CompleteQuickFileWriteAsync(Stream fileStream, string localPath, CancellationToken token) {
+			return Task.CompletedTask;
 			// if quick transfer is enabled
 			/*if (fileStream is MemoryStream) {
 


### PR DESCRIPTION
The `async` keyword makes the compiler add a bunch of code to create the underlying state machine that drives asynchronous methods in C#.

You can see [here](https://sharplab.io/#v2:D4AQTAjAsAUCAMACEECsBuWsQGZlkQGFYBvWRC5PEADmQDYAeAIwHtWAbAPkQEEBnAJ4A7AMYBpAKaCA7qwBOAEwAUASnKUyMSjuQB2RADMAhh36TM2ygF8NFO1QYt23BgDF5rALYAlSfwBXDgAXNQctXUoQAxB6ADoPbz9AkOUTM0lVSx1bGFzYIA==) what the compiler generated code is.

For a longer explanation of the difference, see e.g https://stackoverflow.com/questions/52146203/async-method-with-no-await-vs-task-fromresult