### PR TITLE
Custom GetAbsolutePath

### DIFF
--- a/FluentFTP/Client/FtpClient_FileDownload.cs
+++ b/FluentFTP/Client/FtpClient_FileDownload.cs
@@ -683,7 +683,7 @@ namespace FluentFTP {
 				// we read until EOF instead of reading a specific number of bytes
 				var readToEnd = (fileLen <= 0) || 
 								(DownloadDataType == FtpDataType.ASCII) || 
-								(ServerType == FtpServer.IBMzOSFTP);
+								(ServerHandler != null && ServerHandler.AlwaysReadToEnd(remotePath));
 
 				const int rateControlResolution = 100;
 				var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;
@@ -920,8 +920,8 @@ namespace FluentFTP {
 				// if the server is IBM z/OS
 				// we read until EOF instead of reading a specific number of bytes
 				var readToEnd = (fileLen <= 0) || 
-								(DownloadDataType == FtpDataType.ASCII) || 
-								(ServerType == FtpServer.IBMzOSFTP);
+								(DownloadDataType == FtpDataType.ASCII) ||
+								(ServerHandler != null && ServerHandler.AlwaysReadToEnd(remotePath));
 
 				const int rateControlResolution = 100;
 				var rateLimitBytes = DownloadRateLimit != 0 ? (long)DownloadRateLimit * 1024 : 0;

--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -259,10 +259,7 @@ namespace FluentFTP {
 			var isGetModified = options.HasFlag(FtpListOption.Modify);
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
-			// calc the absolute filepath
-			if (ServerHandler == null || ServerHandler.ConvertListingPath(path)) {
-				path = GetAbsolutePath(path);
-			}
+			path = GetAbsolutePath(path);
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option
@@ -632,10 +629,7 @@ namespace FluentFTP {
 			var isGetModified = options.HasFlag(FtpListOption.Modify);
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
-			// calc the absolute filepath
-			if (ServerHandler == null || ServerHandler.ConvertListingPath(path)) {
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			path = await GetAbsolutePathAsync(path, token);
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option
@@ -750,10 +744,7 @@ namespace FluentFTP {
 			var isGetModified = options.HasFlag(FtpListOption.Modify);
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
-			// calc the absolute filepath
-			if (ServerHandler == null || ServerHandler.ConvertListingPath(path)) {
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			path = await GetAbsolutePathAsync(path, token);
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option

--- a/FluentFTP/Client/FtpClient_Utils.cs
+++ b/FluentFTP/Client/FtpClient_Utils.cs
@@ -92,6 +92,10 @@ namespace FluentFTP {
 		/// </summary>
 		private string GetAbsolutePath(string path) {
 
+			if (ServerHandler != null && ServerHandler.IsCustomGetAbsolutePath())	{
+				return ServerHandler.GetAbsolutePath(this, path);
+			}
+
 			if (path == null || path.Trim().Length == 0) {
 				// if path not given, then use working dir
 				var pwd = GetWorkingDirectory();
@@ -116,12 +120,6 @@ namespace FluentFTP {
 				// if relative path given then add working dir to calc full path
 				var pwd = GetWorkingDirectory();
 				if (pwd != null && pwd.Trim().Length > 0 && path != pwd) {
-					// Check if PDS (MVS Dataset) file system
-					if (pwd.StartsWith("'") && ServerType == FtpServer.IBMzOSFTP) {
-						// PDS that has single quotes is already fully qualified
-						return pwd;
-					}
-
 					if (path.StartsWith("./")) {
 						path = path.Remove(0, 2);
 					}
@@ -161,7 +159,7 @@ namespace FluentFTP {
 
 				// if relative path given then add working dir to calc full path
 				string pwd = await GetWorkingDirectoryAsync(token);
-				if (pwd != null && pwd.Trim().Length > 0) {
+				if (pwd != null && pwd.Trim().Length > 0 && path != pwd) {
 					if (path.StartsWith("./")) {
 						path = path.Remove(0, 2);
 					}

--- a/FluentFTP/Servers/FtpBaseServer.cs
+++ b/FluentFTP/Servers/FtpBaseServer.cs
@@ -54,20 +54,6 @@ namespace FluentFTP.Servers {
 		}
 
 		/// <summary>
-		/// Return true if the path is an absolute path according to your server's convention.
-		/// </summary>
-		public virtual bool IsAbsolutePath(string path) {
-			return false;
-		}
-
-		/// <summary>
-		/// Return true if the path should be converted to an absolute path.
-		/// </summary>
-		public virtual bool ConvertListingPath(string path) {
-			return true;
-		}
-
-		/// <summary>
 		/// Return the default file listing parser to be used with your FTP server.
 		/// </summary>
 		public virtual FtpParser GetParser() {
@@ -131,12 +117,14 @@ namespace FluentFTP.Servers {
 #endif
 		}
 #endif
-			/// <summary>
-			/// Return true if your server requires custom handling of file size.
-			/// </summary>
+
+		/// <summary>
+		/// Return true if your server requires custom handling of file size.
+		/// </summary>
 		public virtual bool IsCustomFileSize() {
 			return false;
 		}
+
 		/// <summary>
 		/// Perform server-specific file size fetching commands here.
 		/// Return the file size in bytes.
@@ -154,6 +142,7 @@ namespace FluentFTP.Servers {
 			return Task.FromResult(0L);
 		}
 #endif
+
 		/// <summary>
 		/// Check if the given path is a root directory on your FTP server.
 		/// If you are unsure, return false.
@@ -165,10 +154,49 @@ namespace FluentFTP.Servers {
 		/// <summary>
 		/// Skip reporting a parser error
 		/// </summary>
-		public virtual bool SkipParserErrorReport()
+		public virtual bool SkipParserErrorReport()	{
+			return false;
+		}
+
+		/// <summary>
+		/// Always read to end of stream on a download
+		/// If you are unsure, return false.
+		/// </summary>
+		public virtual bool AlwaysReadToEnd(string remotePath) {
+			return false;
+		}
+
+		/// <summary>
+		/// Return true if the path is an absolute path according to your server's convention.
+		/// </summary>
+		public virtual bool IsAbsolutePath(string path)
 		{
 			return false;
 		}
 
+		/// <summary>
+		/// Return true if your server requires custom handling of file size.
+		/// </summary>
+		public virtual bool IsCustomGetAbsolutePath() {
+			return false;
+		}
+
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return the absolute path.
+		/// </summary>
+		public virtual string GetAbsolutePath(FtpClient client, string path) {
+			return path;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return the absolute path.
+		/// </summary>
+		public virtual Task<string> GetAbsolutePathAsync(FtpClient client, string path, CancellationToken token) {
+			return Task.FromResult(path);
+		}
+#endif
 	}
 }

--- a/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
@@ -6,6 +6,7 @@ using FluentFTP;
 using FluentFTP.Servers;
 #if (CORE || NETFX)
 using System.Threading;
+using FluentFTP.Helpers;
 #endif
 #if ASYNC
 using System.Threading.Tasks;
@@ -166,25 +167,66 @@ namespace FluentFTP.Servers.Handlers {
 		}
 
 		/// <summary>
-		/// Return true if the path should be converted to an absolute path.
-		/// </summary>
-		public override bool ConvertListingPath(string path) {
-
-			// Disable the GetAbsolutePath(path) if z/OS
-			// Note: "TEST.TST" is a "path" that does not start with a slash
-			// This could be a unix file on z/OS OR a classic CWD relative dataset
-			// Both of these work with the z/OS FTP server LIST command
-			return path == null || path.StartsWith("/");
-		}
-
-		/// <summary>
 		/// Skip reporting a parser error
 		/// </summary>
-		public override bool SkipParserErrorReport()
-		{
+		public override bool SkipParserErrorReport() {
 			return true;
 		}
 
+		/// <summary>
+		/// Always read to End of stream on a download
+		/// </summary>
+		public override bool AlwaysReadToEnd(string remotePath)	{
+			return true;
+		}
+
+		public override bool IsCustomGetAbsolutePath() {
+			return true;
+		}
+
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return the absolute path.
+		/// </summary>
+		public override string GetAbsolutePath(FtpClient client, string path) {
+
+			if (path == null || path.Trim().Length == 0)
+			{
+				path = client.GetWorkingDirectory();
+			}
+
+			if (path.StartsWith("/") || path.StartsWith("\'"))
+			{
+				return path;
+			}
+
+			var pwd = client.GetWorkingDirectory();
+
+			if (pwd.StartsWith("/"))
+			{
+				if (pwd.Equals("/"))
+				{
+					path = (pwd + path).GetFtpPath();
+
+				}
+				else
+				{
+					path = (pwd + "/" + path).GetFtpPath();
+				}
+			}
+
+			return path;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return the absolute path.
+		/// </summary>
+		public override async Task<string> GetAbsolutePathAsync(FtpClient client, string path, CancellationToken token)	{
+			return path;
+		}
+#endif
 	}
 }
 


### PR DESCRIPTION
Cleans up a lot of `if (Serverhandler...` code.

The original GetAbsolutePath also still contains a `IsAbsolutePath` made for OpenVMS. That one needs to be migrated to the custom GetAbsolutePath in a further separate step.

