### PR TITLE
Store the associated command together with the reply.

### DIFF
--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -68,6 +68,8 @@ namespace FluentFTP.Client.BaseClient {
 				Log(FtpTraceLevel.Info, "Response: " + reply.Code + " " + maskedReply);
 			}
 
+			reply.Command = string.IsNullOrEmpty(command) ? string.Empty : LogMaskModule.MaskCommand(this, command);
+
 			if (LastReplies == null) {
 				LastReplies = new List<FtpReply>();
 				LastReplies.Add(reply);

--- a/FluentFTP/Model/FtpReply.cs
+++ b/FluentFTP/Model/FtpReply.cs
@@ -100,5 +100,10 @@ namespace FluentFTP {
 				return message;
 			}
 		}
+
+		/// <summary>
+		/// Stores the command that produced this reply (if any)
+		/// </summary>
+		public string Command { get; set; }
 	}
 }


### PR DESCRIPTION
When debugging complex problems, it can be usefull to examine `LastReplies[n]`. These will also now contain the command associated with this reply.

