### PR TITLE
Add null checks when disposing

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -35,10 +35,8 @@ namespace FluentFTP {
 				// open the file for reading
 				downStream = await OpenRead(remotePath, Config.DownloadDataType, restartPosition, fileLen, token);
 				// workaround for SOCKS4 and SOCKS4a proxies
-				if (restartPosition == 0)
-				{
-					if (this is AsyncFtpClientSocks4Proxy || this is AsyncFtpClientSocks4aProxy)
-					{
+				if (restartPosition == 0) {
+					if (this is AsyncFtpClientSocks4Proxy || this is AsyncFtpClientSocks4aProxy) {
 						// first 6 bytes contains 2 bytes of unknown (to me) purpose and 4 ip address bytes
 						// we need to skip them otherwise they will be downloaded to the file
 						// moreover, these bytes cause "Failed to get the EPSV port" error
@@ -163,7 +161,7 @@ namespace FluentFTP {
 
 				// Fix #552: close the filestream if it was created in this method
 				if (disposeOutStream) {
-					outStream.Dispose();
+					outStream?.Dispose();
 					disposeOutStream = false;
 				}
 
@@ -205,7 +203,7 @@ namespace FluentFTP {
 
 				// close stream before throwing error
 				try {
-					downStream.Dispose();
+					downStream?.Dispose();
 				}
 				catch (Exception) {
 				}
@@ -213,7 +211,7 @@ namespace FluentFTP {
 				// Fix #552: close the filestream if it was created in this method
 				if (disposeOutStream) {
 					try {
-						outStream.Dispose();
+						outStream?.Dispose();
 						disposeOutStream = false;
 					}
 					catch (Exception) {

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -35,10 +35,8 @@ namespace FluentFTP {
 				// open the file for reading
 				downStream = OpenRead(remotePath, Config.DownloadDataType, restartPosition, fileLen);
 				// workaround for SOCKS4 and SOCKS4a proxies
-				if (restartPosition == 0)
-				{
-					if (this is FtpClientSocks4Proxy || this is FtpClientSocks4aProxy)
-					{
+				if (restartPosition == 0) {
+					if (this is FtpClientSocks4Proxy || this is FtpClientSocks4aProxy) {
 						// first 6 bytes contains 2 bytes of unknown (to me) purpose and 4 ip address bytes
 						// we need to skip them otherwise they will be downloaded to the file
 						// moreover, these bytes cause "Failed to get the EPSV port" error
@@ -156,7 +154,7 @@ namespace FluentFTP {
 
 				// Fix #552: close the filestream if it was created in this method
 				if (disposeOutStream) {
-					outStream.Dispose();
+					outStream?.Dispose();
 					disposeOutStream = false;
 				}
 
@@ -198,7 +196,7 @@ namespace FluentFTP {
 
 				// close stream before throwing error
 				try {
-					downStream.Dispose();
+					downStream?.Dispose();
 				}
 				catch (Exception) {
 				}
@@ -206,7 +204,7 @@ namespace FluentFTP {
 				// Fix #552: close the filestream if it was created in this method
 				if (disposeOutStream) {
 					try {
-						outStream.Dispose();
+						outStream?.Dispose();
 						disposeOutStream = false;
 					}
 					catch (Exception) {


### PR DESCRIPTION
I believe this fixes #961, but I haven't tried it out.

When `OpenRead` throws an exception `downStream` isn't assigned to a non-null value.
This causes a `NullReferenceException` when trying to dispose it.
The exception is immediately caught but that has two drawbacks.
* It's much more expensive to throw and catch an exception than null checking it.
* As reported in the issue it breaks the IDE when a debugger is attached and `NullReferenceException` is checked in "Exception Settings".