### PR TITLE
Fix/Enhance #704 Consider including Code in FtpReply Message

### DIFF
--- a/FluentFTP.Tests/Unit/ExceptionTests.cs
+++ b/FluentFTP.Tests/Unit/ExceptionTests.cs
@@ -1,0 +1,20 @@
+using FluentFTP.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xunit;
+
+namespace FluentFTP.Tests.Unit {
+	public class ExceptionTests {
+
+		[Fact]
+		public void FtpCommandException_includes_CompletionCode_in_message() {
+
+			Action act = () => throw new FtpCommandException("501", "MyErrorMessage");
+
+			var exception = Assert.Throws<FtpCommandException>(act);
+			Assert.Contains("501", exception.ToString());
+			Assert.Contains("MyErrorMessage", exception.ToString());
+		}
+	}
+}

--- a/FluentFTP/Exceptions/FtpCommandException.cs
+++ b/FluentFTP/Exceptions/FtpCommandException.cs
@@ -44,6 +44,8 @@ namespace FluentFTP {
 			}
 		}
 
+		public override string Message => $"Code: {CompletionCode} Message: {base.Message}";
+
 		/// <summary>
 		/// Initializes a new instance of a FtpResponseException
 		/// </summary>


### PR DESCRIPTION
Thanks @jnyrup for your patience with this. Dunno why you didn't PR this yourself - as I had seen empty FtpCommandExceptions myself I decided I would like this too.

Adding a test is of course totally the icing on the cake and I copy/pasted that from you too.

@robinrodricks Depends on you to feel happy with this new message format:

![image](https://user-images.githubusercontent.com/51046875/192028180-03ffce61-1a7f-4e09-80a8-df29626ce34d.png)
