### PR TITLE
Configure containers.

### DIFF
--- a/.github/workflows_WIP/pull_request.yml
+++ b/.github/workflows_WIP/pull_request.yml
@@ -13,9 +13,11 @@ jobs:
     strategy:
       matrix:
         include:
-        - ftp: pure-ftpd
+        - ftp: pureftpd
           os: ubuntu-latest
         - ftp: vsftpd
+          os: ubuntu-latest
+        - ftp: pyftpdlib
           os: ubuntu-latest
           
     runs-on: ${{ matrix.os }}
@@ -29,8 +31,8 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build FluentFTP.Tests.Integration/FluentFTP.Tests.Integration.csproj --no-restore --framework ${{ env.framework }}
+      run: dotnet build FluentFTP.Tests/FluentFTP.Tests.csproj --no-restore --framework ${{ env.framework }}
     - name: Test
       env:
         FluentFTP__Tests__Integration__FtpServerKey: ${{ matrix.ftp }}
-      run: dotnet test FluentFTP.Tests.Integration/FluentFTP.Tests.Integration.csproj --no-build --verbosity normal --framework ${{ env.framework }}
+      run: dotnet test FluentFTP.Tests/FluentFTP.Tests.csproj --no-build --verbosity normal --framework ${{ env.framework }}

--- a/FluentFTP.Tests/DockerCollection.cs
+++ b/FluentFTP.Tests/DockerCollection.cs
@@ -1,0 +1,15 @@
+﻿using FluentFTP.Xunit.Docker;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FluentFTP.Tests
+{
+	[CollectionDefinition("DockerCollection")]
+	public class DockerCollection : ICollectionFixture<DockerFtpServerFixture>
+	{
+	}
+}

