### PR TITLE
Fix regex for files with whitespaces

### DIFF
--- a/FluentFTP/Helpers/Hashing/HashParser.cs
+++ b/FluentFTP/Helpers/Hashing/HashParser.cs
@@ -29,11 +29,7 @@ namespace FluentFTP.Helpers.Hashing {
 			}
 
 			Match m;
-			if (!(m = Regex.Match(reply,
-				@"(?<algorithm>.+)\s" +
-				@"(?<bytestart>\d+)-(?<byteend>\d+)\s" +
-				@"(?<hash>.+)\s" +
-				@"(?<filename>.+)")).Success) {
+			if (!(m = Regex.Match(reply, @"^(?<algorithm>\S+)\s(?<bytestart>\d+)-(?<byteend>\d+)\s(?<hash>\S+)\s(?<filename>.+)$")).Success) {
 				m = Regex.Match(reply, @"(?<algorithm>.+)\s(?<hash>.+)\s");
 			}
 


### PR DESCRIPTION
This fixes a bug that won't allow a correct checksum for files with whitespaces in their name (or in parent directories)