### PR TITLE
Causer server hickup, release pending responses

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -170,6 +170,10 @@ namespace FluentFTP {
 
 				// FIX : if this is not added, there appears to be "stale data" on the socket
 				// listen for a success/failure reply
+
+				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
+				m_stream.WriteLine(Encoding, "NOOP");
+
 				try {
 					while (true) {
 						FtpReply status = await GetReply(token);

--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -172,7 +172,9 @@ namespace FluentFTP {
 				// listen for a success/failure reply
 
 				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				m_stream.WriteLine(Encoding, "NOOP");
+				if (anyNoop) {
+					m_stream.WriteLine(Encoding, "NOOP");
+				}
 
 				try {
 					while (true) {

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -246,7 +246,9 @@ namespace FluentFTP {
 				// listen for a success/failure reply
 
 				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				m_stream.WriteLine(Encoding, "NOOP");
+				if (anyNoop) {
+					m_stream.WriteLine(Encoding, "NOOP");
+				}
 
 				try {
 					while (true) {

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -244,6 +244,10 @@ namespace FluentFTP {
 
 				// FIX : if this is not added, there appears to be "stale data" on the socket
 				// listen for a success/failure reply
+
+				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
+				m_stream.WriteLine(Encoding, "NOOP");
+
 				try {
 					while (true) {
 						FtpReply status = await GetReply(token);

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -163,6 +163,10 @@ namespace FluentFTP {
 
 				// FIX : if this is not added, there appears to be "stale data" on the socket
 				// listen for a success/failure reply
+
+				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
+				m_stream.WriteLine(Encoding, "NOOP");
+
 				try {
 					while (true) {
 						var status = GetReply();

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -165,7 +165,9 @@ namespace FluentFTP {
 				// listen for a success/failure reply
 
 				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				m_stream.WriteLine(Encoding, "NOOP");
+				if (anyNoop) {
+					m_stream.WriteLine(Encoding, "NOOP");
+				}
 
 				try {
 					while (true) {

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -236,6 +236,10 @@ namespace FluentFTP {
 
 				// FIX : if this is not added, there appears to be "stale data" on the socket
 				// listen for a success/failure reply
+
+				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
+				m_stream.WriteLine(Encoding, "NOOP");
+
 				try {
 					while (true) {
 						var status = GetReply();

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -238,7 +238,9 @@ namespace FluentFTP {
 				// listen for a success/failure reply
 
 				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				m_stream.WriteLine(Encoding, "NOOP");
+				if (anyNoop) {
+					m_stream.WriteLine(Encoding, "NOOP");
+				}
 
 				try {
 					while (true) {


### PR DESCRIPTION
This is a very very dirty quick fix for those servers (.NET 6.0, vsftpd) that can't seem to want to relinquish their pent up NOOP responses **until the next command** comes along, which brings commands and responses out of sync.

It fixes the NOOP problems of vsftpd with .NET 6.0+