--- a/FluentFTP.Tests/Integration/IntegrationTestSuite.cs
+++ b/FluentFTP.Tests/Integration/IntegrationTestSuite.cs
@@ -10,7 +10,8 @@ using FluentFTP.Xunit.Docker;
 using FluentFTP.Xunit.Attributes;
 
 namespace FluentFTP.Tests.Integration {
-	public class IntegrationTestSuite : IClassFixture<DockerFtpServerFixture> {
+	[Collection("DockerCollection")]
+	public class IntegrationTestSuite {
 
 		protected readonly DockerFtpServerFixture _fixture;
 

--- a/FluentFTP.Xunit/Attributes/Internal/SkippableTheoryDiscoverer.cs
+++ b/FluentFTP.Xunit/Attributes/Internal/SkippableTheoryDiscoverer.cs
@@ -1,4 +1,4 @@
-﻿using FluentFTP.Xunit.Attributes.Internal;
+﻿using FluentFTP.Xunit.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace FluentFTP.Xunit.Internal {
+namespace FluentFTP.Xunit.Attributes.Internal {
 	internal class SkippableTheoryDiscoverer : IXunitTestCaseDiscoverer {
 		readonly IMessageSink diagnosticMessageSink;
 		readonly TheoryDiscoverer theoryDiscoverer;

--- a/FluentFTP.Xunit/Attributes/SkippableFactAttribute.cs
+++ b/FluentFTP.Xunit/Attributes/SkippableFactAttribute.cs
@@ -7,6 +7,6 @@ using Xunit;
 using Xunit.Sdk;
 
 namespace FluentFTP.Xunit.Attributes {
-	[XunitTestCaseDiscoverer("FluentFTP.Xunit.Internal.SkippableFactDiscoverer", "FluentFTP.Tests.Integration")]
+	[XunitTestCaseDiscoverer("FluentFTP.Xunit.Attributes.Internal.SkippableFactDiscoverer", "FluentFTP.Xunit")]
 	public class SkippableFactAttribute : FactAttribute { }
 }

--- a/FluentFTP.Xunit/Attributes/SkippableTheoryAttribute.cs
+++ b/FluentFTP.Xunit/Attributes/SkippableTheoryAttribute.cs
@@ -7,6 +7,6 @@ using Xunit;
 using Xunit.Sdk;
 
 namespace FluentFTP.Xunit.Attributes {
-	[XunitTestCaseDiscoverer("FluentFTP.Xunit.Internal.SkippableTheoryDiscoverer", "FluentFTP.Tests.Integration")]
+	[XunitTestCaseDiscoverer("FluentFTP.Xunit.Attributes.Internal.SkippableTheoryDiscoverer", "FluentFTP.Xunit")]
 	public class SkippableTheoryAttribute : TheoryAttribute { }
 }

--- a/FluentFTP.Xunit/Docker/Containers/CrushFtpContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/CrushFtpContainer.cs
@@ -22,22 +22,23 @@ namespace FluentFTP.Xunit.Docker.Containers {
 		/// <summary>
 		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
 		/// </summary>
-		public override void Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
 
-			builder
+			builder = builder
 				.WithPortBinding(443)
 				.WithPortBinding(2222)
 				.WithPortBinding(8080)
 				.WithPortBinding(9090);
 
-			ExposePortRange(builder, 2000, 2100);
-
-			builder
+			builder = ExposePortRange(builder, 2000, 2100);
+			//todo AutoConnect failing: FtpInvalidCertificateException : FTPS security could not be established on the server. The certificate was not accepted.
+			//todo volume
+			builder = builder
 				.WithEnvironment("CRUSH_ADMIN_USER", DockerFtpConfig.FtpUser)
 				.WithEnvironment("CRUSH_ADMIN_PASSWORD", DockerFtpConfig.FtpPass)
 				.WithEnvironment("CRUSH_ADMIN_PORT", "8080");
 
-
+			return builder;
 		}
 	}
 }

--- a/FluentFTP.Xunit/Docker/Containers/FileZillaContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/FileZillaContainer.cs
@@ -11,6 +11,7 @@ namespace FluentFTP.Xunit.Docker.Containers {
 		public FileZillaContainer() {
 			Type = FtpServer.FileZilla;
 			ServerType = "filezilla";
+			//todo Find server. This seems to be only the client (accessable via webUI).
 			DockerImage = "jlesage/filezilla";
 			DockerGithub = "https://github.com/jlesage/docker-filezilla";
 			//RunCommand = "docker run -d --name=filezilla -p 5800:5800 -v /docker/appdata/filezilla:/config:rw -v $HOME:/storage:rw filezilla:fluentftp";
@@ -21,13 +22,14 @@ namespace FluentFTP.Xunit.Docker.Containers {
 		/// <summary>
 		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
 		/// </summary>
-		public override void Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
 
-			builder
+			builder = builder
 				.WithPortBinding(5800)
 				.WithBindMount("/docker/appdata/filezilla", "/config:rw")
 				.WithBindMount("$HOME", "/storage:rw");
 
+			return builder;
 		}
 	}
 }

--- a/FluentFTP.Xunit/Docker/Containers/GlFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/GlFtpdContainer.cs
@@ -22,9 +22,11 @@ namespace FluentFTP.Xunit.Docker.Containers {
 		/// <summary>
 		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
 		/// </summary>
-		public override void Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
-			builder
+		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+			builder = builder
 				.WithEnvironment("GL_PORT", "21");
+			//todo fails during build. Unknown cause.
+			return builder;
 		}
 	}
 }

--- a/FluentFTP.Xunit/Docker/Containers/ProFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/ProFtpdContainer.cs
@@ -20,16 +20,20 @@ namespace FluentFTP.Xunit.Docker.Containers {
 		/// <summary>
 		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
 		/// </summary>
-		public override void Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
 
-			ExposePortRange(builder, 50000, 50100);
+			builder = ExposePortRange(builder, 50000, 50100);
 
-			builder
+			builder = builder
 				.WithEnvironment("FTP_LIST", DockerFtpConfig.FtpUser + ":" + DockerFtpConfig.FtpPass)
 				.WithEnvironment("PASSIVE_MIN_PORT", "50000")
 				.WithEnvironment("PASSIVE_MAX_PORT", "50100")
-				.WithEnvironment("MASQUERADE_ADDRESS", "1.2.3.4");
+				.WithEnvironment("MASQUERADE_ADDRESS", "127.0.0.1");
+				
+				//todo Volume for user home
+				// -v /path_to_ftp_dir_for_user1:/home/user1
 
+			return builder;
 		}
 	}
 }

