### PR TITLE
Fix fix #909

### DIFF
--- a/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
@@ -168,7 +168,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// <summary>
 		/// Return true if the path should be converted to an absolute path.
 		/// </summary>
-		public virtual bool ConvertListingPath(string path) {
+		public override bool ConvertListingPath(string path) {
 
 			// Only disable the GetAbsolutePath(path) if z/OS
 			// Note: "TEST.TST" is a "path" that does not start with a slash

--- a/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
@@ -170,7 +170,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// </summary>
 		public override bool ConvertListingPath(string path) {
 
-			// Only disable the GetAbsolutePath(path) if z/OS
+			// Disable the GetAbsolutePath(path) if z/OS
 			// Note: "TEST.TST" is a "path" that does not start with a slash
 			// This could be a unix file on z/OS OR a classic CWD relative dataset
 			// Both of these work with the z/OS FTP server LIST command


### PR DESCRIPTION
Refactoring of `IbmZosFtpServer.cs`:

Small oversight/typo, discovered on further testing.

`ConvertListingPath` was never being called. Thus, file sizes were only correct for z/OS unix files.