### PR TITLE
WIP Test supported FTP servers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,36 @@
+name: pull_request
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  Tests:
+    env:
+      framework: 'net6.0'
+    strategy:
+      matrix:
+        include:
+        - ftp: pure-ftpd
+          os: ubuntu-latest
+        - ftp: vsftpd
+          os: ubuntu-latest
+          
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build FluentFTP.Tests.Integration/FluentFTP.Tests.Integration.csproj --no-restore --framework ${{ env.framework }}
+    - name: Test
+      env:
+        FluentFTP__Tests__Integration__FtpServerKey: ${{ matrix.ftp }}
+      run: dotnet test FluentFTP.Tests.Integration/FluentFTP.Tests.Integration.csproj --no-build --verbosity normal --framework ${{ env.framework }}

--- a/FluentFTP.Tests.Integration/DockerFtpServerFixture.cs
+++ b/FluentFTP.Tests.Integration/DockerFtpServerFixture.cs
@@ -1,0 +1,117 @@
+﻿using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FluentFTP.Tests.Integration
+{
+	public class DockerFtpServerFixture : IDisposable
+	{
+		internal TestcontainersContainer container;
+		internal string user { get; } = "bob";
+		internal string password { get; } = "12345";
+
+		public DockerFtpServerFixture()
+		{
+			// CI is "Always set to true" in GitHub Actions, used to detect if currently running in CI (Continuous Integration) pipeline.
+			var ci = Environment.GetEnvironmentVariable("CI");
+			var isCi = string.Equals(ci, "true", StringComparison.OrdinalIgnoreCase);
+			var testContainerKey = Environment.GetEnvironmentVariable("FluentFTP__Tests__Integration__FtpServerKey");
+			if (string.IsNullOrEmpty(testContainerKey) && !isCi)
+			{
+				// Default on developer machine.
+				testContainerKey = "pure-ftpd";
+			}
+
+			ITestcontainersBuilder<TestcontainersContainer>? testcontainersBuilder = null;
+			try
+			{
+				testcontainersBuilder = GetContainer(testContainerKey);
+			}
+			catch (TypeInitializationException ex)
+			{
+				// Probably because docker is not running on the machine.
+				if (isCi)
+					throw new InvalidOperationException("Unable to setup FTP server for integration test. TypeInitializationException.", ex);
+
+				Skippable.SkippableState.ShouldSkip = true;
+			}
+
+			if (testcontainersBuilder is not null)
+			{
+				container = testcontainersBuilder.Build();
+				container.StartAsync().Wait();
+			}
+			else
+			{
+				if (isCi)
+					throw new InvalidOperationException($"Unable to setup FTP server for integration test. No testcontainer found for key: '{testContainerKey}'");
+
+				Skippable.SkippableState.ShouldSkip = true;
+			}
+		}
+
+		public void Dispose()
+		{
+			container?.DisposeAsync();
+		}
+
+		private ITestcontainersBuilder<TestcontainersContainer>? GetContainer(string? key)
+		{
+			var container = key switch
+			{
+				"pure-ftpd" => GetPureFtpdContainerBuilder(),
+				"vsftpd" => GetVsftpdContainerBuilder(),
+				_ => null
+			};
+
+			return container;
+		}
+
+		private ITestcontainersBuilder<TestcontainersContainer> GetPureFtpdContainerBuilder()
+		{
+			var builder = new TestcontainersBuilder<TestcontainersContainer>()
+				.WithImage("stilliard/pure-ftpd")
+				.WithName("pure-ftpd")
+				.WithPortBinding(21);
+
+			for (var port = 30000; port <= 30009; port++)
+			{
+				builder = builder.WithPortBinding(port);
+			}
+
+			builder = builder.WithEnvironment("FTP_USER_NAME", user)
+				.WithEnvironment("FTP_USER_PASS", password)
+				.WithEnvironment("FTP_USER_HOME", "/home/bob")
+				.WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(21));
+
+			return builder;
+		}
+
+		private ITestcontainersBuilder<TestcontainersContainer> GetVsftpdContainerBuilder()
+		{
+			var builder = new TestcontainersBuilder<TestcontainersContainer>()
+				.WithImage("fauria/vsftpd")
+				.WithName("vsftpd")
+				.WithPortBinding(20)
+				.WithPortBinding(21);
+
+			for (var port = 21100; port <= 21110; port++)
+			{
+				builder = builder.WithExposedPort(port);
+				builder = builder.WithPortBinding(port);
+			}
+
+			builder = builder
+				.WithEnvironment("PASV_ADDRESS", "127.0.0.1")
+				.WithEnvironment("FTP_USER", user)
+				.WithEnvironment("FTP_PASS", password)
+				.WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(21));
+
+			return builder;
+		}
+	}
+}

