### PR TITLE
Forward cancellation token

### DIFF
--- a/FluentFTP/Client/AsyncClient/UploadDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/UploadDirectory.cs
@@ -83,7 +83,7 @@ namespace FluentFTP {
 			token.ThrowIfCancellationRequested();
 
 			// get all the already existing files
-			var remoteListing = checkFileExistence ? await GetListing(remoteFolder, FtpListOption.Recursive) : null;
+			var remoteListing = checkFileExistence ? await GetListing(remoteFolder, FtpListOption.Recursive, token) : null;
 
 			// break if task is cancelled
 			token.ThrowIfCancellationRequested();

--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4Proxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4Proxy.cs
@@ -21,8 +21,8 @@ namespace FluentFTP.Proxy.AsyncProxy {
 		/// Called during <see cref="ConnectAsync()"/>. Typically extended by FTP proxies.
 		/// </summary>
 		protected virtual async Task HandshakeAsync(CancellationToken token = default) {
-			await ((IInternalFtpClient)this).GetBaseStream().ReadAsync(new byte[6], 0, 6);
-			await base.HandshakeAsync();
+			await ((IInternalFtpClient)this).GetBaseStream().ReadAsync(new byte[6], 0, 6, token);
+			await base.HandshakeAsync(token);
 		}
 
 		protected override async Task ConnectAsync(FtpSocketStream stream, CancellationToken cancellationToken) {

--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4aProxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4aProxy.cs
@@ -21,8 +21,8 @@ namespace FluentFTP.Proxy.AsyncProxy {
 		/// Called during <see cref="ConnectAsync()"/>. Typically extended by FTP proxies.
 		/// </summary>
 		protected virtual async Task HandshakeAsync(CancellationToken token = default) {
-			await ((IInternalFtpClient)this).GetBaseStream().ReadAsync(new byte[6], 0, 6);
-			await base.HandshakeAsync();
+			await ((IInternalFtpClient)this).GetBaseStream().ReadAsync(new byte[6], 0, 6, token);
+			await base.HandshakeAsync(token);
 		}
 
 		protected override async Task ConnectAsync(FtpSocketStream stream, CancellationToken cancellationToken) {


### PR DESCRIPTION
Found some places, where the `CancellationToken` parameter was not passed along to inner async calls.