### PR TITLE
Make vsftpd Dockerfile work

### DIFF
--- a/FluentFTP.Dockers/vsftpd/Dockerfile
+++ b/FluentFTP.Dockers/vsftpd/Dockerfile
@@ -35,8 +35,11 @@ ENV PASV_PROMISCUOUS NO
 ENV PORT_PROMISCUOUS NO
 
 COPY vsftpd.conf /etc/vsftpd/
+RUN sed -i -e "s/\r//" /etc/vsftpd/vsftpd.conf
 COPY vsftpd_virtual /etc/pam.d/
+RUN sed -i -e "s/\r//" /etc/pam.d/vsftpd_virtual
 COPY run-vsftpd.sh /usr/sbin/
+RUN sed -i -e "s/\r//" /usr/sbin/run-vsftpd.sh
 
 RUN chmod +x /usr/sbin/run-vsftpd.sh
 RUN mkdir -p /home/vsftpd/

--- a/FluentFTP.Tests/Integration/System/IntegrationTestRunner.cs
+++ b/FluentFTP.Tests/Integration/System/IntegrationTestRunner.cs
@@ -20,7 +20,7 @@ namespace FluentFTP.Tests.Integration.System {
 			}
 
 			// spin up a new docker
-			var server = new DockerFtpServer(serverType);
+			using var server = new DockerFtpServer(serverType);
 
 			try {
 
@@ -41,8 +41,6 @@ namespace FluentFTP.Tests.Integration.System {
 				Assert.True(false, $"Integration test failed : " + ex.ToString());
 			}
 
-			// shut down the docker
-			server.Dispose();
 
 		}
 

--- a/FluentFTP.Xunit/Docker/DockerFtpServer.cs
+++ b/FluentFTP.Xunit/Docker/DockerFtpServer.cs
@@ -27,11 +27,17 @@ namespace FluentFTP.Xunit.Docker {
 			StartContainer();
 		}
 
-		public void Dispose() {
-			_container?.DisposeAsync();
+		~DockerFtpServer() {
+			Dispose(false);
+		}
 
-			// Run system command to shut down docker
-			SystemProcess.Execute("docker stop " + _server.DockerImage);
+		public void Dispose() {
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool _) {
+			_container?.DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 		}
 
 		public string GetUsername() {


### PR DESCRIPTION
Make Dispose wait for completion to avoid starting next container before the previous is shut down.
Add finalizer to call Dispose if an exception is thrown in constructor.