### PR TITLE
Catch errors in async tests.

### DIFF
--- a/FluentFTP.Tests/Integration/IntegrationTests.cs
+++ b/FluentFTP.Tests/Integration/IntegrationTests.cs
@@ -10,32 +10,32 @@ namespace FluentFTP.Tests.Integration {
 	public class IntegrationTests {
 
 		[Fact]
-		public void CrushFtp() {
-			IntegrationTestRunner.Run(FtpServer.CrushFTP);
+		public async Task CrushFtp() {
+			await IntegrationTestRunner.Run(FtpServer.CrushFTP);
 		}
 		[Fact]
-		public void FileZilla() {
-			IntegrationTestRunner.Run(FtpServer.FileZilla);
+		public async Task FileZilla() {
+			await IntegrationTestRunner.Run(FtpServer.FileZilla);
 		}
 		[Fact]
-		public void GlFtpd() {
-			IntegrationTestRunner.Run(FtpServer.glFTPd);
+		public async Task GlFtpd() {
+			await IntegrationTestRunner.Run(FtpServer.glFTPd);
 		}
 		[Fact]
-		public void ProFtpd() {
-			IntegrationTestRunner.Run(FtpServer.ProFTPD);
+		public async Task ProFtpd() {
+			await IntegrationTestRunner.Run(FtpServer.ProFTPD);
 		}
 		[Fact]
-		public void PureFtpd() {
-			IntegrationTestRunner.Run(FtpServer.PureFTPd);
+		public async Task PureFtpd() {
+			await IntegrationTestRunner.Run(FtpServer.PureFTPd);
 		}
 		[Fact]
-		public void PyFtpdLib() {
-			IntegrationTestRunner.Run(FtpServer.PyFtpdLib);
+		public async Task PyFtpdLib() {
+			await IntegrationTestRunner.Run(FtpServer.PyFtpdLib);
 		}
 		[Fact]
-		public void VsFtpd() {
-			IntegrationTestRunner.Run(FtpServer.VsFTPd);
+		public async Task VsFtpd() {
+			await IntegrationTestRunner.Run(FtpServer.VsFTPd);
 		}
 
 	}

--- a/FluentFTP.Tests/Integration/System/IntegrationTestRunner.cs
+++ b/FluentFTP.Tests/Integration/System/IntegrationTestRunner.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace FluentFTP.Tests.Integration.System {
 	internal static class IntegrationTestRunner {
 
-		public static void Run(FtpServer serverType) {
+		public static async Task Run(FtpServer serverType) {
 
 			// If we are in CI pipeline
 			if (DockerFtpConfig.IsCI) {
@@ -32,11 +32,9 @@ namespace FluentFTP.Tests.Integration.System {
 
 				// run all types of async tests
 				// TODO: create a better system instead of calling each test suite manually
-				Task.Run(async () => {
-					await new ConnectTests(server).RunAllTestsAsync();
-					await new FileTransferTests(server).RunAllTestsAsync();
-					await new ListingTests(server).RunAllTestsAsync();
-				});
+				await new ConnectTests(server).RunAllTestsAsync();
+				await new FileTransferTests(server).RunAllTestsAsync();
+				await new ListingTests(server).RunAllTestsAsync();
 
 			}
 			catch (Exception ex) {


### PR DESCRIPTION
Bugfix observe exceptions from async tests.
Since the Task.Run was not awaited the tests would ignore exceptions.
Changed tests to async Task to remove need for Task.Run and instead await the tests directly.