### PR TITLE
Clean up parameters / signatures

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -67,6 +67,7 @@ namespace FluentFTP {
 				await m_stream.ActivateEncryptionAsync(Host,
 					Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
 					Config.SslProtocols,
+					true,
 					token);
 			}
 
@@ -92,6 +93,7 @@ namespace FluentFTP {
 					await m_stream.ActivateEncryptionAsync(Host,
 						Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
 						Config.SslProtocols,
+						true,
 						token);
 				}
 			}

--- a/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
@@ -129,7 +129,7 @@ namespace FluentFTP {
 				await stream.ActivateEncryptionAsync(m_host,
 					Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
 					Config.SslProtocols,
-					token);
+					token: token);
 			}
 
 			stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);

--- a/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
@@ -143,7 +143,7 @@ namespace FluentFTP {
 				await stream.ActivateEncryptionAsync(m_host,
 					Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
 					Config.SslProtocols,
-					token);
+					token: token);
 			}
 
 			return stream;

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -65,7 +65,10 @@ namespace FluentFTP {
 				m_stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);
 
 				if (Config.EncryptionMode == FtpEncryptionMode.Implicit) {
-					m_stream.ActivateEncryption(Host, Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null, Config.SslProtocols, true);
+					m_stream.ActivateEncryption(Host,
+						Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
+						Config.SslProtocols,
+						true);
 				}
 
 				Handshake();
@@ -87,7 +90,10 @@ namespace FluentFTP {
 						}
 					}
 					else {
-						m_stream.ActivateEncryption(Host, Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null, Config.SslProtocols, true);
+						m_stream.ActivateEncryption(Host,
+							Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
+							Config.SslProtocols,
+							true);
 					}
 				}
 


### PR DESCRIPTION
OpenActiveDataStream Sync/Async
OpenPassiveDataStream Sync/Async
Connect Sync/Async
FtpSocketStream : ActivateEncryption Sync/Async

Sorry, sort of got into a slight conflict here with you @jnyrup, on your token propagation. I did some reordering, removed some unused overloads and fixed up all the references.

Thanks also for reminding me of "Named Parameters". Should use them more often. 