### PR TITLE
z/OS Listing FullName sometimes incorrect

### DIFF
--- a/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IbmZosFtpServer.cs
@@ -393,7 +393,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// Return null indicates custom code decided not to handle this
 		/// </summary>
 		public override bool? CalculateFullFtpPath(FtpClient client, string path, FtpListItem item) {
-			if (client.zOSListingRealm != FtpZOSListRealm.Unix)	{
+			if (client.zOSListingRealm == FtpZOSListRealm.Unix)	{
 				return null;
 			}
 


### PR DESCRIPTION
#928 is fine but I discovered this type that needs to be fixed. 

It causes the `item.FullName` to be incorrect for any z/OS GetListing.