### PR TITLE
Getreply redesign

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -168,40 +168,15 @@ namespace FluentFTP {
 				// send progress reports
 				progress?.Report(new FtpProgress(100.0, offset, 0, TimeSpan.Zero, localPath, remotePath, metaProgress));
 
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
+				// listen for a success/failure reply or out of band data (like NOOP responses)
+				// GetReply(true) means: Exhaust any NOOP responses
+				FtpReply status = await GetReplyAsyncInternal(anyNoop, token: token);
 
-				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				if (anyNoop) {
-					m_stream.WriteLine(Encoding, "NOOP");
+				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
+				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
+				if (status.Code != null && !status.Success) {
+					return false;
 				}
-
-				try {
-					while (true) {
-						FtpReply status = await GetReply(token);
-
-						// Fix #387: exhaust any NOOP responses (not guaranteed during file transfers)
-						if (anyNoop && status.Message != null && status.Message.Contains("NOOP")) {
-							continue;
-						}
-
-						// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
-						// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
-						if (status.Code != null && !status.Success) {
-							return false;
-						}
-
-						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
-						if (anyNoop) {
-							await ReadStaleDataAsync(false, true, "after download", token);
-						}
-
-						break;
-					}
-				}
-
-				// absorb "System.TimeoutException: Timed out trying to read data from the socket stream!" at GetReply()
-				catch (Exception) { }
 
 				return true;
 			}

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -41,14 +41,14 @@ namespace FluentFTP {
 			}
 
 			// hide sensitive data from logs
-			string commandTxt = OnPostExecute(command);
+			string commandClean = OnPostExecute(command);
 
-			Log(FtpTraceLevel.Info, "Command:  " + commandTxt);
+			Log(FtpTraceLevel.Info, "Command:  " + commandClean);
 
 			// send command to FTP server
 			await m_stream.WriteLineAsync(m_textEncoding, command, token);
 			LastCommandTimestamp = DateTime.UtcNow;
-			reply = await GetReplyAsyncInternal(token, command);
+			reply = await GetReplyAsyncInternal(false, command, token);
 
 			return reply;
 		}

