### PR TITLE
Forward CancellationToken in async calls

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -40,7 +40,7 @@ namespace FluentFTP {
 						// first 6 bytes contains 2 bytes of unknown (to me) purpose and 4 ip address bytes
 						// we need to skip them otherwise they will be downloaded to the file
 						// moreover, these bytes cause "Failed to get the EPSV port" error
-						await downStream.ReadAsync(new byte[6], 0, 6);
+						await downStream.ReadAsync(new byte[6], 0, 6, token);
 					}
 				}
 

--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4Proxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4Proxy.cs
@@ -28,7 +28,7 @@ namespace FluentFTP.Proxy.AsyncProxy {
 		protected override async Task ConnectAsync(FtpSocketStream stream, CancellationToken cancellationToken) {
 			await base.ConnectAsync(stream, cancellationToken);
 			var proxy = new Socks4Proxy(Host, Port, stream);
-			await proxy.ConnectAsync();
+			await proxy.ConnectAsync(cancellationToken);
 		}
 
 	}

--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4aProxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4aProxy.cs
@@ -28,7 +28,7 @@ namespace FluentFTP.Proxy.AsyncProxy {
 		protected override async Task ConnectAsync(FtpSocketStream stream, CancellationToken cancellationToken) {
 			await base.ConnectAsync(stream, cancellationToken);
 			var proxy = new Socks4aProxy(Host, Port, stream);
-			await proxy.ConnectAsync();
+			await proxy.ConnectAsync(cancellationToken);
 		}
 	}
 }

--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks5Proxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks5Proxy.cs
@@ -21,9 +21,9 @@ namespace FluentFTP.Proxy.AsyncProxy {
 		protected override async Task ConnectAsync(FtpSocketStream stream, CancellationToken cancellationToken) {
 			await base.ConnectAsync(stream, cancellationToken);
 			var proxy = new SocksProxy(Host, Port, stream, Proxy);
-			await proxy.NegotiateAsync();
-			await proxy.AuthenticateAsync();
-			await proxy.ConnectAsync();
+			await proxy.NegotiateAsync(cancellationToken);
+			await proxy.AuthenticateAsync(cancellationToken);
+			await proxy.ConnectAsync(cancellationToken);
 		}
 	}
 }

--- a/FluentFTP/Proxy/Socks/Socks4Proxy.cs
+++ b/FluentFTP/Proxy/Socks/Socks4Proxy.cs
@@ -90,7 +90,7 @@ namespace FluentFTP.Proxy.Socks {
 			}
 		}
 
