### PR TITLE
#910 Add CompareFile & CompareFIleAsync to IFtpClient

### DIFF
--- a/FluentFTP/Client/IFtpClient.cs
+++ b/FluentFTP/Client/IFtpClient.cs
@@ -260,5 +260,13 @@ namespace FluentFTP {
 		Task<FtpHash> GetChecksumAsync(string path, FtpHashAlgorithm algorithm = FtpHashAlgorithm.NONE, CancellationToken token = default(CancellationToken));
 
 #endif
+
+		// FILECOMPARE
+		FtpCompareResult CompareFile(string localPath, string remotePath, FtpCompareOption options = FtpCompareOption.Auto);
+
+#if ASYNC
+		Task<FtpCompareResult> CompareFileAsync(string localPath, string remotePath, FtpCompareOption options = FtpCompareOption.Auto, CancellationToken token = default(CancellationToken));
+
+#endif
 	}
 }


### PR DESCRIPTION
Being a total noob to this library, I found myself in need having the CompareFIle & CompareFIleAsync in IFtpClient for unit testing purposes.

I could not find any reasons why the should not be there. If there are please enlighten me :)

I had som issues running all integrationtests, even prior to making any change - but I believe that this is related to #903