### PR TITLE
Fixes IOException in synchronous methods when AUTH TLS is rejected

### DIFF
--- a/FluentFTP/Client/FtpClient_Stream.cs
+++ b/FluentFTP/Client/FtpClient_Stream.cs
@@ -479,7 +479,7 @@ namespace FluentFTP {
 #if !NO_SSL
 
 			// this needs to take place after the command is executed
-			if (m_dataConnectionEncryption && m_encryptionmode != FtpEncryptionMode.None) {
+			if (m_dataConnectionEncryption && m_encryptionmode != FtpEncryptionMode.None && !_ConnectionFTPSFailure) {
 				stream.ActivateEncryption(m_host,
 					ClientCertificates.Count > 0 ? ClientCertificates : null,
 					m_SslProtocols);
@@ -796,7 +796,7 @@ namespace FluentFTP {
 #endif
 
 #if !NO_SSL
-			if (m_dataConnectionEncryption && m_encryptionmode != FtpEncryptionMode.None) {
+			if (m_dataConnectionEncryption && m_encryptionmode != FtpEncryptionMode.None && !_ConnectionFTPSFailure) {
 				stream.ActivateEncryption(m_host,
 					ClientCertificates.Count > 0 ? ClientCertificates : null,
 					m_SslProtocols);


### PR DESCRIPTION
When trying to open a data stream if client.EncryptionMode=Auto client.DataConnectionEncryption=true and AUTH TLS is rejected, a significant delay occurs followed by an IOException - "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond."

Reproduced the error by setting up a FileZilla server and turning off TLS and then trying to connect with the conditions above and trying to call UploadFile().

Async calls are unaffected as they already have the "&& !_ConnectionFTPSFailure" test.

**Workaround:**
I have worked around this issue in production by turning off DataConnectionEncryption manually.

```
client.Connect().
if (!client.IsEncrypted)
    client.DataConnectionEncryption = false;
```