### PR TITLE
Added localPath to log message

### DIFF
--- a/FluentFTP/Client/FtpClient_FileUpload.cs
+++ b/FluentFTP/Client/FtpClient_FileUpload.cs
@@ -388,7 +388,7 @@ namespace FluentFTP {
 
 			// skip uploading if the local file does not exist
 			if (!File.Exists(localPath)) {
-				LogStatus(FtpTraceLevel.Error, "File does not exist.");
+				LogStatus(FtpTraceLevel.Error, "File does not exist: " + localPath);
 				return FtpStatus.Failed;
 			}
 			
@@ -482,7 +482,7 @@ namespace FluentFTP {
 #else
 			if (!File.Exists(localPath)) {
 #endif
-				LogStatus(FtpTraceLevel.Error, "File does not exist.");
+				LogStatus(FtpTraceLevel.Error, "File does not exist: " + localPath);
 				return FtpStatus.Failed;
 			}
 


### PR DESCRIPTION
I've had a couple of uploads fail today with the error "File does not exist". I'm using the UploadFiles() function to upload a bunch of files at once. Since I didn't see any way of retrieving a list of failed files, my approach is to filter the log for messages and create my own list.

Regarding the problem itself: I suppose it's an issue with a path being too long (running the code on a Windows system). Since I can only access the system during certain times, I can't provide any more details at the moment. I'll open a separate issue if necessary.

Feel free to adjust my changes if necessary.