### PR TITLE
Move CurrentDataType to Status and remove ForceSetDataType

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -176,8 +176,8 @@ namespace FluentFTP {
 			// Create the parser even if the auto-OS detection failed
 			CurrentListParser.Init(m_serverOS, Config.ListingParser);
 
-			// FIX : #318 always set the type when we create a new connection
-			ForceSetDataType = true;
+			// FIX : #318 always reset the type when we create a new connection
+			Status.CurrentDataType = FtpDataType.Unknown;
 
 			// Execute server-specific post-connection event
 			if (ServerHandler != null) {

--- a/FluentFTP/Client/AsyncClient/SetDataType.cs
+++ b/FluentFTP/Client/AsyncClient/SetDataType.cs
@@ -21,10 +21,7 @@ namespace FluentFTP {
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		protected async Task SetDataTypeNoLockAsync(FtpDataType type, CancellationToken token = default(CancellationToken)) {
 			// FIX : #291 only change the data type if different
-			if (CurrentDataType != type || ForceSetDataType) {
-				// FIX : #318 always set the type when we create a new connection
-				ForceSetDataType = false;
-
+			if (Status.CurrentDataType != type) {
 				FtpReply reply;
 				switch (type) {
 					case FtpDataType.ASCII:
@@ -45,7 +42,7 @@ namespace FluentFTP {
 						throw new FtpException("Unsupported data type: " + type.ToString());
 				}
 
-				CurrentDataType = type;
+				Status.CurrentDataType = type;
 			}
 		}
 

--- a/FluentFTP/Client/BaseClient/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseClient/BaseFtpClient.cs
@@ -32,8 +32,7 @@ namespace FluentFTP.Client.BaseClient {
 
 			CloneClient(this, newClone);
 
-			newClone.CurrentDataType = CurrentDataType;
-			newClone.ForceSetDataType = true;
+			newClone.Status.CurrentDataType = FtpDataType.Unknown;
 
 			return newClone;
 		}

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -55,6 +55,16 @@ namespace FluentFTP.Client.BaseClient {
 				Status.LastWorkingDir = null;
 			}
 
+			// A TYPE I could invalidate the cached value.
+			else if (command.StartsWith("TYPE I", StringComparison.Ordinal)) {
+				Status.CurrentDataType = FtpDataType.Binary;
+			}
+
+			// A TYPE A could invalidate the cached value.
+			else if (command.StartsWith("TYPE A", StringComparison.Ordinal)) {
+				Status.CurrentDataType = FtpDataType.ASCII;
+			}
+
 			return command;
 		}
 

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -88,11 +88,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// </summary>
 		protected DateTime LastCommandTimestamp;
 
-		protected FtpDataType CurrentDataType;
-
 		protected FtpReply HandshakeReply;
-
-		protected bool ForceSetDataType = false;
 
 		protected string LastStreamPath;
 

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -432,30 +432,5 @@ namespace FluentFTP.Client.BaseClient {
 			get => m_stream?.RemoteEndPoint;
 		}
 
-
-		protected FtpZOSListRealm _zOSListingRealm;
-
-		/// <summary>
-		/// During and after a z/OS GetListing(), this value shows the
-		/// z/OS filesystem realm that was encountered.
-		/// </summary>
-		public FtpZOSListRealm zOSListingRealm {
-			get => _zOSListingRealm;
-			set => _zOSListingRealm = value;
-		}
-
-		protected ushort _zOSListingLRECL;
-
-		/// <summary>
-		/// During and after a z/OS GetListing(), this value shows the
-		/// the LRECL that was encountered (for a realm = Member only).
-		/// The value is used internally to calculate member sizes
-		/// </summary>
-		public ushort zOSListingLRECL {
-			get => _zOSListingLRECL;
-			set => _zOSListingLRECL = value;
-		}
-
-
 	}
 }

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -176,7 +176,7 @@ namespace FluentFTP {
 				CurrentListParser.Init(m_serverOS, Config.ListingParser);
 
 				// FIX #318 always set the type when we create a new connection
-				ForceSetDataType = true;
+				Status.CurrentDataType = FtpDataType.Unknown;
 
 				// Execute server-specific post-connection event
 				ServerHandler?.AfterConnected(this);

--- a/FluentFTP/Client/SyncClient/SetDataType.cs
+++ b/FluentFTP/Client/SyncClient/SetDataType.cs
@@ -22,10 +22,7 @@ namespace FluentFTP {
 		/// <remarks>This method doesn't do any locking to prevent recursive lock scenarios.  Callers must do their own locking.</remarks>
 		protected void SetDataTypeNoLock(FtpDataType type) {
 			// FIX : #291 only change the data type if different
-			if (CurrentDataType != type || ForceSetDataType) {
-				// FIX : #318 always set the type when we create a new connection
-				ForceSetDataType = false;
-
+			if (Status.CurrentDataType != type) {
 				FtpReply reply;
 				switch (type) {
 					case FtpDataType.ASCII:
@@ -46,7 +43,7 @@ namespace FluentFTP {
 						throw new FtpException("Unsupported data type: " + type.ToString());
 				}
 
-				CurrentDataType = type;
+				Status.CurrentDataType = type;
 			}
 		}
 

--- a/FluentFTP/Enums/FtpDataType.cs
+++ b/FluentFTP/Enums/FtpDataType.cs
@@ -13,6 +13,12 @@ namespace FluentFTP {
 		/// <summary>
 		/// Binary transfer
 		/// </summary>
-		Binary
+		Binary,
+
+		/// <summary>
+		/// Not known yet
+		/// </summary>
+		Unknown
+
 	}
 }

--- a/FluentFTP/Helpers/Parsers/IBMzOSParser.cs
+++ b/FluentFTP/Helpers/Parsers/IBMzOSParser.cs
@@ -39,7 +39,7 @@ namespace FluentFTP.Helpers.Parsers {
 			// "Volume Unit    Referred Ext Used Recfm Lrecl BlkSz Dsorg Dsname"
 			if (record.Contains("Volume Unit") ||
 				record.Contains("Volume Referred")) {
-				client.zOSListingRealm = FtpZOSListRealm.Dataset;
+				client.Status.zOSListingRealm = FtpZOSListRealm.Dataset;
 				return null;
 			}
 
@@ -69,33 +69,33 @@ namespace FluentFTP.Helpers.Parsers {
 				// SITE PDSTYPE=PDSE RECFM=FB BLKSIZE=16000 DIRECTORY=1 LRECL=80 PRIMARY=3 SECONDARY=110 TRACKS EATTR=SYSTEM
 				string[] words = reply.Message.Split(' ');
 				string[] val = words[5].Split('=');
-				client.zOSListingLRECL = UInt16.Parse(val[1]);
-				client.zOSListingRealm = FtpZOSListRealm.Member;
+				client.Status.zOSListingLRECL = UInt16.Parse(val[1]);
+				client.Status.zOSListingRealm = FtpZOSListRealm.Member;
 				return null;
 			}
 
 			// "Name      Size     TTR   Alias-of AC--------- Attributes--------- Amode Rmode"
 			if (record.Contains("Name      Size     TTR")) {
-				client.zOSListingRealm = FtpZOSListRealm.MemberU;
+				client.Status.zOSListingRealm = FtpZOSListRealm.MemberU;
 				return null;
 			}
 
 			if (record.Contains("JOBNAME  JOBID")) {
-				client.zOSListingRealm = FtpZOSListRealm.Jes2;
+				client.Status.zOSListingRealm = FtpZOSListRealm.Jes2;
 				return null;
 			}
 
 			// "total nnnn"
 			if (record.Contains("total")) {
-				client.zOSListingRealm = FtpZOSListRealm.Unix;
+				client.Status.zOSListingRealm = FtpZOSListRealm.Unix;
 				return null;
 			}
 
 			if (IsValidHFS(record)) {
-				client.zOSListingRealm = FtpZOSListRealm.Unix;
+				client.Status.zOSListingRealm = FtpZOSListRealm.Unix;
 			}
 
-			if (client.zOSListingRealm == FtpZOSListRealm.Unix) {
+			if (client.Status.zOSListingRealm == FtpZOSListRealm.Unix) {
 				// HFS (=unix) mode
 				//
 				//total 17904
@@ -109,7 +109,7 @@ namespace FluentFTP.Helpers.Parsers {
 				return UnixParser.Parse(client, record);
 			}
 
-			if (client.zOSListingRealm == FtpZOSListRealm.Dataset) {
+			if (client.Status.zOSListingRealm == FtpZOSListRealm.Dataset) {
 				// PS/PO mode
 				//
 				// If SITE LISTLEVEL=0 is set:
@@ -196,7 +196,7 @@ namespace FluentFTP.Helpers.Parsers {
 				return null;
 			}
 
-			if (client.zOSListingRealm == FtpZOSListRealm.Member) {
+			if (client.Status.zOSListingRealm == FtpZOSListRealm.Member) {
 				// Member mode
 				//
 				// Name     VV.MM   Created       Changed      Size  Init   Mod   Id   
@@ -219,12 +219,12 @@ namespace FluentFTP.Helpers.Parsers {
 				bool isDir = false;
 				var lastModifiedStr = changed;
 				var lastModified = ParseDateTime(client, lastModifiedStr);
-				var size = ushort.Parse(records) * client.zOSListingLRECL;
+				var size = ushort.Parse(records) * client.Status.zOSListingLRECL;
 				var file = new FtpListItem(record, name, size, isDir, lastModified);
 				return file;
 			}
 
-			if (client.zOSListingRealm == FtpZOSListRealm.MemberU) {
+			if (client.Status.zOSListingRealm == FtpZOSListRealm.MemberU) {
 				// Member Loadlib mode
 				//
 				// Name      Size     TTR   Alias-of AC --------- Attributes --------- Amode Rmode
@@ -248,7 +248,7 @@ namespace FluentFTP.Helpers.Parsers {
 				return file;
 			}
 
-			if (client.zOSListingRealm == FtpZOSListRealm.Jes2) {
+			if (client.Status.zOSListingRealm == FtpZOSListRealm.Jes2) {
 				// FILETYPE=JES
 				//
 				//JOBNAME JOBID    OWNER STATUS CLASS

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -52,6 +52,11 @@ namespace FluentFTP {
 		public bool ConnectionUTF8Success { get; set; } = false;
 
 		/// <summary>
+		/// Store the current data type setting
+		/// </summary>
+		public FtpDataType CurrentDataType { get; set; } = FtpDataType.Unknown;
+
+		/// <summary>
 		/// Allow checking for stale data on socket?
 		/// </summary>
 		public bool AllowCheckStaleData { get; set; } = false;

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -85,6 +85,19 @@ namespace FluentFTP {
 			RecursiveListSupported = original.RecursiveListSupported;
 		}
 
+		/// <summary>
+		/// During and after a z/OS GetListing(), this value stores the
+		/// z/OS filesystem realm that was encountered.
+		/// The value is used internally to control the list parse mode
+		/// </summary>
+		public FtpZOSListRealm zOSListingRealm { get; set; }
+
+		/// <summary>
+		/// During and after a z/OS GetListing(), this value stores the
+		/// the LRECL that was encountered (for a realm = Member only).
+		/// The value is used internally to calculate member sizes
+		/// </summary>
+		public ushort zOSListingLRECL { get; set; }
 
 	}
 }

--- a/FluentFTP/Servers/Handlers/IBMzOSFtpServer.cs
+++ b/FluentFTP/Servers/Handlers/IBMzOSFtpServer.cs
@@ -378,7 +378,7 @@ namespace FluentFTP.Servers.Handlers {
 		/// Return null indicates custom code decided not to handle this
 		/// </summary>
 		public override bool? CalculateFullFtpPath(BaseFtpClient client, string path, FtpListItem item) {
-			if (client.zOSListingRealm == FtpZOSListRealm.Unix) {
+			if (client.Status.zOSListingRealm == FtpZOSListRealm.Unix) {
 				return null;
 			}
 
@@ -393,7 +393,7 @@ namespace FluentFTP.Servers.Handlers {
 
 			// Is caller using FtpListOption.NoPath and CWD to the right place?
 			if (path.Length == 0) {
-				if (client.zOSListingRealm == FtpZOSListRealm.Dataset) {
+				if (client.Status.zOSListingRealm == FtpZOSListRealm.Dataset) {
 					// Path: ""
 					// Fullname: 'GEEK.PROJECTS.LOADLIB'
 					item.FullName = ((IInternalFtpClient)client).GetWorkingDirectoryInternal().TrimEnd('\'') + item.Name + "\'";
@@ -407,7 +407,7 @@ namespace FluentFTP.Servers.Handlers {
 			// Caller is not using FtpListOption.NoPath, so the fullname can be built
 			// depending on the listing realm
 			else if (path[0] == '\'') {
-				if (client.zOSListingRealm == FtpZOSListRealm.Dataset) {
+				if (client.Status.zOSListingRealm == FtpZOSListRealm.Dataset) {
 					// Path: "'GEEK.PROJECTS.LOADLIB'"
 					// Fullname: 'GEEK.PROJECTS.LOADLIB'
 					item.FullName = item.Name;
@@ -424,7 +424,7 @@ namespace FluentFTP.Servers.Handlers {
 				}
 			}
 			else {
-				if (client.zOSListingRealm == FtpZOSListRealm.Dataset) {
+				if (client.Status.zOSListingRealm == FtpZOSListRealm.Dataset) {
 					// Path: "PROJECTS.LOADLIB"
 					// Fullname: 'GEEK.PROJECTS.LOADLIB'
 					item.FullName = ((IInternalFtpClient)client).GetWorkingDirectoryInternal().TrimEnd('\'') + item.Name + '\'';


### PR DESCRIPTION
`Status` was created to keep status information for the session, so why not move `CurrentDataType` to that substructure.

At the same time, if it inits to `Unknown` we can do away with the `ForceSetDataType`.

Also, a bug fixed: If a user executes a `TYPE` command, `CurrentDataType` goes out of sync. Happily, no one really does this, right?

Sometime in the future, issue a STAT command after connect and parse per server, set the initial value from there