### PR TITLE
Next step: Read stale data

### DIFF
--- a/FluentFTP/Client/AsyncClient/Authenticate.cs
+++ b/FluentFTP/Client/AsyncClient/Authenticate.cs
@@ -44,7 +44,7 @@ namespace FluentFTP {
 
 				// fix for #620: some servers send multiple responses that must be read and decoded,
 				// otherwise the connection is aborted and remade and it goes into an infinite loop
-				var staleData = await ReadStaleData(false, true, true, token);
+				var staleData = await ReadStaleDataAsync(false, true, "in authentication", token);
 				if (staleData != null) {
 					var staleReply = new FtpReply();
 					if (DecodeStringToReply(staleData, ref staleReply) && !staleReply.Success) {

--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -187,7 +187,7 @@ namespace FluentFTP {
 
 						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
 						if (anyNoop) {
-							await ReadStaleData(false, true, true, token);
+							await ReadStaleDataAsync(false, true, "after download", token);
 						}
 
 						break;

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -22,9 +22,9 @@ namespace FluentFTP {
 
 			if (Config.StaleDataCheck && Status.AllowCheckStaleData) {
 #if NETSTANDARD
-				await ReadStaleData(true, false, true, token);
+				await ReadStaleDataAsync(true, true, "prior to command execution", token);
 #else
-				ReadStaleData(true, false, true);
+				ReadStaleData(true, true, "prior to command execution");
 #endif
 			}
 

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -261,7 +261,7 @@ namespace FluentFTP {
 
 						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
 						if (anyNoop) {
-							await ReadStaleData(false, true, true, token);
+							await ReadStaleDataAsync(false, true, "after upload", token);
 						}
 
 						break;

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -16,7 +16,7 @@ namespace FluentFTP.Client.BaseClient {
 
 			lock (m_lock) {
 				if (Config.StaleDataCheck && Status.AllowCheckStaleData) {
-					ReadStaleData(true, false, true);
+					ReadStaleData(true, true, "prior to command execution");
 				}
 
 				if (!IsConnected) {

--- a/FluentFTP/Client/BaseClient/ReadStaleData.cs
+++ b/FluentFTP/Client/BaseClient/ReadStaleData.cs
@@ -12,32 +12,43 @@ namespace FluentFTP.Client.BaseClient {
 		/// Returns the stale data as text, if any, or null if none was found.
 		/// </summary>
 		/// <param name="closeStream">close the connection?</param>
-		/// <param name="evenEncrypted">even read encrypted data?</param>
-		/// <param name="traceData">trace data to logs?</param>
-		protected string ReadStaleData(bool closeStream, bool evenEncrypted, bool traceData) {
+		/// <param name="logData">copy stale data information to logs?</param>
+		/// <param name="logFrom">for the log information</param>
+		protected string ReadStaleData(bool closeStream, bool logData, string logFrom) {
 			string staleData = null;
-			if (m_stream != null && m_stream.SocketDataAvailable > 0) {
-				if (traceData) {
-					LogWithPrefix(FtpTraceLevel.Info, "There is stale data on the socket, maybe our connection timed out or you did not call GetReply(). Re-connecting...");
-				}
 
-				if (m_stream.IsConnected && (!m_stream.IsEncrypted || evenEncrypted)) {
-					var buf = new byte[m_stream.SocketDataAvailable];
-					m_stream.RawSocketRead(buf);
-					staleData = Encoding.GetString(buf).TrimEnd('\r', '\n');
-					if (traceData) {
+			if (logData) {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Checking for stale data: " + logFrom);
+			}
+
+			if (m_stream != null) {
+				while (m_stream.SocketDataAvailable > 0) {
+					if (logData) {
+						LogWithPrefix(FtpTraceLevel.Info, "Socket has stale data");
+					}
+					byte[] buf = new byte[m_stream.SocketDataAvailable];
+					if (m_stream.IsEncrypted) {
+						m_stream.Read(buf, 0, buf.Length);
+					}
+					else {
+						m_stream.RawSocketRead(buf);
+					}
+					staleData = Encoding.GetString(buf).TrimEnd('\0', '\r', '\n');
+					if (logData) {
 						LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: " + staleData);
 					}
-					if (string.IsNullOrEmpty(staleData)) {
-						closeStream = false;
-					}
-				}
-
-				if (closeStream) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "Closing stream because of stale data");
-					m_stream.Close();
 				}
 			}
+
+			if (string.IsNullOrEmpty(staleData)) {
+				closeStream = false;
+			}
+
+			if (closeStream) {
+				LogWithPrefix(FtpTraceLevel.Info, "Closing stream because of stale data");
+				m_stream.Close();
+			}
+
 			return staleData;
 		}
 
@@ -47,30 +58,43 @@ namespace FluentFTP.Client.BaseClient {
 		/// Returns the stale data as text, if any, or null if none was found.
 		/// </summary>
 		/// <param name="closeStream">close the connection?</param>
-		/// <param name="evenEncrypted">even read encrypted data?</param>
-		/// <param name="traceData">trace data to logs?</param>
+		/// <param name="logData">copy stale data information to logs?</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
-		protected async Task<string> ReadStaleData(bool closeStream, bool evenEncrypted, bool traceData, CancellationToken token) {
+		protected async Task<string> ReadStaleDataAsync(bool closeStream, bool traceData, string logFrom, CancellationToken token) {
 			string staleData = null;
-			if (m_stream != null && m_stream.SocketDataAvailable > 0) {
-				if (traceData) {
-					LogWithPrefix(FtpTraceLevel.Info, "There is stale data on the socket, maybe our connection timed out or you did not call GetReply(). Re-connecting...");
-				}
 
-				if (m_stream.IsConnected && (!m_stream.IsEncrypted || evenEncrypted)) {
-					var buf = new byte[m_stream.SocketDataAvailable];
-					await m_stream.RawSocketReadAsync(buf, token);
-					staleData = Encoding.GetString(buf).TrimEnd('\r', '\n');
+			if (traceData) {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Checking for stale data: " + logFrom);
+			}
+
+			if (m_stream != null) {
+				while (m_stream.SocketDataAvailable > 0) {
+					if (traceData) {
+						LogWithPrefix(FtpTraceLevel.Info, "Socket has stale data");
+					}
+					byte[] buf = new byte[m_stream.SocketDataAvailable];
+					if (m_stream.IsEncrypted) {
+						await m_stream.ReadAsync(buf, 0, buf.Length, token);
+					}
+					else {
+						await m_stream.RawSocketReadAsync(buf, token);
+					}
+					staleData = Encoding.GetString(buf).TrimEnd('\0', '\r', '\n');
 					if (traceData) {
 						LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: " + staleData);
 					}
 				}
-
-				if (closeStream) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "Closing stream because of stale data");
-					m_stream.Close();
-				}
 			}
+
+			if (string.IsNullOrEmpty(staleData)) {
+				closeStream = false;
+			}
+
+			if (closeStream) {
+				LogWithPrefix(FtpTraceLevel.Info, "Closing stream because of stale data");
+				m_stream.Close();
+			}
+
 			return staleData;
 		}
 

--- a/FluentFTP/Client/BaseClient/ReadStaleData.cs
+++ b/FluentFTP/Client/BaseClient/ReadStaleData.cs
@@ -22,6 +22,7 @@ namespace FluentFTP.Client.BaseClient {
 			}
 
 			if (m_stream != null) {
+
 				while (m_stream.SocketDataAvailable > 0) {
 					if (logData) {
 						LogWithPrefix(FtpTraceLevel.Info, "Socket has stale data");
@@ -38,15 +39,16 @@ namespace FluentFTP.Client.BaseClient {
 						LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: " + staleData);
 					}
 				}
-			}
 
-			if (string.IsNullOrEmpty(staleData)) {
-				closeStream = false;
-			}
+				if (string.IsNullOrEmpty(staleData)) {
+					closeStream = false;
+				}
 
-			if (closeStream) {
-				LogWithPrefix(FtpTraceLevel.Info, "Closing stream because of stale data");
-				m_stream.Close();
+				if (closeStream) {
+					LogWithPrefix(FtpTraceLevel.Info, "Closing stream because of stale data");
+					m_stream.Close();
+				}
+
 			}
 
 			return staleData;
@@ -68,6 +70,7 @@ namespace FluentFTP.Client.BaseClient {
 			}
 
 			if (m_stream != null) {
+
 				while (m_stream.SocketDataAvailable > 0) {
 					if (traceData) {
 						LogWithPrefix(FtpTraceLevel.Info, "Socket has stale data");
@@ -84,15 +87,16 @@ namespace FluentFTP.Client.BaseClient {
 						LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: " + staleData);
 					}
 				}
-			}
 
-			if (string.IsNullOrEmpty(staleData)) {
-				closeStream = false;
-			}
+				if (string.IsNullOrEmpty(staleData)) {
+					closeStream = false;
+				}
 
-			if (closeStream) {
-				LogWithPrefix(FtpTraceLevel.Info, "Closing stream because of stale data");
-				m_stream.Close();
+				if (closeStream) {
+					LogWithPrefix(FtpTraceLevel.Info, "Closing stream because of stale data");
+					m_stream.Close();
+				}
+
 			}
 
 			return staleData;

--- a/FluentFTP/Client/SyncClient/Authenticate.cs
+++ b/FluentFTP/Client/SyncClient/Authenticate.cs
@@ -45,7 +45,7 @@ namespace FluentFTP {
 
 				// fix for #620: some servers send multiple responses that must be read and decoded,
 				// otherwise the connection is aborted and remade and it goes into an infinite loop
-				var staleData = ReadStaleData(false, true, true);
+				var staleData = ReadStaleData(false, true, "in authentication");
 				if (staleData != null) {
 					var staleReply = new FtpReply();
 					if (DecodeStringToReply(staleData, ref staleReply) && !staleReply.Success) {

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -180,7 +180,7 @@ namespace FluentFTP {
 
 						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
 						if (anyNoop) {
-							ReadStaleData(false, true, true);
+							ReadStaleData(false, true, "after download");
 						}
 
 						break;

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -253,7 +253,7 @@ namespace FluentFTP {
 
 						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
 						if (anyNoop) {
-							ReadStaleData(false, true, true);
+							ReadStaleData(false, true, "after upload");
 						}
 
 						break;


### PR DESCRIPTION
This is a simple addition to `ReadStaleData` which does not change very much.

Each call to this method is garnished with an additional string parameter so that in verbose logging, you can see from where it has been called.

More importantly, it decides to not use the raw socket for cleaning any stale data if encryption is turned on. 

With encryption turned on, this would be destructive in random (but quite often) occurring cases.

This change is not risky. It needs to be in place before I can put in the next one, for `GetReply`, because there is a dependancy.