### PR TITLE
Keep a (short, n=5) list of previous replies.

### DIFF
--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using FluentFTP.Helpers;
 using System.Text.RegularExpressions;
 using FluentFTP.Client.Modules;
+using System.Collections.Generic;
 
 namespace FluentFTP.Client.BaseClient {
 
@@ -67,7 +68,16 @@ namespace FluentFTP.Client.BaseClient {
 				Log(FtpTraceLevel.Info, "Response: " + reply.Code + " " + maskedReply);
 			}
 
-			LastReply = reply;
+			if (LastReplies == null) {
+				LastReplies = new List<FtpReply>();
+				LastReplies.Add(reply);
+			}
+			else {
+				LastReplies.Insert(0, reply);
+				if (LastReplies.Count > 5) {
+					LastReplies.RemoveAt(5);
+				}
+			}
 
 			return reply;
 		}

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -378,14 +378,15 @@ namespace FluentFTP.Client.BaseClient {
 			protected set => m_connectionType = value;
 		}
 
-		protected FtpReply m_lastReply;
-
 		/// <summary> Gets the last reply received from the server</summary>
 		public FtpReply LastReply {
-			get => m_lastReply;
-			protected set => m_lastReply = value;
+			get {
+				return LastReplies == null ? new FtpReply() : LastReplies[0];
+			}
 		}
 
+		/// <summary> Gets the last replies received from the server</summary>
+		public List<FtpReply> LastReplies { get; set; }
 
 		/// <summary>
 		/// Callback format to implement your custom FTP listing line parser.


### PR DESCRIPTION
Fixes (as an enhancement) https://github.com/robinrodricks/FluentFTP/issues/747

There is now a List<FtpReply> LastReplies with max 5 elements.

The previous LastReply still exists - it is fed from LastReplies[0]. If you want the next reply previous to that, you need LastReplies[1] and so on.

Especially useful to access intermediate messages on download (RETR) and upload (STOR) commands