-		public virtual async Task ConnectAsync() {
+		public virtual async Task ConnectAsync(CancellationToken cancellationToken) {
 			// The client connects to the server,
 			// and sends a version identifier / method selection message.
 			byte[] destIp = GetIPAddressBytes(_destinationHost);
@@ -103,11 +103,11 @@ namespace FluentFTP.Proxy.Socks {
 			destIp.CopyTo(methodsBuffer, 4);
 			methodsBuffer[8] = 0x00;  // null (byte with all zeros) terminator
 
-			await _socketStream.WriteAsync(methodsBuffer, 0, methodsBuffer.Length);
+			await _socketStream.WriteAsync(methodsBuffer, 0, methodsBuffer.Length, cancellationToken);
 
 			// The server selects from one of the methods given in METHODS,
 			// and sends a METHOD selection message:
-			var receivedBytes = await _socketStream.ReadAsync(_buffer, 0, 2);
+			var receivedBytes = await _socketStream.ReadAsync(_buffer, 0, 2, cancellationToken);
 			if (receivedBytes != 2) {
 				_socketStream.Close();
 				throw new FtpProxyException($"Negotiation Response had an invalid length of {receivedBytes}");

--- a/FluentFTP/Proxy/Socks/Socks4aProxy.cs
+++ b/FluentFTP/Proxy/Socks/Socks4aProxy.cs
@@ -63,7 +63,7 @@ namespace FluentFTP.Proxy.Socks {
 			}
 		}
 
-		public override async Task ConnectAsync() {
+		public override async Task ConnectAsync(CancellationToken cancellationToken) {
 			// The client connects to the server,
 			// and sends a version identifier / method selection message.
 			byte[] destIp = { 0, 0, 0, 1 };
@@ -79,11 +79,11 @@ namespace FluentFTP.Proxy.Socks {
 			hostBytes.CopyTo(methodsBuffer, 9);  // copy the host name to the request byte array
 			methodsBuffer[13] = 0x00;  // null (byte with all zeros) terminator
 
-			await _socketStream.WriteAsync(methodsBuffer, 0, methodsBuffer.Length);
+			await _socketStream.WriteAsync(methodsBuffer, 0, methodsBuffer.Length, cancellationToken);
 
 			// The server selects from one of the methods given in METHODS,
 			// and sends a METHOD selection message:
-			var receivedBytes = await _socketStream.ReadAsync(_buffer, 0, 2);
+			var receivedBytes = await _socketStream.ReadAsync(_buffer, 0, 2, cancellationToken);
 			if (receivedBytes != 2) {
 				_socketStream.Close();
 				throw new FtpProxyException($"Negotiation Response had an invalid length of {receivedBytes}");

--- a/FluentFTP/Servers/Handlers/IBMzOSFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IBMzOSFtpServer.cs
@@ -342,10 +342,10 @@ namespace FluentFTP.Servers.Handlers {
 		/// Return null indicates custom code decided not to handle this
 		/// Return concatenation of path and filename
 		/// </summary>
-		public override async Task<string> GetAbsoluteFilePathAsync(AsyncFtpClient client, string path, string fileName, CancellationToken token) {
+		public override Task<string> GetAbsoluteFilePathAsync(AsyncFtpClient client, string path, string fileName, CancellationToken token) {
 
 			if (!path.StartsWith("\'")) {
-				return null;
+				return Task.FromResult<string>(null);
 			}
 
 			if (path.EndsWith(".\'")) {
@@ -355,7 +355,7 @@ namespace FluentFTP.Servers.Handlers {
 				path = path.TrimEnd('\'') + "(" + fileName.Substring(0, 8) + ")\'";
 			}
 
-			return path;
+			return Task.FromResult(path);
 		}
 
 		/// <summary>

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -426,7 +426,11 @@ namespace FluentFTP {
 			var read = 0;
 
 			if (m_socket != null && m_socket.Connected && !token.IsCancellationRequested) {
+#if NET6_0_OR_GREATER
+				read = await m_socket.ReceiveAsync(buffer, 0, token);
+#else
 				read = await m_socket.ReceiveAsync(new ArraySegment<byte>(buffer), 0);
+#endif
 			}
 
 			return read;
@@ -913,7 +917,11 @@ namespace FluentFTP {
 		/// <param name="ipVersions">Internet Protocol versions to support during the connection phase</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		public async Task ConnectAsync(string host, int port, FtpIpVersion ipVersions, CancellationToken token) {
+#if NET6_0_OR_GREATER
+			IPAddress[] addresses = await Dns.GetHostAddressesAsync(host, token);
+#else
 			IPAddress[] addresses = await Dns.GetHostAddressesAsync(host);
+#endif
 
 			if (ipVersions == 0) {
 				throw new ArgumentException("The ipVersions parameter must contain at least 1 flag.");
@@ -1121,19 +1129,19 @@ namespace FluentFTP {
 			// Fix: user needs NOOPs - See #823
 			// Fix: running on .NET 5.0 and later due to issues in .NET framework - See #682
 #if NET50_OR_LATER
-			if ( (Client.Config.SslBuffering == FtpsBuffering.On || Client.Config.SslBuffering == FtpsBuffering.Auto) ) {
+			if ((Client.Config.SslBuffering == FtpsBuffering.On || Client.Config.SslBuffering == FtpsBuffering.Auto)) {
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Warn, "SSL Buffering force disabled, is .NET 5.0 and later");
 			}
 
 			m_bufStream = null;
 #else
-			if ( (Client.Config.SslBuffering == FtpsBuffering.On || Client.Config.SslBuffering == FtpsBuffering.Auto) &&
-        		 (!Client.IsProxy()) &&
-				 (Client.Config.NoopInterval == 0) ) {
+			if ((Client.Config.SslBuffering == FtpsBuffering.On || Client.Config.SslBuffering == FtpsBuffering.Auto) &&
+				 (!Client.IsProxy()) &&
+				 (Client.Config.NoopInterval == 0)) {
 				m_bufStream = new BufferedStream(NetworkStream, 81920);
 			}
 			else {
-				if ( (Client.Config.SslBuffering == FtpsBuffering.On || Client.Config.SslBuffering == FtpsBuffering.Auto) ) {
+				if ((Client.Config.SslBuffering == FtpsBuffering.On || Client.Config.SslBuffering == FtpsBuffering.Auto)) {
 					if (Client.IsProxy()) {
 						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Warn, "SSL Buffering force disabled, is proxy");
 					}
@@ -1141,7 +1149,7 @@ namespace FluentFTP {
 						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Warn, "SSL Buffering force disabled, NOOPs requested");
 					}
 				}
-				
+
 				m_bufStream = null;
 			}
 #endif


### PR DESCRIPTION
Found some places where a `CancellationToken` was not passed along.

The changes in PR only changes method signatures that are not publicly exposed.

These methods do not take a `CancellationToken` but call a method that does take a `CancellationToken`, but I didn't change them as they are public.

* `PurgeSuccessfulUploadsAsync` -> `DeleteFile`
* `ResumeDownloadAsync` -> `OpenRead`
* `ResumeUploadAsync` -> `OpenAppend`
* `ActivateEncryptionAsync` -> `AuthenticateAsClientAsync`
* `GetFilesToTransfer` -> `GetFileSize`
* `FtpSocketStream.AcceptAsync` -> `Socket.AcceptAsync`