### PR TITLE
Take back FtpListOption.NoImage. Not needed

### DIFF
--- a/FluentFTP/Client/AsyncClient/GetListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetListing.cs
@@ -270,12 +270,9 @@ namespace FluentFTP {
 		protected async Task<List<string>> GetListingInternal(string listcmd, FtpListOption options, bool retry, CancellationToken token) {
 			var rawlisting = new List<string>();
 			var isUseStat = options.HasFlag(FtpListOption.UseStat);
-			var isNoImage = options.HasFlag(FtpListOption.NoImage);
 
-			if (!isNoImage) {
-				// nearly always get the file listing in binary to avoid character translation issues with ASCII.
-				await SetDataTypeNoLockAsync(Config.ListingDataType, token);
-			}
+			// Get the file listing in the desired format
+			await SetDataTypeNoLockAsync(Config.ListingDataType, token);
 
 			try {
 

--- a/FluentFTP/Client/SyncClient/GetListing.cs
+++ b/FluentFTP/Client/SyncClient/GetListing.cs
@@ -171,12 +171,9 @@ namespace FluentFTP {
 		protected List<string> GetListingInternal(string listcmd, FtpListOption options, bool retry) {
 			var rawlisting = new List<string>();
 			var isUseStat = options.HasFlag(FtpListOption.UseStat);
-			var isNoImage = options.HasFlag(FtpListOption.NoImage);
 
-			// nearly always get the file listing in binary to avoid character translation issues with ASCII.
-			if (!isNoImage) {
-				SetDataTypeNoLock(Config.ListingDataType);
-			}
+			// Get the file listing in the desired format
+			SetDataTypeNoLock(Config.ListingDataType);
 
 			try {
 				// read in raw file listing from control stream

--- a/FluentFTP/Enums/FtpListOption.cs
+++ b/FluentFTP/Enums/FtpListOption.cs
@@ -89,12 +89,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Force the use of STAT command for getting file listings
 		/// </summary>
-		UseStat = 1024,
-
-		/// <summary>
-		/// Do not change the ASCII/Image setting to Image
-		/// </summary>
-		NoImage = 2048
+		UseStat = 1024
 
 	}
 }


### PR DESCRIPTION
No further comment, apart from:

Use
`FTP_Sess.Config.ListingDataType = FtpDataType.ASCII;`
instead.