### PR TITLE
Invalidate PWD cache in ASYNC code also, this was missing

### DIFF
--- a/FluentFTP/Client/FtpClient_Stream.cs
+++ b/FluentFTP/Client/FtpClient_Stream.cs
@@ -162,6 +162,11 @@ namespace FluentFTP {
 				commandTxt = "PASS ***";
 			}
 
+			// A CWD will invalidate the cached value.
+			if (command.StartsWith("CWD ", StringComparison.Ordinal)) {
+				_LastWorkingDir = null;
+			}
+
 			LogLine(FtpTraceLevel.Info, "Command:  " + commandTxt);
 
 			// send command to FTP server


### PR DESCRIPTION
This should fix #842. Once again fell into the trap of a missing ASYNC duplicate of a change.