### PR TITLE
Show protocol in Auth Success message

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1091,7 +1091,7 @@ namespace FluentFTP {
 				}
 
 				auth_time_total = DateTime.Now.Subtract(auth_start);
-				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Info, "FTPS Authentication Successful");
+				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Info, "FTPS authentication successful, protocol = " + Client.SslProtocolActive);
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Time to activate encryption: " + auth_time_total.Hours + "h " + auth_time_total.Minutes + "m " + auth_time_total.Seconds + "s.  Total Seconds: " + auth_time_total.TotalSeconds + ".");
 			}
 			catch (AuthenticationException) {
@@ -1181,7 +1181,7 @@ namespace FluentFTP {
 				}
 
 				auth_time_total = DateTime.Now.Subtract(auth_start);
-				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Info, "FTPS Authentication Successful");
+				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Info, "FTPS authentication successful, protocol = " + Client.SslProtocolActive);
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Time to activate encryption: " + auth_time_total.Hours + "h " + auth_time_total.Minutes + "m " + auth_time_total.Seconds + "s.  Total Seconds: " + auth_time_total.TotalSeconds + ".");
 			}
 			catch (AuthenticationException) {


### PR DESCRIPTION
I find this very useful when debugging connects.

Show protocol in the FTPS authentication successful message. Change some upper case to lower case at the same time.

```
Command:  AUTH TLS
Status:   Waiting for response to: AUTH TLS
Response: 234 AUTH TLS successful
Status:   FTPS Authentication Successful, protocol = Tls12
Status:   Time to activate encryption: 0h 0m 0s.  Total Seconds: 0,0030331.
```