--- a/FluentFTP.Tests.Integration/FluentFTP.Tests.Integration.csproj
+++ b/FluentFTP.Tests.Integration/FluentFTP.Tests.Integration.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Testcontainers" Version="2.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FluentFTP\FluentFTP.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FluentFTP.Tests.Integration/Skippable/SkipTestException.cs
+++ b/FluentFTP.Tests.Integration/Skippable/SkipTestException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FluentFTP.Tests.Integration.Skippable
+{
+	public class SkipTestException : Exception
+	{
+		public SkipTestException(string reason)
+			: base(reason) { }
+	}
+}

--- a/FluentFTP.Tests.Integration/Skippable/SkippableFactAttribute.cs
+++ b/FluentFTP.Tests.Integration/Skippable/SkippableFactAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+namespace FluentFTP.Tests.Integration.Skippable
+{
+	[XunitTestCaseDiscoverer("FluentFTP.Tests.Integration.Skippable.XunitExtensions.SkippableFactDiscoverer", "FluentFTP.Tests.Integration")]
+	public class SkippableFactAttribute : FactAttribute { }
+}

--- a/FluentFTP.Tests.Integration/Skippable/SkippableState.cs
+++ b/FluentFTP.Tests.Integration/Skippable/SkippableState.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FluentFTP.Tests.Integration.Skippable
+{
+	internal static class SkippableState
+	{
+		internal static bool ShouldSkip { get; set; }
+	}
+}

--- a/FluentFTP.Tests.Integration/Skippable/SkippableTheoryAttribute.cs
+++ b/FluentFTP.Tests.Integration/Skippable/SkippableTheoryAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+namespace FluentFTP.Tests.Integration.Skippable
+{
+	[XunitTestCaseDiscoverer("FluentFTP.Tests.Integration.Skippable.XunitExtensions.SkippableTheoryDiscoverer", "FluentFTP.Tests.Integration")]
+	public class SkippableTheoryAttribute : TheoryAttribute { }
+}

--- a/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableFactDiscoverer.cs
+++ b/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableFactDiscoverer.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentFTP.Tests.Integration.Skippable.XunitExtensions
+{
+	public class SkippableFactDiscoverer : IXunitTestCaseDiscoverer
+	{
+		readonly IMessageSink diagnosticMessageSink;
+
+		public SkippableFactDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+			this.diagnosticMessageSink = diagnosticMessageSink;
+		}
+
+		public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+		{
+			yield return new SkippableFactTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
+		}
+	}
+}

--- a/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableFactMessageBus.cs
+++ b/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableFactMessageBus.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentFTP.Tests.Integration.Skippable.XunitExtensions
+{
+	public class SkippableFactMessageBus : IMessageBus
+	{
+		readonly IMessageBus innerBus;
+
+		public SkippableFactMessageBus(IMessageBus innerBus)
+		{
+			this.innerBus = innerBus;
+		}
+
+		public int DynamicallySkippedTestCount { get; private set; }
+
+		public void Dispose() { }
+
+		public bool QueueMessage(IMessageSinkMessage message)
+		{
+			var testFailed = message as ITestFailed;
+			if (testFailed != null)
+			{
+				var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
+				if (exceptionType == typeof(SkipTestException).FullName)
+				{
+					DynamicallySkippedTestCount++;
+					return innerBus.QueueMessage(new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault()));
+				}
+			}
+
+			// Nothing we care about, send it on its way
+			return innerBus.QueueMessage(message);
+		}
+	}
+}

