### PR TITLE
Redundant If

### DIFF
--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -86,7 +86,7 @@ namespace FluentFTP {
 							throw new FtpSecurityNotAvailableException("AUTH TLS command failed.");
 						}
 					}
-					else if (reply.Success) {
+					else {
 						m_stream.ActivateEncryption(Host, Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null, Config.SslProtocols);
 					}
 				}


### PR DESCRIPTION
Maybe I am blind, so someone else also have a lool at this. I just stumbled accross it.

```
					reply = Execute("AUTH TLS");
					if (!reply.Success) {
						Status.ConnectionFTPSFailure = true;
						if (Config.EncryptionMode == FtpEncryptionMode.Explicit) {
							throw new FtpSecurityNotAvailableException("AUTH TLS command failed.");
						}
					}
					else if (reply.Success) {
						m_stream.ActivateEncryption(Host, Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null, Config.SslProtocols);
					}
```