### PR TITLE
Fix z/OS IsRoot() and some comment typos

### DIFF
--- a/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
@@ -85,7 +85,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// <summary>
 		/// Get z/OS file size
 		/// </summary>
-		/// <param name="path">The full path of th file whose size you want to retrieve</param>
+		/// <param name="path">The full path of the file whose size you want to retrieve</param>
 		/// <remarks>
 		/// Make sure you are in the right realm (z/OS or HFS) before doing this
 		/// </remarks>
@@ -112,7 +112,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// <summary>
 		/// Get z/OS file size
 		/// </summary>
-		/// <param name="path">The full path of th file whose size you want to retrieve</param>
+		/// <param name="path">The full path of the file whose size you want to retrieve</param>
 		/// <remarks>
 		/// Make sure you are in the right realm (z/OS or HFS) before doing this
 		/// </remarks>
@@ -144,12 +144,12 @@ namespace FluentFTP.Servers.Handlers {
 		public override bool IsRoot(FtpClient client, string path) {
 
 			// If it is not a "/" root, it could perhaps be a z/OS root (like 'SYS1.')
-			// Note: If on z/OS you have somehow managed to CWD "over" th top, i.e.
+			// Note: If on z/OS you have somehow managed to CWD "over" the top, i.e.
 			// PWD returns "''" - you would need to CWD to some HLQ that only you can
 			// imagine. There is no way to list the available top level HLQs.
-			if (path.Split('.').Length - 1 == 1) {
-				return true;
-			}
+			if (path == "/") return true;
+			if (path.StartsWith("/")) return false;
+			if (path.Trim('\'').TrimEnd('.').Split('.').Length <= 1) return true;
 			return false;
 		}
 	}

--- a/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
@@ -143,13 +143,27 @@ namespace FluentFTP.Servers.Handlers {
 		/// </summary>
 		public override bool IsRoot(FtpClient client, string path) {
 
-			// If it is not a "/" root, it could perhaps be a z/OS root (like 'SYS1.')
 			// Note: If on z/OS you have somehow managed to CWD "over" the top, i.e.
-			// PWD returns "''" - you would need to CWD to some HLQ that only you can
-			// imagine. There is no way to list the available top level HLQs.
-			if (path == "/") return true;
-			if (path.StartsWith("/")) return false;
-			if (path.Trim('\'').TrimEnd('.').Split('.').Length <= 1) return true;
+			// PWD returns "''", it is also root - you would need to CWD to some HLQ
+			// that only you can imagine. There is no way to list the available top
+			// level HLQs.
+
+			// z/OS HFS root
+			if (path == "/") { 
+				return true;
+			}
+
+			// z/OS HFS some path
+			if (path.StartsWith("/")) {
+				return false;
+			}
+
+			// z/OS HLQ (like 'SYS1.' or '')
+			if (path.Trim('\'').TrimEnd('.').Split('.').Length <= 1) { 
+				return true;
+			}
+
+			// all others
 			return false;
 		}
 	}


### PR DESCRIPTION
Since moving this to the server specific handler, needs to handle z/OS unix realm as well. Also the z/OS realm was not handled correctly in all cases.