### PR TITLE
Fix issue #946

### DIFF
--- a/FluentFTP/Servers/Handlers/IBMOS400FtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IBMOS400FtpServer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using FluentFTP.Client.BaseClient;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FluentFTP.Servers.Handlers {
@@ -34,6 +35,34 @@ namespace FluentFTP.Servers.Handlers {
 		/// </summary>
 		public override FtpParser GetParser() {
 			return FtpParser.IBMOS400;
+		}
+
+		/// <summary>
+		/// Return true if your server requires custom handling to handle listing analysis.
+		/// </summary>
+		public override bool IsCustomCalculateFullFtpPath() {
+			return true;
+		}
+
+		/// <summary>
+		/// Get the full path of a given FTP Listing entry
+		/// Return null indicates custom code decided not to handle this
+		/// </summary>
+		public override bool? CalculateFullFtpPath(BaseFtpClient client, string path, FtpListItem item) {
+
+			// If item.name is in the library/filename format, check if the current
+			// working directory ends with that library name and then do not
+			// duplicate that library name in the fullname.
+
+			var parts = item.Name.Split('/');
+			if (parts.Length < 2 || !path.EndsWith(parts[0])) {
+				return null;
+			}
+
+			item.Name = parts[1];
+			item.FullName = path + '/' + parts[1];
+
+			return true;
 		}
 
 	}


### PR DESCRIPTION
This concerns #946

As is done in FileZilla - remove the library name from the `item.Name`. Avoid the duplicate library name in the `item.Fullname`.

This modification DOES not handle other cases in which there is a `library/filename` format. Perhaps one could actually do this for all cases.

Further investigation of different possible OS/400 FTP server listing formats is needed.

Perhaps also an initial setting is useful, similar to the z/OS server handler:

```
		public override void AfterConnected(FtpClient client) {
			FtpReply reply;
			if (!(reply = client.Execute("SITE LISTFMT 0")).Success) {
				throw new FtpCommandException(reply);
			}
			if (!(reply = client.Execute("SITE NAMEFMT 1")).Success) {
				throw new FtpCommandException(reply);
			}
		}
```
