### PR TITLE
Make #747 happy: Add LIST functionality for z/OS JES subsystem

### DIFF
--- a/FluentFTP/Client/AsyncClient/GetListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetListing.cs
@@ -273,7 +273,7 @@ namespace FluentFTP {
 			var isNoImage = options.HasFlag(FtpListOption.NoImage);
 
 			if (!isNoImage) {
-				// always get the file listing in binary to avoid character translation issues with ASCII.
+				// nearly always get the file listing in binary to avoid character translation issues with ASCII.
 				await SetDataTypeNoLockAsync(Config.ListingDataType, token);
 			}
 

--- a/FluentFTP/Client/AsyncClient/GetListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetListing.cs
@@ -270,9 +270,12 @@ namespace FluentFTP {
 		protected async Task<List<string>> GetListingInternal(string listcmd, FtpListOption options, bool retry, CancellationToken token) {
 			var rawlisting = new List<string>();
 			var isUseStat = options.HasFlag(FtpListOption.UseStat);
+			var isNoImage = options.HasFlag(FtpListOption.NoImage);
 
-			// always get the file listing in binary to avoid character translation issues with ASCII.
-			await SetDataTypeNoLockAsync(Config.ListingDataType, token);
+			if (!isNoImage) {
+				// always get the file listing in binary to avoid character translation issues with ASCII.
+				await SetDataTypeNoLockAsync(Config.ListingDataType, token);
+			}
 
 			try {
 

--- a/FluentFTP/Client/SyncClient/GetListing.cs
+++ b/FluentFTP/Client/SyncClient/GetListing.cs
@@ -171,9 +171,12 @@ namespace FluentFTP {
 		protected List<string> GetListingInternal(string listcmd, FtpListOption options, bool retry) {
 			var rawlisting = new List<string>();
 			var isUseStat = options.HasFlag(FtpListOption.UseStat);
+			var isNoImage = options.HasFlag(FtpListOption.NoImage);
 
 			// always get the file listing in binary to avoid character translation issues with ASCII.
-			SetDataTypeNoLock(Config.ListingDataType);
+			if (!isNoImage) {
+				SetDataTypeNoLock(Config.ListingDataType);
+			}
 
 			try {
 				// read in raw file listing from control stream

--- a/FluentFTP/Client/SyncClient/GetListing.cs
+++ b/FluentFTP/Client/SyncClient/GetListing.cs
@@ -173,7 +173,7 @@ namespace FluentFTP {
 			var isUseStat = options.HasFlag(FtpListOption.UseStat);
 			var isNoImage = options.HasFlag(FtpListOption.NoImage);
 
-			// always get the file listing in binary to avoid character translation issues with ASCII.
+			// nearly always get the file listing in binary to avoid character translation issues with ASCII.
 			if (!isNoImage) {
 				SetDataTypeNoLock(Config.ListingDataType);
 			}

--- a/FluentFTP/Enums/FtpListOption.cs
+++ b/FluentFTP/Enums/FtpListOption.cs
@@ -89,6 +89,12 @@ namespace FluentFTP {
 		/// <summary>
 		/// Force the use of STAT command for getting file listings
 		/// </summary>
-		UseStat = 1024
+		UseStat = 1024,
+
+		/// <summary>
+		/// Do not change the ASCII/Image setting to Image
+		/// </summary>
+		NoImage = 2048
+
 	}
 }

--- a/FluentFTP/Enums/FtpZOSListRealm.cs
+++ b/FluentFTP/Enums/FtpZOSListRealm.cs
@@ -29,6 +29,11 @@ namespace FluentFTP {
 		/// <summary>
 		/// Partitioned dataset member, RECFM = U
 		/// </summary>
-		MemberU = 3
+		MemberU = 3,
+
+		/// <summary>
+		/// SITE FILETYPE=JES LIST
+		/// </summary>
+		Jes2 = 4
 	}
 }


### PR DESCRIPTION
Issue #747: Please read (especially at the end) or in the Wiki: [here](https://github.com/robinrodricks/FluentFTP/wiki/IBM-zOS-and-OS-400-Support#accessing-the-jes2-internal-reader-to-submit-batch-jobs-and-how-to-list-and-retrieve-job-output)

Added `FtpZOSListRealm.Jes2`.

Added the capability to parse this realm.

Needed to add a listing option to deter `GetListing(...)` from switching to `Image`, we need this process to stay in `ASCII`.