### PR TITLE
Optimize SIZE command usage for UploadFile NoCheck AND OverWrite (Issue #858)

### DIFF
--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -27,7 +27,7 @@ namespace FluentFTP {
 			}
 
 			try {
-				long localPosition = 0, remotePosition = 0, remoteFileLen = 0;
+				long localPosition = 0, remotePosition = 0, remoteFileLen = -1;
 
 				// check if the file exists, and skip, overwrite or append
 				if (existsMode == FtpRemoteExists.NoCheck) {

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -27,7 +27,7 @@ namespace FluentFTP {
 			}
 
 			try {
-				long localPosition = 0, remotePosition = 0, remoteFileLen = 0;
+				long localPosition = 0, remotePosition = 0, remoteFileLen = -1;
 
 				// check if the file exists, and skip, overwrite or append
 				if (existsMode == FtpRemoteExists.NoCheck) {


### PR DESCRIPTION
Please see the tail end of Issue #858 

After adding the needed code, I realised that a refactor of `UploadFileInternal` would optimise the use of the SIZE command **not only** for the case when `NoCheck` is requested, but **also** for the case when `OverWrite` is active.

Here is what it now looks like if `Overwrite` is requested (only one SIZE command, previously there were **two!**):
```
>         UploadFile("D:\temp\test1", "/home/mike/test1", Overwrite, False, None)
>         FileExists("/home/mike/test1")
Command:  SIZE /home/mike/test1
Response: 550 /home/mike/test1: No such file or directory
>         OpenWrite("/home/mike/test1", Binary)
>         OpenActiveDataStream(PORT, "STOR /home/mike/test1", 0)
Command:  PORT 192,168,1,147,31,146
Response: 200 PORT command successful
Command:  STOR /home/mike/test1
Response: 150 Opening BINARY mode data connection for /home/mike/test1
Response: 226 Transfer complete
```
And for `NoCheck` (no SIZE command, previously there was **one!**):
```
>         UploadFile("D:\temp\test1", "/home/mike/test1", NoCheck, False, None)
>         OpenWrite("/home/mike/test1", Binary)
Command:  TYPE I
Response: 200 Type set to I
>         OpenActiveDataStream(PORT, "STOR /home/mike/test1", 0)
Command:  PORT 192,168,1,147,31,146
Response: 200 PORT command successful
Command:  STOR /home/mike/test1
Response: 150 Opening BINARY mode data connection for /home/mike/test1
Response: 226 Transfer complete
```