--- a/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableFactTestCase.cs
+++ b/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableFactTestCase.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentFTP.Tests.Integration.Skippable.XunitExtensions
+{
+	public class SkippableFactTestCase : XunitTestCase
+	{
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+		public SkippableFactTestCase() { }
+
+		public SkippableFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments = null)
+			: base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments) { }
+
+		public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+														IMessageBus messageBus,
+														object[] constructorArguments,
+														ExceptionAggregator aggregator,
+														CancellationTokenSource cancellationTokenSource)
+		{
+			var skipMessageBus = new SkippableFactMessageBus(messageBus);
+			RunSummary result;
+			if (SkippableState.ShouldSkip)
+			{
+				/*
+				 * This does skip execution, but does not register as "skipped" in the summary.
+				 */
+				result = new RunSummary
+				{
+					Total = 1,
+					Skipped = 1,
+				};
+			}
+			else
+			{
+				result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+			}
+
+
+			if (skipMessageBus.DynamicallySkippedTestCount > 0)
+			{
+				result.Failed -= skipMessageBus.DynamicallySkippedTestCount;
+				result.Skipped += skipMessageBus.DynamicallySkippedTestCount;
+			}
+
+			return result;
+		}
+	}
+}

--- a/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableTheoryDiscoverer.cs
+++ b/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableTheoryDiscoverer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentFTP.Tests.Integration.Skippable.XunitExtensions
+{
+	public class SkippableTheoryDiscoverer : IXunitTestCaseDiscoverer
+	{
+		readonly IMessageSink diagnosticMessageSink;
+		readonly TheoryDiscoverer theoryDiscoverer;
+
+		public SkippableTheoryDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+			this.diagnosticMessageSink = diagnosticMessageSink;
+
+			theoryDiscoverer = new TheoryDiscoverer(diagnosticMessageSink);
+		}
+
+		public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+		{
+			var defaultMethodDisplay = discoveryOptions.MethodDisplayOrDefault();
+			var defaultMethodDisplayOptions = discoveryOptions.MethodDisplayOptionsOrDefault();
+
+			// Unlike fact discovery, the underlying algorithm for theories is complex, so we let the theory discoverer
+			// do its work, and do a little on-the-fly conversion into our own test cases.
+			return theoryDiscoverer.Discover(discoveryOptions, testMethod, factAttribute)
+								   .Select(testCase => testCase is XunitTheoryTestCase
+														   ? (IXunitTestCase)new SkippableTheoryTestCase(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testCase.TestMethod)
+														   : new SkippableFactTestCase(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testCase.TestMethod, testCase.TestMethodArguments));
+		}
+	}
+}

--- a/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableTheoryTestCase.cs
+++ b/FluentFTP.Tests.Integration/Skippable/XunitExtensions/SkippableTheoryTestCase.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentFTP.Tests.Integration.Skippable.XunitExtensions
+{
+	public class SkippableTheoryTestCase : XunitTheoryTestCase
+	{
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+		public SkippableTheoryTestCase() { }
+
+		public SkippableTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+			: base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
+
+		public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+														IMessageBus messageBus,
+														object[] constructorArguments,
+														ExceptionAggregator aggregator,
+														CancellationTokenSource cancellationTokenSource)
+		{
+			// Duplicated code from SkippableFactTestCase. I'm sure we could find a way to de-dup with some thought.
+			var skipMessageBus = new SkippableFactMessageBus(messageBus);
+			RunSummary result;
+			if (SkippableState.ShouldSkip)
+			{
+				/*
+				 * This does skip execution, but does not register as "skipped" in the summary.
+				 */
+				result = new RunSummary
+				{
+					Total = 1,
+					Skipped = 1,
+				};
+			}
+			else
+			{
+				result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+			}
+
+			if (skipMessageBus.DynamicallySkippedTestCount > 0)
+			{
+				result.Failed -= skipMessageBus.DynamicallySkippedTestCount;
+				result.Skipped += skipMessageBus.DynamicallySkippedTestCount;
+			}
+
+			return result;
+		}
+	}
+}

