### PR TITLE
Fix issue 954

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1235,7 +1235,9 @@ namespace FluentFTP {
 		/// </summary>
 		public void Accept() {
 			if (m_socket != null) {
+				var socketSave = m_socket;
 				m_socket = m_socket.Accept();
+				socketSave.Close();
 			}
 		}
 
@@ -1260,7 +1262,9 @@ namespace FluentFTP {
 		/// <param name="ar">IAsyncResult returned from BeginAccept</param>
 		public void EndAccept(IAsyncResult ar) {
 			if (m_socket != null) {
+				var socketSave = m_socket;
 				m_socket = m_socket.EndAccept(ar);
+				socketSave.Close();
 				m_netStream = new NetworkStream(m_socket);
 				m_netStream.ReadTimeout = m_readTimeout;
 			}
@@ -1283,7 +1287,9 @@ namespace FluentFTP {
 		/// </summary>
 		public async Task AcceptAsync() {
 			if (m_socket != null) {
+				var socketSave = m_socket;
 				m_socket = await m_socket.AcceptAsync();
+				socketSave.Close();
 #if NETSTANDARD
 				m_netStream = new NetworkStream(m_socket);
 				m_netStream.ReadTimeout = m_readTimeout;


### PR DESCRIPTION
** Active Mode, cannot reuse the ActivePorts **

Please refer to the excellent problem description on #954

Accepting on a listening socket creates a **new** socket. The previous code simply took over the new socket, literally leaving the listening socket sitting there, still listening, for eternity, thus it was no longer eligible when the next request tried to select an available socket.

The new approach is to close this listening socket after accepting from it.

Surprisingly, a shallow copy of the socket suffices to be able to do this.

Passes the intergration tests.
