### PR TITLE
Eliminate redundant ServerHandler queries

### DIFF
--- a/FluentFTP/Client/FtpClient_FileManagement.cs
+++ b/FluentFTP/Client/FtpClient_FileManagement.cs
@@ -105,13 +105,7 @@ namespace FluentFTP {
 
 				LogFunc(nameof(FileExists), new object[] { path });
 
-				// A check for path.StartsWith("/") tells us, even if it is z/OS, we can use the normal unix logic
-
-				// If z/OS: Do not GetAbsolutePath(), unless we have a leading slash
-				if (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/")) {
-					// calc the absolute filepath
-					path = GetAbsolutePath(path);
-				}
+				path = GetAbsolutePath(path);
 
 				// since FTP does not include a specific command to check if a file exists
 				// here we check if file exists by attempting to get its filesize (SIZE)
@@ -199,13 +193,7 @@ namespace FluentFTP {
 
 			LogFunc(nameof(FileExistsAsync), new object[] { path });
 
-			// A check for path.StartsWith("/") tells us, even if it is z/OS, we can use the normal unix logic
-
-			// Do not need GetAbsolutePath(path) if z/OS
-			if (ServerType != FtpServer.IBMzOSFTP || path.StartsWith("/")) {
-				// calc the absolute filepath
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			path = await GetAbsolutePathAsync(path, token);
 
 			// since FTP does not include a specific command to check if a file exists
 			// here we check if file exists by attempting to get its filesize (SIZE)

--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -259,10 +259,7 @@ namespace FluentFTP {
 			var isGetModified = options.HasFlag(FtpListOption.Modify);
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
-			// calc the absolute filepath
-			if (ServerHandler == null || ServerHandler.ConvertListingPath(path)) {
-				path = GetAbsolutePath(path);
-			}
+			path = GetAbsolutePath(path);
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option
@@ -632,10 +629,7 @@ namespace FluentFTP {
 			var isGetModified = options.HasFlag(FtpListOption.Modify);
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
-			// calc the absolute filepath
-			if (ServerHandler == null || ServerHandler.ConvertListingPath(path)) {
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			path = await GetAbsolutePathAsync(path, token);
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option
@@ -750,10 +744,7 @@ namespace FluentFTP {
 			var isGetModified = options.HasFlag(FtpListOption.Modify);
 			var isGetSize = options.HasFlag(FtpListOption.Size);
 
-			// calc the absolute filepath
-			if (ServerHandler == null || ServerHandler.ConvertListingPath(path)) {
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			path = await GetAbsolutePathAsync(path, token);
 
 			// MLSD provides a machine readable format with 100% accurate information
 			// so always prefer MLSD over LIST unless the caller of this method overrides it with the ForceList option
@@ -1165,10 +1156,7 @@ namespace FluentFTP {
 
 			var listing = new List<string>();
 
-			if (ServerType != FtpServer.IBMzOSFTP || path == null || path.StartsWith("/")) {
-				// calc path to request
-				path = GetAbsolutePath(path);
-			}
+			path = GetAbsolutePath(path);
 
 #if !CORE14
 			lock (m_lock) {
@@ -1276,10 +1264,7 @@ namespace FluentFTP {
 
 			var listing = new List<string>();
 
-			if (ServerType != FtpServer.IBMzOSFTP || path == null || path.StartsWith("/")) {
-				// calc path to request
-				path = await GetAbsolutePathAsync(path, token);
-			}
+			path = await GetAbsolutePathAsync(path, token);
 
 			// always get the file listing in binary to avoid character translation issues with ASCII.
 			await SetDataTypeNoLockAsync(ListingDataType, token);

--- a/FluentFTP/Client/FtpClient_Utils.cs
+++ b/FluentFTP/Client/FtpClient_Utils.cs
@@ -92,6 +92,10 @@ namespace FluentFTP {
 		/// </summary>
 		private string GetAbsolutePath(string path) {
 
+			if (ServerHandler != null && ServerHandler.IsCustomGetAbsolutePath())	{
+				return ServerHandler.GetAbsolutePath(this, path);
+			}
+
 			if (path == null || path.Trim().Length == 0) {
 				// if path not given, then use working dir
 				var pwd = GetWorkingDirectory();
@@ -116,12 +120,6 @@ namespace FluentFTP {
 				// if relative path given then add working dir to calc full path
 				var pwd = GetWorkingDirectory();
 				if (pwd != null && pwd.Trim().Length > 0 && path != pwd) {
-					// Check if PDS (MVS Dataset) file system
-					if (pwd.StartsWith("'") && ServerType == FtpServer.IBMzOSFTP) {
-						// PDS that has single quotes is already fully qualified
-						return pwd;
-					}
-
 					if (path.StartsWith("./")) {
 						path = path.Remove(0, 2);
 					}
@@ -138,6 +136,10 @@ namespace FluentFTP {
 		/// Ensure a relative path is absolute by appending the working dir
 		/// </summary>
 		private async Task<string> GetAbsolutePathAsync(string path, CancellationToken token) {
+
+			if (ServerHandler != null && ServerHandler.IsCustomGetAbsolutePath()) {
+				return await ServerHandler.GetAbsolutePathAsync(this, path, token);
+			}
 
 			if (path == null || path.Trim().Length == 0) {
 				// if path not given, then use working dir
@@ -161,7 +163,7 @@ namespace FluentFTP {
 
 				// if relative path given then add working dir to calc full path
 				string pwd = await GetWorkingDirectoryAsync(token);
-				if (pwd != null && pwd.Trim().Length > 0) {
+				if (pwd != null && pwd.Trim().Length > 0 && path != pwd) {
 					if (path.StartsWith("./")) {
 						path = path.Remove(0, 2);
 					}

--- a/FluentFTP/Servers/FtpBaseServer.cs
+++ b/FluentFTP/Servers/FtpBaseServer.cs
@@ -54,20 +54,6 @@ namespace FluentFTP.Servers {
 		}
 
 		/// <summary>
-		/// Return true if the path is an absolute path according to your server's convention.
-		/// </summary>
-		public virtual bool IsAbsolutePath(string path) {
-			return false;
-		}
-
-		/// <summary>
-		/// Return true if the path should be converted to an absolute path.
-		/// </summary>
-		public virtual bool ConvertListingPath(string path) {
-			return true;
-		}
-
-		/// <summary>
 		/// Return the default file listing parser to be used with your FTP server.
 		/// </summary>
 		public virtual FtpParser GetParser() {
@@ -131,12 +117,14 @@ namespace FluentFTP.Servers {
 #endif
 		}
 #endif
-			/// <summary>
-			/// Return true if your server requires custom handling of file size.
-			/// </summary>
+
+		/// <summary>
+		/// Return true if your server requires custom handling of file size.
+		/// </summary>
 		public virtual bool IsCustomFileSize() {
 			return false;
 		}
+
 		/// <summary>
 		/// Perform server-specific file size fetching commands here.
 		/// Return the file size in bytes.
@@ -154,6 +142,7 @@ namespace FluentFTP.Servers {
 			return Task.FromResult(0L);
 		}
 #endif
+
 		/// <summary>
 		/// Check if the given path is a root directory on your FTP server.
 		/// If you are unsure, return false.
@@ -165,8 +154,7 @@ namespace FluentFTP.Servers {
 		/// <summary>
 		/// Skip reporting a parser error
 		/// </summary>
-		public virtual bool SkipParserErrorReport()
-		{
+		public virtual bool SkipParserErrorReport()	{
 			return false;
 		}
 
@@ -174,9 +162,41 @@ namespace FluentFTP.Servers {
 		/// Always read to end of stream on a download
 		/// If you are unsure, return false.
 		/// </summary>
-		public virtual bool AlwaysReadToEnd(string remotePath)
+		public virtual bool AlwaysReadToEnd(string remotePath) {
+			return false;
+		}
+
+		/// <summary>
+		/// Return true if the path is an absolute path according to your server's convention.
+		/// </summary>
+		public virtual bool IsAbsolutePath(string path)
 		{
 			return false;
 		}
+
+		/// <summary>
+		/// Return true if your server requires custom handling of file size.
+		/// </summary>
+		public virtual bool IsCustomGetAbsolutePath() {
+			return false;
+		}
+
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return the absolute path.
+		/// </summary>
+		public virtual string GetAbsolutePath(FtpClient client, string path) {
+			return path;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return the absolute path.
+		/// </summary>
+		public virtual Task<string> GetAbsolutePathAsync(FtpClient client, string path, CancellationToken token) {
+			return Task.FromResult(path);
+		}
+#endif
 	}
 }


### PR DESCRIPTION
This gives us a `IsCustomGetAbsolutePath()` query **INSIDE** the regular `GetAbsolutePath()` and thus eliminates a lot of `if (ServerHandler...` code outside.

**Note:** The regular `GetAbsolutePath(...)` **still** contains a second ServerHandler function, `IsAbsolutePath(...)` which was created for **OpenVMS**. This can probably be migrated to the new custom mechanism, but since I cannot test it, I have left it in place for the time being.

The functionality of `IsAbsolutePath(...)` sadly was not sufficient to also use for z/OS, although it looked promising at first, early simple tests actually worked, but not all special cases.

There was also some "old" z/OS (MVS) code in there that has been redundant for some time.

An additional benefit of this change, is that **all** callers of `GetAbsolutePath(...)` will now go through the ServerHandler and not only those that I changed for z/OS some time ago.