### PR TITLE
Rest of the changes

### DIFF
--- a/FluentFTP/Client/FtpClient_Utils.cs
+++ b/FluentFTP/Client/FtpClient_Utils.cs
@@ -88,11 +88,11 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
-		/// Ensure a relative path is absolute by appending the working dir
+		/// Ensure a relative path is absolute by prepending the working dir
 		/// </summary>
 		private string GetAbsolutePath(string path) {
 
-			if (ServerHandler != null && ServerHandler.IsCustomGetAbsolutePath())	{
+			if (ServerHandler != null && ServerHandler.IsCustomGetAbsolutePath()) {
 				return ServerHandler.GetAbsolutePath(this, path);
 			}
 
@@ -105,7 +105,6 @@ namespace FluentFTP {
 				else {
 					path = "/";
 				}
-
 			}
 
 			// FIX : #153 ensure this check works with unix & windows
@@ -133,7 +132,7 @@ namespace FluentFTP {
 
 #if ASYNC
 		/// <summary>
-		/// Ensure a relative path is absolute by appending the working dir
+		/// Ensure a relative path is absolute by prepending the working dir
 		/// </summary>
 		private async Task<string> GetAbsolutePathAsync(string path, CancellationToken token) {
 
@@ -175,6 +174,88 @@ namespace FluentFTP {
 			return path;
 		}
 #endif
+
+		/// <summary>
+		/// Ensure a relative dir is absolute by prepending the working dir
+		/// </summary>
+		private string GetAbsoluteDir(string path) {
+			string dirPath = null;
+			if (ServerHandler != null && ServerHandler.IsCustomGetAbsoluteDir()) {
+				dirPath = ServerHandler.GetAbsoluteDir(this, path);
+			}
+
+			if (dirPath != null) {
+				return dirPath;
+			}
+
+			path = GetAbsolutePath(path);
+
+			path = !path.EndsWith("/") ? path + "/" : path;
+
+			return path;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Ensure a relative dir is absolute by prepending the working dir
+		/// </summary>
+		private async Task<string> GetAbsoluteDirAsync(string path, CancellationToken token) {
+			string dirPath = null;
+			if (ServerHandler != null && ServerHandler.IsCustomGetAbsoluteDir()) {
+				dirPath = await ServerHandler.GetAbsoluteDirAsync(this, path, token);
+			}
+
+			if (dirPath != null) {
+				return dirPath;
+			}
+
+			path = await GetAbsolutePathAsync(path, token);
+
+			path = !path.EndsWith("/") ? path + "/" : path;
+
+			return path;
+		}
+#endif
+
+		/// <summary>
+		/// Concat a path and a filename
+		/// </summary>
+		private string GetAbsoluteFilePath(string path, string fileName)
+		{
+			string filePath = null;
+			if (ServerHandler != null && ServerHandler.IsCustomGetAbsoluteFilePath()) {
+				filePath = ServerHandler.GetAbsoluteFilePath(this, path, fileName);
+			}
+
+			if (filePath != null) {
+				return filePath;
+			}
+
+			path = !path.EndsWith("/") ? path + "/" + fileName : path + fileName;
+
+			return path;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Concat a path and a filename
+		/// </summary>
+		private async Task<string> GetAbsoluteFilePathAsync(string path, string fileName, CancellationToken token) {
+			string filePath = null;
+			if (ServerHandler != null && ServerHandler.IsCustomGetAbsoluteFilePath()) {
+				filePath = await ServerHandler.GetAbsoluteFilePathAsync(this, path, fileName, token);
+			}
+
+			if (filePath != null) {
+				return filePath;
+			}
+
+			path = !path.EndsWith("/") ? path + "/" + fileName : path + fileName;
+
+			return path;
+		}
+#endif
+
 
 		private static string DecodeUrl(string url) {
 #if CORE

--- a/FluentFTP/Helpers/FtpListParser.cs
+++ b/FluentFTP/Helpers/FtpListParser.cs
@@ -163,7 +163,16 @@ namespace FluentFTP.Helpers {
 				}
 
 				// calc absolute file paths
-				result.CalculateFullFtpPath(client, path);
+
+				bool? handledByCustom = null;
+
+				if (client.ServerHandler != null && client.ServerHandler.IsCustomCalculateFullFtpPath()) {
+					handledByCustom = client.ServerHandler.CalculateFullFtpPath(client, path, result);
+				}
+
+				if (handledByCustom == null) {
+					result.CalculateFullFtpPath(client, path);
+				}
 			}
 
 			return result;

--- a/FluentFTP/Servers/FtpBaseServer.cs
+++ b/FluentFTP/Servers/FtpBaseServer.cs
@@ -169,13 +169,12 @@ namespace FluentFTP.Servers {
 		/// <summary>
 		/// Return true if the path is an absolute path according to your server's convention.
 		/// </summary>
-		public virtual bool IsAbsolutePath(string path)
-		{
+		public virtual bool IsAbsolutePath(string path) {
 			return false;
 		}
 
 		/// <summary>
-		/// Return true if your server requires custom handling of file size.
+		/// Return true if your server requires custom handling of absolute paths.
 		/// </summary>
 		public virtual bool IsCustomGetAbsolutePath() {
 			return false;
@@ -196,6 +195,110 @@ namespace FluentFTP.Servers {
 		/// </summary>
 		public virtual Task<string> GetAbsolutePathAsync(FtpClient client, string path, CancellationToken token) {
 			return Task.FromResult(path);
+		}
+#endif
+
+		/// <summary>
+		/// Return true if your server requires custom handling of absolute dir.
+		/// </summary>
+		public virtual bool IsCustomGetAbsoluteDir() {
+			return false;
+		}
+
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return the absolute dir.
+		/// </summary>
+		public virtual string GetAbsoluteDir(FtpClient client, string path)	{
+			return null;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return the absolute path.
+		/// </summary>
+		public virtual Task<string> GetAbsoluteDirAsync(FtpClient client, string path, CancellationToken token) { 
+			return Task.FromResult((string)null);
+		}
+#endif
+
+		/// <summary>
+		/// Return true if your server requires custom handling of path and filename concatenation.
+		/// </summary>
+		public virtual bool IsCustomGetAbsoluteFilePath() {
+			return false;
+		}
+
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return concatenation of path and filename
+		/// </summary>
+		public virtual string GetAbsoluteFilePath(FtpClient client, string path, string fileName) {
+			return !path.EndsWith("/") ? path + "/" + fileName : path + fileName;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return concatenation of path and filename
+		/// </summary>
+		public virtual Task<string> GetAbsoluteFilePathAsync(FtpClient client, string path, string fileName, CancellationToken token) {
+			return Task.FromResult(!path.EndsWith("/") ? path + "/" + fileName : path + fileName);
+		}
+#endif
+
+		/// <summary>
+		/// Return true if your server requires custom handling to handle listing analysis.
+		/// </summary>
+		public virtual bool IsCustomCalculateFullFtpPath() {
+			return false;
+		}
+
+		/// <summary>
+		/// Get the full path of a given FTP Listing entry
+		/// Return null indicates custom code decided not to handle this
+		/// </summary>
+		public virtual bool? CalculateFullFtpPath(FtpClient client, string path, FtpListItem item) {
+			return null;
+		}
+
+		/// <summary>
+		/// Disable SIZE command even if server says it is supported
+		/// </summary>
+		public virtual bool DontUseSizeEvenIfCapable(string path) {
+			return false;
+		}
+
+		/// <summary>
+		/// Disable MDTM command even if server says it is supported
+		/// </summary>
+		public virtual bool DontUseMdtmEvenIfCapable(string path) {
+			return false;
+		}
+
+		/// <summary>
+		/// Return true if your server requires custom handling to check file existence.
+		/// </summary>
+		public virtual bool IsCustomFileExists() {
+			return false;
+		}
+
+		/// <summary>
+		/// Check for existence of a file
+		/// Return null indicates custom code decided not to handle this
+		/// </summary>
+		public virtual bool? FileExists(FtpClient client, string path) {
+			return null;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Check for existence of a file
+		/// Return null indicates custom code decided not to handle this
+		/// </summary>
+		public virtual Task<bool?> FileExistsAsync(FtpClient client, string path, CancellationToken token) {
+			return Task.FromResult((bool?)null);
 		}
 #endif
 	}

--- a/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
@@ -7,6 +7,7 @@ using FluentFTP.Servers;
 #if (CORE || NETFX)
 using System.Threading;
 using FluentFTP.Helpers;
+using System.Linq;
 #endif
 #if ASYNC
 using System.Threading.Tasks;
@@ -180,6 +181,9 @@ namespace FluentFTP.Servers.Handlers {
 			return true;
 		}
 
+		/// <summary>
+		/// Return true if your server requires custom handling of absolute path.
+		/// </summary>
 		public override bool IsCustomGetAbsolutePath() {
 			return true;
 		}
@@ -216,7 +220,13 @@ namespace FluentFTP.Servers.Handlers {
 					path = ("\'" + path + "\'").GetFtpPath();
 				}
 				else {
-					path = (pwd.TrimEnd('\'') + path + "\'").GetFtpPath();
+					pwd = pwd.TrimEnd('\'');
+					if (pwd.EndsWith(".")) {
+						path = (pwd + path + "\'").GetFtpPath();
+					}
+					else {
+						path = (pwd + "(" + path + ")\'").GetFtpPath();
+					}
 				}
 				return path;
 			}
@@ -243,7 +253,7 @@ namespace FluentFTP.Servers.Handlers {
 			var pwd = await client.GetWorkingDirectoryAsync(token);
 
 			if (pwd.StartsWith("/")) {
-				if (pwd.Equals("/")) { 
+				if (pwd.Equals("/")) {
 					path = (pwd + path).GetFtpPath();
 				}
 				else {
@@ -257,12 +267,246 @@ namespace FluentFTP.Servers.Handlers {
 					path = ("\'" + path + "\'").GetFtpPath();
 				}
 				else {
-					path = (pwd.TrimEnd('\'') + path + "\'").GetFtpPath();
+					pwd = pwd.TrimEnd('\'');
+					if (pwd.EndsWith(".")) {
+						path = (pwd + path + "\'").GetFtpPath();
+					}
+					else {
+						path = (pwd + "(" + path + ")\'").GetFtpPath();
+					}
 				}
 				return path;
 			}
 
 			return path;
+		}
+#endif
+
+		/// <summary>
+		/// Return true if your server requires custom handling of absolute dir.
+		/// </summary>
+		public override bool IsCustomGetAbsoluteDir() {
+			return true;
+		}
+
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return null indicates custom code decided not to handle this
+		/// Return the absolute dir.
+		/// </summary>
+		public override string GetAbsoluteDir(FtpClient client, string path) {
+			path = client.ServerHandler.GetAbsolutePath(client, path);
+
+			if (!path.StartsWith("\'")) {
+				return null;
+			}
+
+			if (!path.EndsWith(".\'")) {
+				path = path.TrimEnd('\'') + "(*)\'";
+			}
+
+			return path;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return null indicates custom code decided not to handle this
+		/// Return the absolute dir.
+		/// </summary>
+		public override async Task<string> GetAbsoluteDirAsync(FtpClient client, string path, CancellationToken token) {
+
+			path = await client.ServerHandler.GetAbsolutePathAsync(client, path, token);
+
+			if (!path.StartsWith("\'")) {
+				return null;
+			}
+
+			if (!path.EndsWith(".\'")) {
+				path = path.TrimEnd('\'') + "(*)\'";
+			}
+
+			return path;
+		}
+#endif
+
+		/// <summary>
+		/// Return true if your server requires custom handling of path and filename concatenation.
+		/// </summary>
+		public override bool IsCustomGetAbsoluteFilePath() {
+			return true;
+		}
+
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return null indicates custom code decided not to handle this
+		/// Return concatenation of path and filename
+		/// </summary>
+		public override string GetAbsoluteFilePath(FtpClient client, string path, string fileName) {
+
+			if (!path.StartsWith("\'"))	{
+				return null;
+			}
+
+			if (path.EndsWith(".\'")) {
+				path = path.TrimEnd('\'') + "." + fileName + "\'";
+			}
+			else {
+				path = path.TrimEnd('\'') + "(" + fileName + ")\'";
+			}
+
+			return path;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Perform server-specific path modification here.
+		/// Return null indicates custom code decided not to handle this
+		/// Return concatenation of path and filename
+		/// </summary>
+		public override async Task<string> GetAbsoluteFilePathAsync(FtpClient client, string path, string fileName, CancellationToken token) {
+
+			if (!path.StartsWith("\'"))	{
+				return null;
+			}
+
+			if (path.EndsWith(".\'")) {
+				path = path.TrimEnd('\'') + "." + fileName + "\'";
+			}
+			else {
+				path = path.TrimEnd('\'') + "(" + fileName.Substring(0, 8) + ")\'";
+			}
+
+			return path;
+		}
+#endif
+
+		/// <summary>
+		/// Return true if your server requires custom handling to handle listing analysis.
+		/// </summary>
+		public override bool IsCustomCalculateFullFtpPath() {
+			return true;
+		}
+
+		/// <summary>
+		/// Get the full path of a given FTP Listing entry
+		/// Return null indicates custom code decided not to handle this
+		/// </summary>
+		public override bool? CalculateFullFtpPath(FtpClient client, string path, FtpListItem item) {
+			if (client.zOSListingRealm != FtpZOSListRealm.Unix)	{
+				return null;
+			}
+
+			// The user might be using GetListing("", FtpListOption.NoPath)
+			// or he might be using    GetListing("not_fully_qualified_zOS path")
+			// or he might be using    GetListing("'fully_qualified_zOS path'") (note the single quotes)
+
+			// The following examples in the comments assume a current working
+			// directory of 'GEEK.'.
+
+			// If it is not a FtpZOSListRealm.Dataset, it must be FtpZOSListRealm.Member*
+
+			// Is caller using FtpListOption.NoPath and CWD to the right place?
+			if (path.Length == 0) {
+				if (client.zOSListingRealm == FtpZOSListRealm.Dataset)
+				{
+					// Path: ""
+					// Fullname: 'GEEK.PROJECTS.LOADLIB'
+					item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + item.Name + "\'";
+				}
+				else {
+					// Path: ""
+					// Fullname: 'GEEK.PROJECTS.LOADLIB(MYPROG)'
+					item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + "(" + item.Name + ")\'";
+				}
+			}
+			// Caller is not using FtpListOption.NoPath, so the fullname can be built
+			// depending on the listing realm
+			else if (path[0] == '\'') {
+				if (client.zOSListingRealm == FtpZOSListRealm.Dataset) {
+					// Path: "'GEEK.PROJECTS.LOADLIB'"
+					// Fullname: 'GEEK.PROJECTS.LOADLIB'
+					item.FullName = item.Name;
+				}
+				else {
+					if (path.EndsWith("(*)\'"))	{
+						// Path: "'GEEK.PROJECTS.LOADLIB(*)'"
+						// Fullname: 'GEEK.PROJECTS.LOADLIB(MYPROG)'
+						item.FullName = path.Substring(0, path.Length - 4) + "(" + item.Name + ")\'";
+					}
+					else {
+						item.FullName = path;
+					}
+				}
+			}
+			else {
+				if (client.zOSListingRealm == FtpZOSListRealm.Dataset) {
+					// Path: "PROJECTS.LOADLIB"
+					// Fullname: 'GEEK.PROJECTS.LOADLIB'
+					item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + item.Name + '\'';
+				}
+				else {
+					if (path.EndsWith("(*)")) {
+						// Path: "PROJECTS.LOADLIB(*)"
+						// Fullname: 'GEEK.PROJECTS.LOADLIB(MYPROG)'
+						item.FullName = client.GetWorkingDirectory().TrimEnd('\'') + path.Substring(0, path.Length - 3) + "(" + item.Name + ")\'";
+					}
+					else {
+						item.FullName = path;
+					}
+				}
+			}
+			return true;
+		}
+
+		/// <summary>
+		/// Disable SIZE command even if server says it is supported
+		/// </summary>
+		public override bool DontUseSizeEvenIfCapable(string path) {
+			return !path.StartsWith("/");
+		}
+
+		/// <summary>
+		/// Disable MDTM command even if server says it is supported
+		/// </summary>
+		public override bool DontUseMdtmEvenIfCapable(string path) {
+			return !path.StartsWith("/");
+		}
+
+		/// <summary>
+		/// Return true if your server requires custom handling to check file existence.
+		/// </summary>
+		public override bool IsCustomFileExists() {
+			return true;
+		}
+
+		/// <summary>
+		/// Check for existence of a file
+		/// Return null indicates custom code decided not to handle this
+		/// </summary>
+		public override bool? FileExists(FtpClient client, string path)
+		{
+			if (path.StartsWith("/")) {
+				return null;
+			}
+
+			var fileList = client.GetNameListing(path);
+			return fileList.Count() > 0;
+		}
+
+#if ASYNC
+		/// <summary>
+		/// Check for existence of a file
+		/// Return null indicates custom code decided not to handle this
+		/// </summary>
+		public override async Task<bool?> FileExistsAsync(FtpClient client, string path, CancellationToken token)
+		{
+			if (path.StartsWith("/")) {
+				return null;
+			}
+
+			var fileList = await client.GetNameListingAsync(path, token);
+			return fileList.Count() > 0;
 		}
 #endif
 	}

--- a/FluentFTP/Servers/Handlers/OpenVmsServer.cs
+++ b/FluentFTP/Servers/Handlers/OpenVmsServer.cs
@@ -59,13 +59,13 @@ namespace FluentFTP.Servers.Handlers {
 		/// Used if your server does not broadcast its capabilities using the FEAT command.
 		/// </summary>
 		public override string[] DefaultCapabilities() {
-			
+
 			// OpenVMS HGFTP
 			// https://gist.github.com/robinrodricks/9631f9fad3c0fc4c667adfd09bd98762
-			
+
 			// assume the basic features supported
 			return new[] { "CWD", "DELE", "LIST", "NLST", "MKD", "MDTM", "PASV", "PORT", "PWD", "QUIT", "RNFR", "RNTO", "SITE", "STOR", "STRU", "TYPE" };
-			
+
 		}
 
 		/// <summary>
@@ -91,6 +91,21 @@ namespace FluentFTP.Servers.Handlers {
 			return FtpParser.VMS;
 		}
 
+		public override bool IsCustomCalculateFullFtpPath() {
+			return true;
+		}
 
+		/// <summary>
+		/// Get the full path of a given FTP Listing entry
+		/// Return null indicates custom code decided not to handle this
+		/// </summary>
+		public override bool? CalculateFullFtpPath(FtpClient client, string path, FtpListItem item)
+		{
+			// if this is a vax/openvms file listing
+			// there are no slashes in the path name
+			item.FullName = path + item.Name;
+
+			return true;
+		}
 	}
 }

--- a/FluentFTP/Servers/Handlers/OpenVmsServer.cs
+++ b/FluentFTP/Servers/Handlers/OpenVmsServer.cs
@@ -6,6 +6,7 @@ using FluentFTP;
 using FluentFTP.Servers;
 #if (CORE || NETFX)
 using System.Threading;
+using FluentFTP.Helpers;
 #endif
 #if ASYNC
 using System.Threading.Tasks;
@@ -99,8 +100,17 @@ namespace FluentFTP.Servers.Handlers {
 		/// Get the full path of a given FTP Listing entry
 		/// Return null indicates custom code decided not to handle this
 		/// </summary>
-		public override bool? CalculateFullFtpPath(FtpClient client, string path, FtpListItem item)
-		{
+		public override bool? CalculateFullFtpPath(FtpClient client, string path, FtpListItem item) {
+			if (path == null) {
+				// check if the path is absolute
+				if (IsAbsolutePath(item.Name)) {
+					item.FullName = item.Name;
+					item.Name = item.Name.GetFtpFileName();
+				}
+
+				return true;
+			}
+
 			// if this is a vax/openvms file listing
 			// there are no slashes in the path name
 			item.FullName = path + item.Name;


### PR DESCRIPTION
This change finalizes my attempts to move the z/OS logic to a ServerHandler. Once you get some practice (on the previous ones), you can move faster... Success!

Added ServerHandler(s):

For `FtpClient_FileManagement`

**FileExists(..)**
`ServerHandler.DontUseSizeEvenIfCapable`
`ServerHandler.DontUseMdtmEvenIfCapable`

`ServerHandler.IsCustomFileExists`
`ServerHandler.FileExists`

For `FtpClient_FileUpload`

**UploadFiles(..)**
More or less complete rewrite of the path/directory handling logic so to use the new ServerHandlers and the following new ones:

`GetAbsoluteDir()`
`GetAbsoluteFilePath()'

For `FtpListParser`

`ServerHandler.IsCustomCalculateFullFtpPath`
`ServerHandler.CalculateFullFtpPath`

and so on and on.. it is a lot, I realize, but quite systematic:

1. A number of new serverhandler routines, some are boolean, some return values, some are even conditional - using either nullable value types as indicators or as in the case of a string return value, a value of null to indicate: Let the base handler do it, I refuse to handle it. Oh, and wherever needed, also for ASYNC.

2. Replace every usage of the server type enum with the appropriate logic.

3. Recode UploadFiles from the changes of #741 to a more consistant approach to path/filename handling.

![image](https://user-images.githubusercontent.com/51046875/186241698-aecebc43-6f06-4163-97d8-a062b99ee4a7.png)

Looking OK. 

In the next period of time, I will endeavour to improve the comments and docs for FtpBaseServer.