--- a/FluentFTP.Tests.Integration/Tests.cs
+++ b/FluentFTP.Tests.Integration/Tests.cs
@@ -1,0 +1,226 @@
+﻿using FluentFTP.Tests.Integration.Skippable;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FluentFTP.Tests.Integration
+{
+	/// <summary>
+	/// All tests must use [SkippableFact] or [SkippableTheory] (as opposed to [Fact] and [Theory]) to allow
+	/// "all tests" to run successfully on a developer machine without Docker (skipping all integration tests).
+	/// 
+	/// Making tests skippable is mostly copied from https://github.com/xunit/samples.xunit/tree/main/DynamicSkipExample
+	/// </summary>
+	public class Tests : IClassFixture<DockerFtpServerFixture>
+	{
+		private readonly DockerFtpServerFixture _fixture;
+		private readonly string _host = "localhost";
+		private readonly string _user;
+		private readonly string _password;
+
+		public Tests(DockerFtpServerFixture fixture)
+		{
+			_fixture = fixture;
+			_user = _fixture.user;
+			_password = _fixture.password;
+		}
+
+		private FtpClient GetConnectedClient()
+		{
+			var client = new FtpClient(_host, _user, _password);
+			client.Connect();
+			return client;
+		}
+
+		#region Connect
+		[SkippableFact]
+		public async Task ConnectAsync()
+		{
+			using var ftpClient = new FtpClient(_host, _user, _password);
+			await ftpClient.ConnectAsync();
+			// Connect without error => pass
+			Assert.True(true);
+		}
+
+		[SkippableFact]
+		public void Connect()
+		{
+			using var ftpClient = new FtpClient(_host, _user, _password);
+			ftpClient.Connect();
+			// Connect without error => pass
+			Assert.True(true);
+		}
+
+		[SkippableFact]
+		public void AutoConnect()
+		{
+			using var ftpClient = new FtpClient(_host, _user, _password);
+			var profile = ftpClient.AutoConnect();
+			Assert.NotNull(profile);
+		}
+
+		[SkippableFact]
+		public async Task AutoConnectAsync()
+		{
+			using var ftpClient = new FtpClient(_host, _user, _password);
+			var profile = await ftpClient.AutoConnectAsync();
+			Assert.NotNull(profile);
+		}
+
+		[SkippableFact]
+		public void AutoDetect()
+		{
+			using var ftpClient = new FtpClient(_host, _user, _password);
+			var profiles = ftpClient.AutoDetect();
+			Assert.NotEmpty(profiles);
+		}
+
+		[SkippableFact]
+		public async Task AutoDetectAsync()
+		{
+			using var ftpClient = new FtpClient(_host, _user, _password);
+			var profiles = await ftpClient.AutoDetectAsync(false);
+			Assert.NotEmpty(profiles);
+		}
+		#endregion
+
+		#region UploadDownload
+		[SkippableFact]
+		public async Task UploadDownloadBytesAsync()
+		{
+			const string content = "Hello World!";
+			var bytes = Encoding.UTF8.GetBytes(content);
+
+			using var ftpClient = GetConnectedClient();
+
+			const string path = "/UploadDownloadBytesAsync/helloworld.txt";
+			var uploadStatus = await ftpClient.UploadBytesAsync(bytes, path, createRemoteDir: true);
+			Assert.Equal(FtpStatus.Success, uploadStatus);
+
+			var outBytes = await ftpClient.DownloadBytesAsync(path, CancellationToken.None);
+			Assert.NotNull(outBytes);
+
+			var outContent = Encoding.UTF8.GetString(outBytes);
+			Assert.Equal(content, outContent);
+		}
+
+		[SkippableFact]
+		public void UploadDownloadBytes()
+		{
+			const string content = "Hello World!";
+			var bytes = Encoding.UTF8.GetBytes(content);
+
+			using var ftpClient = GetConnectedClient();
+
+			const string path = "/UploadDownloadBytes/helloworld.txt";
+			var uploadStatus = ftpClient.UploadBytes(bytes, path, createRemoteDir: true);
+			Assert.Equal(FtpStatus.Success, uploadStatus);
+
+			var success = ftpClient.DownloadBytes(out var outBytes, path);
+			Assert.True(success);
+
+			var outContent = Encoding.UTF8.GetString(outBytes);
+			Assert.Equal(content, outContent);
+		}
+
+		[SkippableFact]
+		public async Task UploadDownloadStreamAsync()
+		{
+			const string content = "Hello World!";
+			using var stream = new MemoryStream();
+			using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
+			await streamWriter.WriteAsync(content);
+			await streamWriter.FlushAsync();
+			stream.Position = 0;
+
+			const string path = "/UploadDownloadStreamAsync/helloworld.txt";
+			using var ftpClient = GetConnectedClient();
+			var uploadStatus = await ftpClient.UploadStreamAsync(stream, path, createRemoteDir: true);
+			Assert.Equal(FtpStatus.Success, uploadStatus);
+
+			using var outStream = new MemoryStream();
+			var success = await ftpClient.DownloadStreamAsync(outStream, path);
+			Assert.True(success);
+
+			outStream.Position = 0;
+			using var streamReader = new StreamReader(outStream, Encoding.UTF8);
+			var outContent = await streamReader.ReadToEndAsync();
+			Assert.Equal(content, outContent);
+		}
+
+		[SkippableFact]
+		public void UploadDownloadStream()
+		{
+			const string content = "Hello World!";
+			using var stream = new MemoryStream();
+			using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
+			streamWriter.Write(content);
+			streamWriter.Flush();
+			stream.Position = 0;
+
+			const string path = "/UploadDownloadStreamAsync/helloworld.txt";
+			using var ftpClient = GetConnectedClient();
+			var uploadStatus = ftpClient.UploadStream(stream, path, createRemoteDir: true);
+			Assert.Equal(FtpStatus.Success, uploadStatus);
+
+			using var outStream = new MemoryStream();
+			var success = ftpClient.DownloadStream(outStream, path);
+			Assert.True(success);
+
+			outStream.Position = 0;
+			using var streamReader = new StreamReader(outStream, Encoding.UTF8);
+			var outContent = streamReader.ReadToEnd();
+			Assert.Equal(content, outContent);
+		}
+
+		#endregion
+
+		#region GetListing
+		[SkippableFact]
+		public async Task GetListingAsync()
+		{
+			using var client = GetConnectedClient();
+			var bytes = Encoding.UTF8.GetBytes("a");
+			const string directory = "/GetListingAsync/";
+			const string fileNameInRoot = "GetListingAsync.txt";
+			const string fileNameInDirectory = "GetListingAsyncInDirectory.txt";
+			await client.UploadBytesAsync(bytes, fileNameInRoot);
+			await client.UploadBytesAsync(bytes, directory + fileNameInDirectory, createRemoteDir: true);
+
+			var listRoot = await client.GetListingAsync();
+			Assert.Contains(listRoot, f => f.Name == fileNameInRoot);
+
+			var listDirectory = await client.GetListingAsync(directory);
+			Assert.Contains(listDirectory, f => f.Name == fileNameInDirectory);
+
+			await client.SetWorkingDirectoryAsync(directory);
+			var listCurrentDirectory = await client.GetListingAsync();
+			Assert.Contains(listCurrentDirectory, f => f.Name == fileNameInDirectory);
+		}
+
+		[SkippableFact]
+		public void GetListing()
+		{
+			using var client = GetConnectedClient();
+			var bytes = Encoding.UTF8.GetBytes("a");
+			const string directory = "/GetListing/";
+			const string fileNameInRoot = "GetListing.txt";
+			const string fileNameInDirectory = "GetListingInDirectory.txt";
+			client.UploadBytes(bytes, fileNameInRoot);
+			client.UploadBytes(bytes, directory + fileNameInDirectory, createRemoteDir: true);
+
+			var listRoot = client.GetListing();
+			Assert.Contains(listRoot, f => f.Name == fileNameInRoot);
+
+			var listDirectory = client.GetListing(directory);
+			Assert.Contains(listDirectory, f => f.Name == fileNameInDirectory);
+
+			client.SetWorkingDirectory(directory);
+			var listCurrentDirectory = client.GetListing();
+			Assert.Contains(listCurrentDirectory, f => f.Name == fileNameInDirectory);
+		}
+		#endregion
+	}
+}

