### PR TITLE
** DO NOT MERGE** Parser tests problem.

### DIFF
--- a/FluentFTP.Tests/Unit/ParserTests.cs
+++ b/FluentFTP.Tests/Unit/ParserTests.cs
@@ -1,3 +1,4 @@
+using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
 using System;
 using System.Collections.Generic;
@@ -372,10 +373,14 @@ namespace FluentFTP.Tests.Unit {
 		}
 		[Fact]
 		public void IBMOS400() {
-			var parser = new FtpListParser(new FtpClient());
+			var client = new FtpClient();
+			client.ServerHandler = ServerModule.GetServerHandler(FtpServer.IBMOS400FTP);
+			var parser = new FtpListParser(client);
 			parser.Init(FtpOperatingSystem.IBMOS400, FtpParser.IBMOS400);
 
 			var sample = new[] {
+				"OLLIEP           8192 30.03.16 09:00:51 *DIR      prodload/datamods/",
+				"BACKUP           2865 01.09.22 04:36:04 *STMF     prodload/D1234831.013",
 				"CFT             45056 04/12/14 14:19:31 *FILE ANTHONY1.FILE",
 				"CFT                                     *MEM ANTHONY1.FILE/ANTHONY1.MBR",
 				"CFT             36864 28/11/15 15:19:30 *FILE AMANDA3.FILE",
@@ -387,6 +392,8 @@ namespace FluentFTP.Tests.Unit {
 			};
 
 			var expected = new FtpListItem[]{
+				new FtpListItem("datamods", 8192, FtpObjectType.Directory, new DateTime(2016, 3, 30, 9, 0, 51, 0)),
+				new FtpListItem("D1234831.013", 2865, FtpObjectType.File, new DateTime(2022, 9, 1, 4, 36, 4, 0)),
 				new FtpListItem("ANTHONY1.FILE", 45056, FtpObjectType.File, new DateTime(2014, 12, 4, 14, 19, 31, 0)),
 				new FtpListItem("ANTHONY1.FILE/ANTHONY1.MBR", 0, FtpObjectType.File, new DateTime(1, 1, 1, 0, 0, 0, 0)),
 				new FtpListItem("AMANDA3.FILE", 36864, FtpObjectType.File, new DateTime(2015, 11, 28, 15, 19, 30, 0)),
@@ -397,7 +404,7 @@ namespace FluentFTP.Tests.Unit {
 				new FtpListItem("FPKI45POK5.FILE/FPKI45POK5.MBR", 0, FtpObjectType.File, new DateTime(1, 1, 1, 0, 0, 0, 0)),
 			};
 
-			TestParsing(parser, "/", sample, expected);
+			TestParsing(parser, "/user/tests/prodload", sample, expected);
 
 		}
 		[Fact]
@@ -431,7 +438,9 @@ namespace FluentFTP.Tests.Unit {
 
 		[Fact]
 		public void IBMzOSMVS_HFS() {
-			var parser = new FtpListParser(new FtpClient());
+			var client = new FtpClient();
+			client.ServerHandler = ServerModule.GetServerHandler(FtpServer.IBMzOSFTP);
+			var parser = new FtpListParser(client);
 			parser.Init(FtpOperatingSystem.IBMzOS, FtpParser.IBMzOS);
 
 			var sample = new[] {
@@ -444,13 +453,25 @@ namespace FluentFTP.Tests.Unit {
 				"-rw-rw----   1 YNSAS    SYS1       47227 Jun  7  2021 test.txt",
 			};
 
-			TestParsing(parser, "/", sample, null);
+			var expected = new FtpListItem[]{
+				null,
+				new FtpListItem("downloads", 8192, FtpObjectType.Directory, new DateTime(2015, 10, 19, 0, 0, 0, 0)),
+				new FtpListItem("p5zipfile", 8192, FtpObjectType.Directory, new DateTime(2015, 10, 19, 0, 0, 0, 0)),
+				new FtpListItem("t.out", 2723828, FtpObjectType.File, new DateTime(2021, 12, 6, 0, 0, 0, 0)),
+				new FtpListItem("test.bin", 132480, FtpObjectType.File, new DateTime(2022, 1, 2, 0, 0, 0, 0)),
+				new FtpListItem("test.tst", 6209406, FtpObjectType.File, new DateTime(2021, 5, 29, 0, 0, 0, 0)),
+				new FtpListItem("test.txt", 47227, FtpObjectType.File, new DateTime(2021, 6, 7, 0, 0, 0, 0)),
+			};
+
+			TestParsing(parser, "/", sample, expected);
 
 		}
 
 		[Fact]
 		public void IBMzOSMVS_PSPO() {
-			var parser = new FtpListParser(new FtpClient());
+			var client = new FtpClient();
+			client.ServerHandler = ServerModule.GetServerHandler(FtpServer.IBMzOSFTP);
+			var parser = new FtpListParser(client);
 			parser.Init(FtpOperatingSystem.IBMzOS, FtpParser.IBMzOS);
 
 			var sample = new[] {
@@ -459,13 +480,21 @@ namespace FluentFTP.Tests.Unit {
 				"YNSABH 3390   2022/02/18  1+++++  VBS  32767 27966  PS  $.BDATA.XBB",
 			};
 
-			TestParsing(parser, "/", sample, null);
+			var expected = new FtpListItem[]{
+				null,
+				new FtpListItem("$.ADATA.XAA", 849960, FtpObjectType.File, new DateTime(2020, 1, 3, 0, 0, 0, 0)),
+				new FtpListItem("$.BDATA.XBB", 950664167424, FtpObjectType.File, new DateTime(2022, 2, 18, 0, 0, 0, 0)),
+			};
+
+			TestParsing(parser, "/", sample, expected);
 
 		}
 
 		[Fact]
 		public void IBMzOSMVS_Member() {
-			var parser = new FtpListParser(new FtpClient());
+			var client = new FtpClient();
+			client.ServerHandler = ServerModule.GetServerHandler(FtpServer.IBMzOSFTP);
+			var parser = new FtpListParser(client);
 			parser.Init(FtpOperatingSystem.IBMzOS, FtpParser.IBMzOS);
 
 			var sample = new[] {
@@ -473,13 +502,18 @@ namespace FluentFTP.Tests.Unit {
 				"$2CPF1    01.01 2001/10/18 2001/10/18 11:58    29    29     0 QFX3076",
 			};
 
+			// Cannot test expected as this szenario needs an internal XDSS command to get LRECL
+			// for size calculation
+
 			TestParsing(parser, "/", sample, null);
 
 		}
 
 		[Fact]
 		public void IBMzOSMVS_MemberU() {
-			var parser = new FtpListParser(new FtpClient());
+			var client = new FtpClient();
+			client.ServerHandler = ServerModule.GetServerHandler(FtpServer.IBMzOSFTP);
+			var parser = new FtpListParser(client);
 			parser.Init(FtpOperatingSystem.IBMzOS, FtpParser.IBMzOS);
 
 			var sample = new[] {
@@ -488,7 +522,13 @@ namespace FluentFTP.Tests.Unit {
 				"EAGRTPRC  005F48   000011 EAGRTALT 00 FO             RN RU            31    ANY",
 			};
 
-			TestParsing(parser, "/", sample, null);
+			var expected = new FtpListItem[]{
+				null,
+				new FtpListItem("EAGKCPT", 88, FtpObjectType.File, new DateTime(1 ,1, 1, 0, 0, 0, 0)),
+				new FtpListItem("EAGRTPRC", 24392, FtpObjectType.File, new DateTime(1, 1, 1, 0, 0, 0, 0)),
+			};
+
+			TestParsing(parser, "/", sample, expected);
 
 		}
 


### PR DESCRIPTION
**DO NOT MERGE**

Hi Robin,

while finagling some tests for the OS400 issue recently, I noticed that the parser tests were not calling any custom server handler routines. This didn't hurt up to now, success was still reported. Only for my special tests did this show up.

So I needed to change the small `new parser` and `new client` setup slightly, to make the new client get a specific server handler.

**But**: This meant changing 'ServerModule` to public (from internal). I don't think that is really what you would like. **Is there any other way to do this?**:

```
			var client = new FtpClient();
			client.ServerHandler = ServerModule.GetServerHandler(FtpServer.IBMOS400FTP);
			var parser = new FtpListParser(client);
			parser.Init(FtpOperatingSystem.IBMOS400, FtpParser.IBMOS400);
```

The only other place where the server handler is actually set, is within a (successful) connect.

** NOTE: Since this is not really needed, perhaps only a comment would suffice, to warn future coders in this test code that the ServerHandlers are not set, so not to surprised when using the test facility to debug a parser.
