### PR TITLE
Handle possible multiline FEAT reply format

### DIFF
--- a/FluentFTP/Servers/FtpServerSpecificHandler.cs
+++ b/FluentFTP/Servers/FtpServerSpecificHandler.cs
@@ -208,8 +208,7 @@ namespace FluentFTP.Servers {
 				var featName = feat.Trim().ToUpper();
 
 				// Handle possible multiline FEAT reply format
-				if (featName.StartsWith("211-"))
-				{
+				if (featName.StartsWith("211-")) {
 					featName = featName.Substring(4);
 				}
 

--- a/FluentFTP/Servers/FtpServerSpecificHandler.cs
+++ b/FluentFTP/Servers/FtpServerSpecificHandler.cs
@@ -207,6 +207,12 @@ namespace FluentFTP.Servers {
 			foreach (var feat in features) {
 				var featName = feat.Trim().ToUpper();
 
+				// Handle possible multiline FEAT reply format
+				if (featName.StartsWith("211-"))
+				{
+					featName = featName.Substring(4);
+				}
+
 				if (featName.StartsWith("MLST") || featName.StartsWith("MLSD")) {
 					m_capabilities.AddOnce(FtpCapability.MLSD);
 				}


### PR DESCRIPTION
This fixes #766. Works for both formats now. Tested on my proFTPd. 

BTW: As opposed to the statements of OP in #766, this is actually **not'' turned on in the server config by default.

At least, for Debian it was actually turned **on** by default (a mistake) which was corrected on 14 Aug 2020. By now (on Debian 11) it is fixed.

See [here](https://github.com/proftpd/proftpd/issues/1085)