### PR TITLE
Better version of Fix 909

### DIFF
--- a/FluentFTP/Client/FtpClient_FileManagement.cs
+++ b/FluentFTP/Client/FtpClient_FileManagement.cs
@@ -105,13 +105,8 @@ namespace FluentFTP {
 
 				LogFunc(nameof(FileExists), new object[] { path });
 
-				// A check for path.StartsWith("/") tells us, even if it is z/OS, we can use the normal unix logic
-
-				// If z/OS: Do not GetAbsolutePath(), unless we have a leading slash
-				if (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/")) {
-					// calc the absolute filepath
-					path = GetAbsolutePath(path);
-				}
+				// calc the absolute filepath
+				path = GetAbsolutePath(path);
 
 				// since FTP does not include a specific command to check if a file exists
 				// here we check if file exists by attempting to get its filesize (SIZE)
@@ -199,13 +194,8 @@ namespace FluentFTP {
 
 			LogFunc(nameof(FileExistsAsync), new object[] { path });
 
-			// A check for path.StartsWith("/") tells us, even if it is z/OS, we can use the normal unix logic
-
-			// Do not need GetAbsolutePath(path) if z/OS
-			if (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/")) {
-				// calc the absolute filepath
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			// calc the absolute filepath
+			path = await GetAbsolutePathAsync(path, token);
 
 			// since FTP does not include a specific command to check if a file exists
 			// here we check if file exists by attempting to get its filesize (SIZE)

--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -260,9 +260,7 @@ namespace FluentFTP {
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
 			// calc the absolute filepath
-			if (ServerHandler == null || ServerHandler.ConvertListingPath(path)) {
-				path = GetAbsolutePath(path);
-			}
+			path = GetAbsolutePath(path);
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option
@@ -634,9 +632,7 @@ namespace FluentFTP {
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
 			// calc the absolute filepath
-			if (ServerHandler == null || ServerHandler.ConvertListingPath(path)) {
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			path = await GetAbsolutePathAsync(path, token);
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option
@@ -752,9 +748,7 @@ namespace FluentFTP {
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
 			// calc the absolute filepath
-			if (ServerHandler == null || ServerHandler.ConvertListingPath(path)) {
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			path = await GetAbsolutePathAsync(path, token);
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option
@@ -1166,10 +1160,8 @@ namespace FluentFTP {
 
 			var listing = new List<string>();
 
-			if (ServerType != FtpServer.IBMzOSFTP || path == null || path.StartsWith("/")) {
-				// calc path to request
-				path = GetAbsolutePath(path);
-			}
+			// calc path to request
+			path = GetAbsolutePath(path);
 
 #if !CORE14
 			lock (m_lock) {
@@ -1277,10 +1269,8 @@ namespace FluentFTP {
 
 			var listing = new List<string>();
 
-			if (ServerType != FtpServer.IBMzOSFTP || path == null || path.StartsWith("/")) {
-				// calc path to request
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			// calc path to request
+			path = await GetAbsolutePathAsync(path, token);
 
 			// always get the file listing in binary to avoid character translation issues with ASCII.
 			await SetDataTypeNoLockAsync(ListingDataType, token);

--- a/FluentFTP/Client/FtpClient_Utils.cs
+++ b/FluentFTP/Client/FtpClient_Utils.cs
@@ -92,6 +92,12 @@ namespace FluentFTP {
 		/// </summary>
 		private string GetAbsolutePath(string path) {
 
+			// if its a server-specific absolute path then don't add base dir
+			if (ServerHandler != null && ServerHandler.IsAbsolutePath(path))
+			{
+				return path;
+			}
+
 			if (path == null || path.Trim().Length == 0) {
 				// if path not given, then use working dir
 				var pwd = GetWorkingDirectory();
@@ -107,11 +113,6 @@ namespace FluentFTP {
 			// FIX : #153 ensure this check works with unix & windows
 			// FIX : #454 OpenVMS paths can be a single character
 			else if (!path.StartsWith("/") && !(path.Length > 1 && path[1] == ':')) {
-
-				// if its a server-specific absolute path then don't add base dir
-				if (ServerHandler != null && ServerHandler.IsAbsolutePath(path)) {
-					return path;
-				}
 
 				// if relative path given then add working dir to calc full path
 				var pwd = GetWorkingDirectory();
@@ -134,6 +135,12 @@ namespace FluentFTP {
 		/// </summary>
 		private async Task<string> GetAbsolutePathAsync(string path, CancellationToken token) {
 
+			// if its a server-specific absolute path then don't add base dir
+			if (ServerHandler != null && ServerHandler.IsAbsolutePath(path))
+			{
+				return path;
+			}
+
 			if (path == null || path.Trim().Length == 0) {
 				// if path not given, then use working dir
 				string pwd = await GetWorkingDirectoryAsync(token);
@@ -148,11 +155,6 @@ namespace FluentFTP {
 			// FIX : #153 ensure this check works with unix & windows
 			// FIX : #454 OpenVMS paths can be a single character
 			else if (!path.StartsWith("/") && !(path.Length > 1 && path[1] == ':')) {
-
-				// if its a server-specific absolute path then don't add base dir
-				if (ServerHandler != null && ServerHandler.IsAbsolutePath(path)) {
-					return path;
-				}
 
 				// if relative path given then add working dir to calc full path
 				string pwd = await GetWorkingDirectoryAsync(token);

--- a/FluentFTP/Client/FtpClient_Utils.cs
+++ b/FluentFTP/Client/FtpClient_Utils.cs
@@ -116,11 +116,6 @@ namespace FluentFTP {
 				// if relative path given then add working dir to calc full path
 				var pwd = GetWorkingDirectory();
 				if (pwd != null && pwd.Trim().Length > 0 && path != pwd) {
-					// Check if PDS (MVS Dataset) file system
-					if (pwd.StartsWith("'") && ServerType == FtpServer.IBMzOSFTP) {
-						// PDS that has single quotes is already fully qualified
-						return pwd;
-					}
 
 					if (path.StartsWith("./")) {
 						path = path.Remove(0, 2);

--- a/FluentFTP/Servers/FtpBaseServer.cs
+++ b/FluentFTP/Servers/FtpBaseServer.cs
@@ -61,13 +61,6 @@ namespace FluentFTP.Servers {
 		}
 
 		/// <summary>
-		/// Return true if the path should be converted to an absolute path.
-		/// </summary>
-		public virtual bool ConvertListingPath(string path) {
-			return true;
-		}
-
-		/// <summary>
 		/// Return the default file listing parser to be used with your FTP server.
 		/// </summary>
 		public virtual FtpParser GetParser() {

--- a/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
@@ -166,15 +166,11 @@ namespace FluentFTP.Servers.Handlers {
 		}
 
 		/// <summary>
-		/// Return true if the path should be converted to an absolute path.
+		/// Consider all z/OS paths to be absolute
 		/// </summary>
-		public virtual bool ConvertListingPath(string path) {
-
-			// Only disable the GetAbsolutePath(path) if z/OS
-			// Note: "TEST.TST" is a "path" that does not start with a slash
-			// This could be a unix file on z/OS OR a classic CWD relative dataset
-			// Both of these work with the z/OS FTP server LIST command
-			return path == null || path.StartsWith("/");
+		public override bool IsAbsolutePath(string path)
+		{
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
Looking at the code of `GetAbsolutePath(...)`, one can see that it contains a nifty check using `ServerHandler.IsAbsolutePath(...)`.

When I was wrapping the `GetAbsolutePath(...)` calls with checks for z/OS, I had not seen that - it actually is the cleaner way and so a z/OS specific `IsAbsolutePath` is the better way to go.

This tidies up many instances where `GetAbsolutePath(...)` is used.

It means also, we no longer need the newly created `ConvertListingPath(...)` after all.

Question:

Couldn`t we move 
```
				// if its a server-specific absolute path then don't add base dir
				if (ServerHandler != null && ServerHandler.IsAbsolutePath(path)) {
					return path;
				}
```
to the top, before any other processing is done? Would this hurt the only other user (OpenVMS) of `IsAbsolutePath(...)`?

I will do it in this PR, but I would like to discuss that with you.