--- a/FluentFTP.Xunit/Docker/Containers/PureFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/PureFtpdContainer.cs
@@ -21,15 +21,16 @@ namespace FluentFTP.Xunit.Docker.Containers {
 		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
 		/// </summary>
 
-		public override void Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
 
-			ExposePortRange(builder, 30000, 30009);
+			builder = ExposePortRange(builder, 30000, 30009);
 
-			builder
+			builder = builder
 				.WithEnvironment("FTP_USER_NAME", DockerFtpConfig.FtpUser)
 				.WithEnvironment("FTP_USER_PASS", DockerFtpConfig.FtpPass)
 				.WithEnvironment("FTP_USER_HOME", "/home/bob");
 
+			return builder;
 		}
 
 	}

--- a/FluentFTP.Xunit/Docker/Containers/PyFtpdLibContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/PyFtpdLibContainer.cs
@@ -21,10 +21,10 @@ namespace FluentFTP.Xunit.Docker.Containers {
 		/// <summary>
 		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
 		/// </summary>
-		public override void Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
 
-			// no config required
-
+			builder = base.ExposePortRange(builder, 3000, 3010);
+			return builder;
 		}
 	}
 }

--- a/FluentFTP.Xunit/Docker/Containers/VsFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/VsFtpdContainer.cs
@@ -20,18 +20,19 @@ namespace FluentFTP.Xunit.Docker.Containers {
 		/// <summary>
 		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
 		/// </summary>
-		public override void Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
 
-			builder.WithPortBinding(20)
+			builder = builder.WithPortBinding(20)
 				.WithPortBinding(21);
 
-			ExposePortRange(builder, 21100, 21110);
+			builder = ExposePortRange(builder, 21100, 21110);
 
-			builder
+			builder = builder
 				.WithEnvironment("PASV_ADDRESS", "127.0.0.1")
 				.WithEnvironment("FTP_USER", DockerFtpConfig.FtpUser)
 				.WithEnvironment("FTP_PASS", DockerFtpConfig.FtpPass);
 
+			return builder;
 		}
 
 	}

--- a/FluentFTP.Xunit/Docker/DockerFtpContainer.cs
+++ b/FluentFTP.Xunit/Docker/DockerFtpContainer.cs
@@ -17,31 +17,34 @@ namespace FluentFTP.Xunit.Docker {
 		public string FixedUsername;
 		public string FixedPassword;
 
-		public virtual void Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+		public virtual ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+			return builder;
 		}
 		
 		public virtual TestcontainersContainer Build() {
-
+			
 			var builder = new TestcontainersBuilder<TestcontainersContainer>()
 				.WithImage(DockerImage)
 				.WithName(ServerType)
 				.WithPortBinding(21);
 
-			this.Configure(builder);
+			builder = this.Configure(builder);
 
-			builder.WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(21));
+			builder = builder.WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(21));
 
 			var container = builder.Build();
 
 			return container;
 		}
 
-		protected void ExposePortRange(ITestcontainersBuilder<TestcontainersContainer> builder, int startPort, int endPort) {
+		protected ITestcontainersBuilder<TestcontainersContainer> ExposePortRange(ITestcontainersBuilder<TestcontainersContainer> builder, int startPort, int endPort) {
 
 			for (var port = startPort; port <= endPort; port++) {
-				builder.WithExposedPort(port);
-				builder.WithPortBinding(port);
+				builder = builder.WithExposedPort(port);
+				builder = builder.WithPortBinding(port);
 			}
+
+			return builder;
 		}
 
 	}

--- a/FluentFTP.Xunit/Docker/DockerFtpServerFixture.cs
+++ b/FluentFTP.Xunit/Docker/DockerFtpServerFixture.cs
@@ -61,7 +61,7 @@ namespace FluentFTP.Xunit.Docker {
 		}
 
 
-		private async void StartContainer() {
+		private void StartContainer() {
 			if (_server != null) {
 				try {
 					// dispose existing container if any


### PR DESCRIPTION
Correct namespace for SkippableAttributes.
Correct chaining of TestcontainerBuilder.
Change Fixture to CollectionFixture.
Refactor timeout test.
Add SocketException to accept criteria (occurs when running in GitHub Actions).

This PR is a few fixes to get the TestcontainersBuilder back to working in new structure.
Change Fixture to CollectionFixture, from ClassFixture, to keep the same container instance running for all test classes.