--- a/FluentFTP.Tests.Integration/Usings.cs
+++ b/FluentFTP.Tests.Integration/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/FluentFTP.sln
+++ b/FluentFTP.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentFTP.Tests", "FluentFT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentFTPServer", "FluentFTPServer\FluentFTPServer.csproj", "{7ED366D7-5ABD-487C-8632-81A025644B15}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentFTP.Tests.Integration", "FluentFTP.Tests.Integration\FluentFTP.Tests.Integration.csproj", "{1293DE96-A14F-42B5-B5AE-026DAF1EFC13}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,14 @@ Global
 		{7ED366D7-5ABD-487C-8632-81A025644B15}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7ED366D7-5ABD-487C-8632-81A025644B15}.Release|x64.ActiveCfg = Release|Any CPU
 		{7ED366D7-5ABD-487C-8632-81A025644B15}.Release|x64.Build.0 = Release|Any CPU
+		{1293DE96-A14F-42B5-B5AE-026DAF1EFC13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1293DE96-A14F-42B5-B5AE-026DAF1EFC13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1293DE96-A14F-42B5-B5AE-026DAF1EFC13}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1293DE96-A14F-42B5-B5AE-026DAF1EFC13}.Debug|x64.Build.0 = Debug|Any CPU
+		{1293DE96-A14F-42B5-B5AE-026DAF1EFC13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1293DE96-A14F-42B5-B5AE-026DAF1EFC13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1293DE96-A14F-42B5-B5AE-026DAF1EFC13}.Release|x64.ActiveCfg = Release|Any CPU
+		{1293DE96-A14F-42B5-B5AE-026DAF1EFC13}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Related to #816
I noticed @robinrodricks is in the process of implementing a process for this.
I don't know how @robinrodricks is planning to complete his process, and thus I don't know how much this method overlaps/conflicts with his.
Feel free to ask for changes, or use code/ideas from this, or ignore if you don't find it useful.

This method will run 1 single type of ftp-server when run on developer computer.
If the developer is not running Docker, then the integration tests are skipped.
Will run all types of ftp-server on pull-request and push to master.
I have only added 2 ftp-server types (pure-ftpd and vsftpd).

The "Skippable*" files are mostly copied from https://github.com/xunit/samples.xunit/tree/main/DynamicSkipExample
Modified to allow setting "skip all integration tests" (Skippable.SkippableState.ShouldSkip = true;) in DockerFtpServerFixture.cs

Adding new ftp server:
DockerFtpServerFixture.cs:
	Add method that returns ITestcontainersBuilder<TestcontainersContainer> for the ftp server.
		See https://github.com/testcontainers/testcontainers-dotnet
	Add new method to mapping function GetContainer(string? key).
	Add new mapping key to .github/workflows/pull_request.yml matrix
        - ftp: pure-ftpd (key matching function GetContainer(string? key))
          os: ubuntu-latest