--- a/FluentFTP/Client/AsyncClient/Handshake.cs
+++ b/FluentFTP/Client/AsyncClient/Handshake.cs
@@ -11,7 +11,7 @@ namespace FluentFTP {
 		/// </summary>
 		protected virtual async Task HandshakeAsync(CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
-			if (!(reply = await GetReply(token)).Success) {
+			if (!(reply = await GetReply(token: token)).Success) {
 				if (reply.Code == null) {
 					throw new IOException("The connection was terminated before a greeting could be read.");
 				}

--- a/FluentFTP/Client/AsyncClient/TransferFile.cs
+++ b/FluentFTP/Client/AsyncClient/TransferFile.cs
@@ -179,8 +179,8 @@ namespace FluentFTP {
 					long lastSize = 0;
 
 
-					var sourceFXPTransferReply = ftpFxpSession.SourceServer.GetReply(token);
-					var destinationFXPTransferReply = ftpFxpSession.TargetServer.GetReply(token);
+					var sourceFXPTransferReply = ftpFxpSession.SourceServer.GetReply(token: token);
+					var destinationFXPTransferReply = ftpFxpSession.TargetServer.GetReply(token: token);
 
 					// while the transfer is not complete
 					while (!sourceFXPTransferReply.IsCompleted || !destinationFXPTransferReply.IsCompleted) {

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -242,40 +242,15 @@ namespace FluentFTP {
 				// disconnect FTP stream before exiting
 				upStream.Dispose();
 
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
+				// listen for a success/failure reply or out of band data (like NOOP responses)
+				// GetReply(true) means: Exhaust any NOOP responses
+				FtpReply status = await GetReplyAsyncInternal(anyNoop, token: token);
 
-				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				if (anyNoop) {
-					m_stream.WriteLine(Encoding, "NOOP");
+				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
+				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
+				if (status.Code != null && !status.Success) {
+					return FtpStatus.Failed;
 				}
-
-				try {
-					while (true) {
-						FtpReply status = await GetReply(token);
-
-						// Fix #387: exhaust any NOOP responses (not guaranteed during file transfers)
-						if (anyNoop && status.Message != null && status.Message.Contains("NOOP")) {
-							continue;
-						}
-
-						// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
-						// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
-						if (status.Code != null && !status.Success) {
-							return FtpStatus.Failed;
-						}
-
-						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
-						if (anyNoop) {
-							await ReadStaleDataAsync(false, true, "after upload", token);
-						}
-
-						break;
-					}
-				}
-
-				// absorb "System.TimeoutException: Timed out trying to read data from the socket stream!" at GetReply()
-				catch (Exception) { }
 
 				return FtpStatus.Success;
 			}

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -39,7 +39,7 @@ namespace FluentFTP.Client.BaseClient {
 				// send command to FTP server
 				m_stream.WriteLine(m_textEncoding, command);
 				LastCommandTimestamp = DateTime.UtcNow;
-				reply = GetReplyInternal(command);
+				reply = GetReplyInternal(false, command);
 			}
 
 			return reply;

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -104,8 +104,8 @@ namespace FluentFTP.Client.BaseClient {
 					sequence += "," + response.Split(' ')[0];
 
 					if (exhaustNoop &&
-						// NOOP responses can actually come in quite a few flavors
-						(response.StartsWith("200 NOOP") || response.StartsWith("500"))) {
+						// NOOP responses can actually come in quite a few flavors, so watch out..
+						(response.StartsWith("200 NOOP", StringComparison.InvariantCultureIgnoreCase) || response.StartsWith("500"))) {
 
 						Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
 
@@ -232,8 +232,8 @@ namespace FluentFTP.Client.BaseClient {
 				sequence += "," + response.Split(' ')[0];
 
 				if (exhaustNoop &&
-					// NOOP responses can actually come in quite a few flavors
-					(response.StartsWith("200 NOOP") || response.StartsWith("500"))) {
+						// NOOP responses can actually come in quite a few flavors, so watch out..
+						(response.StartsWith("200 NOOP", StringComparison.InvariantCultureIgnoreCase) || response.StartsWith("500"))) {
 
 					Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
 

--- a/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
@@ -27,7 +27,7 @@ namespace FluentFTP {
 		void DisableUTF8();
 
 		Task<FtpReply> Execute(string command, CancellationToken token = default(CancellationToken));
-		Task<FtpReply> GetReply(CancellationToken token = default(CancellationToken));
+		Task<FtpReply> GetReply(bool exhaustNoop = false, string command = null, CancellationToken token = default(CancellationToken));
 		Task Connect(CancellationToken token = default(CancellationToken));
 		Task Connect(FtpProfile profile, CancellationToken token = default(CancellationToken));
 		Task<List<FtpProfile>> AutoDetect(bool firstOnly = true, bool cloneConnection = true, CancellationToken token = default(CancellationToken));

--- a/FluentFTP/Client/Interfaces/IFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IFtpClient.cs
@@ -24,7 +24,7 @@ namespace FluentFTP {
 		// METHODS
 
 		FtpReply Execute(string command);
-		FtpReply GetReply();
+		FtpReply GetReply(bool exhaustNoop = false, string command = null);
 		void Connect();
 		void Connect(FtpProfile profile);
 		List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true);

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -161,40 +161,15 @@ namespace FluentFTP {
 				// send progress reports
 				progress?.Invoke(new FtpProgress(100.0, offset, 0, TimeSpan.Zero, localPath, remotePath, metaProgress));
 
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
+				// listen for a success/failure reply or out of band data (like NOOP responses)
+				// GetReply(true) means: Exhaust any NOOP responses
+				FtpReply status = GetReplyInternal(anyNoop);
 
-				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				if (anyNoop) {
-					m_stream.WriteLine(Encoding, "NOOP");
+				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
+				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
+				if (status.Code != null && !status.Success) {
+					return false;
 				}
-
-				try {
-					while (true) {
-						var status = GetReply();
-
-						// Fix #387: exhaust any NOOP responses (not guaranteed during file transfers)
-						if (anyNoop && status.Message != null && status.Message.Contains("NOOP")) {
-							continue;
-						}
-
-						// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
-						// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
-						if (status.Code != null && !status.Success) {
-							return false;
-						}
-
-						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
-						if (anyNoop) {
-							ReadStaleData(false, true, "after download");
-						}
-
-						break;
-					}
-				}
-
-				// absorb "System.TimeoutException: Timed out trying to read data from the socket stream!" at GetReply()
-				catch (Exception) { }
 
 				return true;
 			}

--- a/FluentFTP/Client/SyncClient/GetReply.cs
+++ b/FluentFTP/Client/SyncClient/GetReply.cs
@@ -12,14 +12,15 @@ namespace FluentFTP {
 	public partial class FtpClient {
 
 		/// <summary>
-		/// Retrieves a reply from the server. Do not execute this method
-		/// unless you are sure that a reply has been sent, i.e., you
-		/// executed a command. Doing so will cause the code to hang
-		/// indefinitely waiting for a server reply that is never coming.
+		/// Retrieves a reply from the server.
+		/// Support "normal" mode waiting for a command reply, subject to timeout exception
+		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
 		/// </summary>
+		/// <param name="exhaustNoop">Set to true to select the NOOP devouring mode</param>
+		/// <param name="command">We are waiting for the response to which command?</param>
 		/// <returns>FtpReply representing the response from the server</returns>
-		public FtpReply GetReply() {
-			return GetReplyInternal();
+		public FtpReply GetReply(bool exhaustNoop = false, string command = null) {
+			return GetReplyInternal(exhaustNoop, command);
 		}
 
 	}

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -234,40 +234,15 @@ namespace FluentFTP {
 				// disconnect FTP stream before exiting
 				upStream.Dispose();
 
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
+				// listen for a success/failure reply or out of band data (like NOOP responses)
+				// GetReply(true) means: Exhaust any NOOP responses
+				FtpReply status = GetReplyInternal(anyNoop);
 
-				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				if (anyNoop) {
-					m_stream.WriteLine(Encoding, "NOOP");
+				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
+				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
+				if (status.Code != null && !status.Success) {
+					return FtpStatus.Failed;
 				}
-
-				try {
-					while (true) {
-						var status = GetReply();
-
-						// Fix #387: exhaust any NOOP responses (not guaranteed during file transfers)
-						if (anyNoop && status.Message != null && status.Message.Contains("NOOP")) {
-							continue;
-						}
-
-						// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
-						// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
-						if (status.Code != null && !status.Success) {
-							return FtpStatus.Failed;
-						}
-
-						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
-						if (anyNoop) {
-							ReadStaleData(false, true, "after upload");
-						}
-
-						break;
-					}
-				}
-
-				// absorb "System.TimeoutException: Timed out trying to read data from the socket stream!" at GetReply()
-				catch (Exception) { }
 
 				return FtpStatus.Success;
 			}

--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientBlueCoatProxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientBlueCoatProxy.cs
@@ -34,7 +34,7 @@ namespace FluentFTP.Proxy.AsyncProxy {
 			// Connection USER@Host means to change user name to add host.
 			Credentials.UserName = Credentials.UserName + "@" + Host + ":" + Port;
 
-			var reply = await GetReply(token);
+			var reply = await GetReplyAsyncInternal(token: token);
 			if (reply.Code == "220") {
 				Log(FtpTraceLevel.Info, "Status: Server is ready for the new client");
 			}

--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientHttp11Proxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientHttp11Proxy.cs
@@ -18,7 +18,7 @@ namespace FluentFTP.Proxy.AsyncProxy {
 
 		/// <summary> Redefine the first dialog: HTTP Frame for the HTTP 1.1 Proxy </summary>
 		protected override async Task HandshakeAsync(CancellationToken token = default) {
-			var proxyConnectionReply = await GetReply(token);
+			var proxyConnectionReply = await GetReplyAsyncInternal(token: token);
 			if (!proxyConnectionReply.Success) {
 				throw new FtpException("Can't connect " + Host + " via proxy " + Proxy.ProxyHost + ".\nMessage : " +
 									   proxyConnectionReply.ErrorMessage);


### PR DESCRIPTION
This concludes the step by step `GetReply` redesign **provoked by the `NOOP` issues**.

V41 introduced rudimentary quick fixes to get things going, but for V42 a better structured approach is in order.

What are the main differences:

`GetReply` now has two operating modes:

1. **Normal mode**, as before - which is a blocking mode that can timeout, raise an exception.

2. **"**exhaust NOOP**" mode**, **new** - this mode is not blocking, it waits 10 seconds to gather all replies on the connection. It also provokes many servers to make stale data finally appear on the connection by issueing a `NOOP` command. This way, a legitimate ensuing command won't be compromised.

This new mode implements the suggestions mentioned [in this discussion](https://lists.apache.org/thread/xzpclw1015qncvczt8hg3nom2p5vtcf5) 

It makes a number of (identical) quick fixes for quite a few past issues in `DownloadFileInternal`, `UploadFileInternal` in both the sync and async client code superfluous.

The following identical code (**in 4 files**) can thus be removed:

```
				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
				if (anyNoop) {
					m_stream.WriteLine(Encoding, "NOOP");
				}

				try {
					while (true) {
						var status = GetReply();

						// Fix #387: exhaust any NOOP responses (not guaranteed during file transfers)
						if (anyNoop && status.Message != null && status.Message.Contains("NOOP")) {
							continue;
						}

						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
						if (anyNoop) {
							ReadStaleData(false, true, "after download");
						}

						break;
					}

				// absorb "System.TimeoutException: Timed out trying to read data from the socket stream!" at GetReply()
				catch (Exception) { }

```
3. **Better and more debugging output in verbose logs**

GetReply informs which command was executed (if any), counts down the seconds in non-blocking mode and outputs the `NOOP` vs. `valid response` sequence to aid in finding problems.

Here is a sample:
```
>         DownloadFile("D:\temp\test11.bin", "/temp/test1.bin", Overwrite, None)
>         GetFileSize("/temp/test1.bin")
Command:  SIZE /temp/test1.bin
Status:   Waiting for response to: SIZE /temp/test1.bin
Response: 213 1073741824
>         OpenRead("/temp/test1.bin", Binary, 0, 1073741824)
>         OpenPassiveDataStream(PASV, "RETR /temp/test1.bin", 0)
Command:  PASV
Status:   Waiting for response to: PASV
Response: 227 Entering Passive Mode (127,0,0,1,229,243)
Status:   Connecting to ***:58867
Command:  RETR /temp/test1.bin
Status:   Waiting for response to: RETR /temp/test1.bin
Response: 150 Starting data transfer.
Status:   FTPS authentication successful, protocol = Tls12
Status:   Time to activate encryption: 0h 0m 0s.  Total Seconds: 0,0030007.
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Status:   Disposing FtpSocketStream...
Status:   Waiting for a response
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Status:   Waiting - 8 seconds left
Status:   Waiting - 7 seconds left
Status:   Waiting - 6 seconds left
Status:   Waiting - 5 seconds left
Status:   Waiting - 4 seconds left
Status:   Waiting - 3 seconds left
Status:   Waiting - 2 seconds left
Status:   Waiting - 1 seconds left
Status:   Waiting - 0 seconds left
Status:   GetReply(...) sequence: 226,200,200,200,200,200,200,200,200,200,200
Response: 226 Operation successful
```
4. **So many files touched?** 

Many of the file changes beyond `GetReply`, `Download...` and `Upload...` are simply changes to the signatures, as the parameters to `GetReply` have been expanded. `bool exhaustNoop` has been added as the first (optional) parameter.

Before: 
`protected FtpReply GetReplyInternal(string command = null))`

After:
`protected FtpReply GetReplyInternal(bool exhaustNoop = false, string command = null)`

Similarly done for async.