### PR TITLE
SOCKS5 Support with Username/Password Authentication

### DIFF
--- a/FluentFTP.sln
+++ b/FluentFTP.sln
@@ -9,7 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpExamples", "FluentFTP
 EndProject
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "VBExamples", "FluentFTP.VBExamples\VBExamples.vbproj", "{FC62AA30-F9F0-4DC1-A9EA-51A24C624973}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentFTP.Tests", "FluentFTP.Tests\FluentFTP.Tests.csproj", "{0B17384E-6849-46D0-B880-2F97FE11A1B3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentFTP.Tests", "FluentFTP.Tests\FluentFTP.Tests.csproj", "{0B17384E-6849-46D0-B880-2F97FE11A1B3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SOCKS5.Test", "SOCKS5.Test\SOCKS5.Test.csproj", "{EAF872D6-8819-453F-8553-3017299ECAC9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,14 @@ Global
 		{0B17384E-6849-46D0-B880-2F97FE11A1B3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0B17384E-6849-46D0-B880-2F97FE11A1B3}.Release|x64.ActiveCfg = Release|x64
 		{0B17384E-6849-46D0-B880-2F97FE11A1B3}.Release|x64.Build.0 = Release|x64
+		{EAF872D6-8819-453F-8553-3017299ECAC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EAF872D6-8819-453F-8553-3017299ECAC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EAF872D6-8819-453F-8553-3017299ECAC9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EAF872D6-8819-453F-8553-3017299ECAC9}.Debug|x64.Build.0 = Debug|Any CPU
+		{EAF872D6-8819-453F-8553-3017299ECAC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EAF872D6-8819-453F-8553-3017299ECAC9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EAF872D6-8819-453F-8553-3017299ECAC9}.Release|x64.ActiveCfg = Release|Any CPU
+		{EAF872D6-8819-453F-8553-3017299ECAC9}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net60;net50;net45;net40;net35;net20;netstandard1.4;netstandard1.6;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net60;net50;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/FluentFTP/Proxy/FtpClientSocks5Proxy.cs
+++ b/FluentFTP/Proxy/FtpClientSocks5Proxy.cs
@@ -16,7 +16,7 @@ namespace FluentFTP.Proxy {
 
 		protected override void Connect(FtpSocketStream stream) {
 			base.Connect(stream);
-			var proxy = new SocksProxy(Host, Port, stream);
+			var proxy = new SocksProxy(Host, Port, stream, this.Proxy);
 			proxy.Negotiate();
 			proxy.Authenticate();
 			proxy.Connect();
@@ -24,7 +24,7 @@ namespace FluentFTP.Proxy {
 
 		protected override void Connect(FtpSocketStream stream, string host, int port, FtpIpVersion ipVersions) {
 			base.Connect(stream);
-			var proxy = new SocksProxy(Host, port, stream);
+			var proxy = new SocksProxy(Host, port, stream, this.Proxy);
 			proxy.Negotiate();
 			proxy.Authenticate();
 			proxy.Connect();
@@ -33,7 +33,7 @@ namespace FluentFTP.Proxy {
 #if ASYNC
 		protected override async Task ConnectAsync(FtpSocketStream stream, CancellationToken cancellationToken) {
 			await base.ConnectAsync(stream, cancellationToken);
-			var proxy = new SocksProxy(Host, Port, stream);
+			var proxy = new SocksProxy(Host, Port, stream, this.Proxy);
 			await proxy.NegotiateAsync();
 			await proxy.AuthenticateAsync();
 			await proxy.ConnectAsync();

--- a/SOCKS5.Test/Program.cs
+++ b/SOCKS5.Test/Program.cs
@@ -1,0 +1,48 @@
+﻿using FluentFTP.Proxy;
+using System;
+
+namespace SOCKS5.Test
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+			var ftp_host = "";
+			var ftp_port = 0;
+			var ftp_user = "";
+			var ftp_pass = "";
+
+			var socks5_host = "";
+			var socks5_port = 0;
+			var socks5_user = "";
+			var socks5_pass = "";
+
+
+			var client = new FtpClientSocks5Proxy(new ProxyInfo()
+			{
+				Host = socks5_host,
+				Port = socks5_port,
+				Credentials = new System.Net.NetworkCredential()
+				{
+					UserName = socks5_user,
+					Password = socks5_pass
+				}
+			});
+
+			client.Host = ftp_host;
+			client.Port = ftp_port;
+			client.Credentials = new System.Net.NetworkCredential()
+			{
+				UserName = ftp_user,
+				Password = ftp_pass
+			};
+
+			client.Connect();
+
+			var listing = client.GetListing("/");
+
+
+
+        }
+    }
+}

--- a/SOCKS5.Test/SOCKS5.Test.csproj
+++ b/SOCKS5.Test/SOCKS5.Test.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FluentFTP\FluentFTP.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Our use case needed username/password authentication against a SOCKS5 proxy.

We realized that the previous pull request did not implement RFC1929.
https://datatracker.ietf.org/doc/html/rfc1929

We saw where/how it was not doing it correctly, and implemented RFC1929 as best as we could.

Then we tested in a separate project (in our dev-environment, we only care about .net core 3.1) and tested the private resources we were working with. Then confirmed everything was working, and prepared this pull request.

Let us know if you have any questions.

Thanks.