### PR TITLE
GetReply Redesign

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -168,40 +168,15 @@ namespace FluentFTP {
 				// send progress reports
 				progress?.Report(new FtpProgress(100.0, offset, 0, TimeSpan.Zero, localPath, remotePath, metaProgress));
 
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
+				// listen for a success/failure reply or out of band data (like NOOP responses)
+				// GetReply(true) means: Exhaust any NOOP responses
+				FtpReply status = await GetReplyAsyncInternal(token, "*DOWNLOAD*", anyNoop);
 
-				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				if (anyNoop) {
-					m_stream.WriteLine(Encoding, "NOOP");
+				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
+				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
+				if (status.Code != null && !status.Success) {
+					return false;
 				}
-
-				try {
-					while (true) {
-						FtpReply status = await GetReply(token);
-
-						// Fix #387: exhaust any NOOP responses (not guaranteed during file transfers)
-						if (anyNoop && status.Message != null && status.Message.Contains("NOOP")) {
-							continue;
-						}
-
-						// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
-						// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
-						if (status.Code != null && !status.Success) {
-							return false;
-						}
-
-						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
-						if (anyNoop) {
-							await ReadStaleDataAsync(false, true, "after download", token);
-						}
-
-						break;
-					}
-				}
-
-				// absorb "System.TimeoutException: Timed out trying to read data from the socket stream!" at GetReply()
-				catch (Exception) { }
 
 				return true;
 			}

--- a/FluentFTP/Client/AsyncClient/GetReply.cs
+++ b/FluentFTP/Client/AsyncClient/GetReply.cs
@@ -7,36 +7,149 @@ using System.Net;
 using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
 
-		// TODO: add example
 		/// <summary>
-		/// Retrieves a reply from the server. Do not execute this method
-		/// unless you are sure that a reply has been sent, i.e., you
-		/// executed a command. Doing so will cause the code to hang
-		/// indefinitely waiting for a server reply that is never coming.
+		/// Retrieves a reply from the server.
+		/// Support "normal" mode waiting for a command reply, subject to timeout exception
+		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
 		/// </summary>
 		/// <returns>FtpReply representing the response from the server</returns>
 		public async Task<FtpReply> GetReply(CancellationToken token) {
-			return await GetReplyAsyncInternal(token);
+			return await GetReplyAsyncInternal(token, null, false);
 		}
 
-		protected async Task<FtpReply> GetReplyAsyncInternal(CancellationToken token, string command = null) {
+		/// <summary>
+		/// Retrieves a reply from the server.
+		/// Support "normal" mode waiting for a command reply, subject to timeout exception
+		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
+		/// </summary>
+		/// <param name="command">We are waiting for the response to which command?</param>
+		/// <returns>FtpReply representing the response from the server</returns>
+		public async Task<FtpReply> GetReplyAsyncInternal(CancellationToken token, string command) {
+			return await GetReplyAsyncInternal(token, command, false);
+		}
+
+		/// <summary>
+		/// Retrieves a reply from the server.
+		/// Support "normal" mode waiting for a command reply, subject to timeout exception
+		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
+		/// </summary>
+		/// <param name="command">We are waiting for the response to which command?</param>
+		/// <param name="exhaustNoop">Set to true to select the NOOP devouring mode</param>
+		/// <returns>FtpReply representing the response from the server</returns>
+		protected async Task<FtpReply> GetReplyAsyncInternal(CancellationToken token, string command, bool exhaustNoop) {
+
 			var reply = new FtpReply();
-			string buf;
 
 			if (!IsConnected) {
 				throw new InvalidOperationException("No connection to the server has been established.");
 			}
 
-			m_stream.ReadTimeout = Config.ReadTimeout;
-			while ((buf = await m_stream.ReadLineAsync(Encoding, token)) != null) {
-				if (DecodeStringToReply(buf, ref reply)) {
+			if (string.IsNullOrEmpty(command)) {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for a response");
+			}
+			else {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + OnPostExecute(command));
+			}
+
+			// Implement this: https://lists.apache.org/thread/xzpclw1015qncvczt8hg3nom2p5vtcf5
+			// Can not use the normal timeout mechanism though, as a System.TimeoutException
+			// causes the stream to disconnect.
+
+			string sequence = string.Empty;
+
+			string response;
+
+			var sw = new Stopwatch();
+
+			long elapsedTime;
+			long previousElapsedTime = 0;
+
+			if (exhaustNoop) {
+				await m_stream.WriteLineAsync(Encoding, "NOOP", token);
+			}
+
+			sw.Start();
+
+			do {
+				elapsedTime = sw.ElapsedMilliseconds;
+
+				// Maximum wait time for collecting NOOP responses: 10 seconds
+				if (exhaustNoop && elapsedTime > 10000) {
 					break;
 				}
-				reply.InfoMessages += buf + "\n";
+
+				if (!exhaustNoop) {
+
+					// If we are not exhausting NOOPs, i.e. doing a normal GetReply(...)
+					// we do a blocking ReadLine(...). This can throw a
+					// System.TimeoutException which will disconnect us.
+
+					m_stream.ReadTimeout = Config.ReadTimeout;
+					response = await m_stream.ReadLineAsync(Encoding, token);
+
+				}
+				else {
+
+					// If we are exhausting NOOPs, use a non-blocking ReadLine(...)
+					// as we don't want a timeout exception, which would disconnect us.
+
+					if (m_stream.SocketDataAvailable > 0) {
+						response = await m_stream.ReadLineAsync(Encoding, token);
+					}
+					else {
+						if (elapsedTime > (previousElapsedTime + 1000)) {
+							previousElapsedTime = elapsedTime;
+							LogWithPrefix(FtpTraceLevel.Verbose, "Waiting - " + ((10000 - elapsedTime) / 1000).ToString() + " seconds left");
+						}
+						response = null;
+						Thread.Sleep(100);
+					}
+
+				}
+
+				if (string.IsNullOrEmpty(response)) {
+					continue;
+				}
+
+				sequence += "," + response.Split(' ')[0];
+
+				if (exhaustNoop &&
+					// NOOP responses can actually come in quite a few flavors
+					(response.StartsWith("200 NOOP") || response.StartsWith("500"))) {
+
+					Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
+
+					continue;
+				}
+
+				if (DecodeStringToReply(response, ref reply)) {
+
+					if (exhaustNoop) {
+						// We need to perhaps exhaust more NOOP responses
+						continue;
+					}
+					else {
+						// On a normal GetReply(...) we are happy to collect the
+						// first valid response
+						break;
+					}
+
+				}
+
+				// Accumulate non-valid response text too, prior to a valid response
+				reply.InfoMessages += response + "\n";
+
+			} while (true);
+
+			sw.Stop();
+
+			if (exhaustNoop) {
+				LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 			}
 
 			reply = ProcessGetReply(reply, command);

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -242,40 +242,15 @@ namespace FluentFTP {
 				// disconnect FTP stream before exiting
 				upStream.Dispose();
 
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
+				// listen for a success/failure reply or out of band data (like NOOP responses)
+				// GetReply(true) means: Exhaust any NOOP responses
+				FtpReply status = await GetReplyAsyncInternal(token, "*UPLOAD*", anyNoop);
 
-				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				if (anyNoop) {
-					m_stream.WriteLine(Encoding, "NOOP");
+				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
+				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
+				if (status.Code != null && !status.Success) {
+					return FtpStatus.Failed;
 				}
-
-				try {
-					while (true) {
-						FtpReply status = await GetReply(token);
-
-						// Fix #387: exhaust any NOOP responses (not guaranteed during file transfers)
-						if (anyNoop && status.Message != null && status.Message.Contains("NOOP")) {
-							continue;
-						}
-
-						// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
-						// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
-						if (status.Code != null && !status.Success) {
-							return FtpStatus.Failed;
-						}
-
-						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
-						if (anyNoop) {
-							await ReadStaleDataAsync(false, true, "after upload", token);
-						}
-
-						break;
-					}
-				}
-
-				// absorb "System.TimeoutException: Timed out trying to read data from the socket stream!" at GetReply()
-				catch (Exception) { }
 
 				return FtpStatus.Success;
 			}

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -6,37 +6,144 @@ using FluentFTP.Helpers;
 using System.Text.RegularExpressions;
 using FluentFTP.Client.Modules;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 
 namespace FluentFTP.Client.BaseClient {
 
 	public partial class BaseFtpClient {
 
+		protected FtpReply GetReplyInternal() {
+			return GetReplyInternal(null, false);
+		}
+
+		protected FtpReply GetReplyInternal(string command) {
+			return GetReplyInternal(command, false);
+		}
+
 		/// <summary>
-		/// Retrieves a reply from the server. Do not execute this method
-		/// unless you are sure that a reply has been sent, i.e., you
-		/// executed a command. Doing so will cause the code to hang
-		/// indefinitely waiting for a server reply that is never coming.
+		/// Retrieves a reply from the server.
+		/// Support "normal" mode waiting for a command reply, subject to timeout exception
+		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
 		/// </summary>
+		/// <param name="command">We are waiting for the response to which command?</param>
+		/// <param name="exhaustNoop">Set to true to select the NOOP devouring mode</param>
 		/// <returns>FtpReply representing the response from the server</returns>
-		protected FtpReply GetReplyInternal(string command = null) {
+		protected FtpReply GetReplyInternal(string command, bool exhaustNoop) {
 			var reply = new FtpReply();
-			string buf;
 
 			lock (m_lock) {
+
 				if (!IsConnected) {
 					throw new InvalidOperationException("No connection to the server has been established.");
 				}
 
-				m_stream.ReadTimeout = Config.ReadTimeout;
-				while ((buf = m_stream.ReadLine(Encoding)) != null) {
-					if (DecodeStringToReply(buf, ref reply)) {
+				if (string.IsNullOrEmpty(command)) {
+					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for a response");
+				}
+				else {
+					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + OnPostExecute(command));
+				}
+
+				// Implement this: https://lists.apache.org/thread/xzpclw1015qncvczt8hg3nom2p5vtcf5
+				// Can not use the normal timeout mechanism though, as a System.TimeoutException
+				// causes the stream to disconnect.
+
+				string sequence = string.Empty;
+
+				string response;
+
+				var sw = new Stopwatch();
+
+				long elapsedTime;
+				long previousElapsedTime = 0;
+
+				sw.Start();
+
+				if (exhaustNoop) {
+					m_stream.WriteLine(Encoding, "NOOP");
+				}
+
+				do {
+					elapsedTime = sw.ElapsedMilliseconds;
+
+					// Maximum wait time for collecting NOOP responses: 10 seconds
+					if (exhaustNoop && elapsedTime > 10000) {
 						break;
 					}
-					reply.InfoMessages += buf + "\n";
+
+					if (!exhaustNoop) {
+
+						// If we are not exhausting NOOPs, i.e. doing a normal GetReply(...)
+						// we do a blocking ReadLine(...). This can throw a
+						// System.TimeoutException which will disconnect us.
+
+						m_stream.ReadTimeout = Config.ReadTimeout;
+						response = m_stream.ReadLine(Encoding);
+
+					}
+					else {
+
+						// If we are exhausting NOOPs, use a non-blocking ReadLine(...)
+						// as we don't want a timeout exception, which would disconnect us.
+
+						if (m_stream.SocketDataAvailable > 0) {
+							response = m_stream.ReadLine(Encoding);
+						}
+						else {
+							if (elapsedTime > (previousElapsedTime + 1000)) {
+								previousElapsedTime = elapsedTime;
+								LogWithPrefix(FtpTraceLevel.Verbose, "Waiting - " + ((10000 - elapsedTime) / 1000).ToString() + " seconds left");
+							}
+							response = null;
+							Thread.Sleep(100);
+						}
+
+					}
+
+					if (string.IsNullOrEmpty(response)) {
+						continue;
+					}
+
+					sequence += "," + response.Split(' ')[0];
+
+					if (exhaustNoop &&
+						// NOOP responses can actually come in quite a few flavors, so watch out..
+						(response.StartsWith("200 NOOP", StringComparison.InvariantCultureIgnoreCase) || response.StartsWith("500"))) {
+
+						Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
+
+						continue;
+					}
+
+					if (DecodeStringToReply(response, ref reply)) {
+
+						if (exhaustNoop) {
+							// We need to perhaps exhaust more NOOP responses
+							continue;
+						}
+						else {
+							// On a normal GetReply(...) we are happy to collect the
+							// first valid response
+							break;
+						}
+
+					}
+
+					// Accumulate non-valid response text too, prior to a valid response
+					reply.InfoMessages += response + "\n";
+
+				} while (true);
+
+				sw.Stop();
+
+				if (exhaustNoop) {
+					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
 
 				reply = ProcessGetReply(reply, command);
-			}
+
+			} // lock
 
 			return reply;
 		}

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -161,40 +161,15 @@ namespace FluentFTP {
 				// send progress reports
 				progress?.Invoke(new FtpProgress(100.0, offset, 0, TimeSpan.Zero, localPath, remotePath, metaProgress));
 
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
+				// listen for a success/failure reply or out of band data (like NOOP responses)
+				// GetReply(true) means: Exhaust any NOOP responses
+				FtpReply status = GetReplyInternal("*DOWNLOAD*", anyNoop);
 
-				// Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
-				if (anyNoop) {
-					m_stream.WriteLine(Encoding, "NOOP");
+				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
+				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
+				if (status.Code != null && !status.Success) {
+					return false;
 				}
-
-				try {
-					while (true) {
-						var status = GetReply();
-
-						// Fix #387: exhaust any NOOP responses (not guaranteed during file transfers)
-						if (anyNoop && status.Message != null && status.Message.Contains("NOOP")) {
-							continue;
-						}
-
-						// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
-						// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
-						if (status.Code != null && !status.Success) {
-							return false;
-						}
-
-						// Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
-						if (anyNoop) {
-							ReadStaleData(false, true, "after download");
-						}
-
-						break;
-					}
-				}
-
-				// absorb "System.TimeoutException: Timed out trying to read data from the socket stream!" at GetReply()
-				catch (Exception) { }
 
 				return true;
 			}

--- a/FluentFTP/Client/SyncClient/GetReply.cs
+++ b/FluentFTP/Client/SyncClient/GetReply.cs
@@ -12,10 +12,9 @@ namespace FluentFTP {
 	public partial class FtpClient {
 
 		/// <summary>
-		/// Retrieves a reply from the server. Do not execute this method
-		/// unless you are sure that a reply has been sent, i.e., you
-		/// executed a command. Doing so will cause the code to hang
-		/// indefinitely waiting for a server reply that is never coming.
+		/// Retrieves a reply from the server.
+		/// Support "normal" mode waiting for a command reply, subject to timeout exception
+		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
 		/// </summary>
 		/// <returns>FtpReply representing the response from the server</returns>
 		public FtpReply GetReply() {

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -236,7 +236,7 @@ namespace FluentFTP {
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
-				FtpReply status = GetReplyInternal("*DOWNLOAD*", anyNoop);
+				FtpReply status = GetReplyInternal("*UPLOAD*", anyNoop);
 
 				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
 				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway


### PR DESCRIPTION
This concludes the step by step `GetReply` redesign **provoked by the `NOOP` issues**.

V41 introduced rudimentary quick fixes to get things going, but for V42 a better structured approach is in order.

What are the main differences:

`GetReply` now has two operating modes:

1. **Normal mode**, as before - which is a blocking mode that can timeout, raise an exception.

2. **"**exhaust NOOP**" mode**, **new** - this mode is not blocking, it waits 10 seconds to gather all replies on the connection. It also provokes many servers to make stale data finally appear on the connection by issueing a `NOOP` command. This way, a legitimate ensuing command won't be compromised.

This new mode implements the suggestions mentioned [in this discussion](https://lists.apache.org/thread/xzpclw1015qncvczt8hg3nom2p5vtcf5) 

It makes a number of (identical) quick fixes for quite a few past issues in `DownloadFileInternal`, `UploadFileInternal` in both the sync and async client code superfluous.

The following identical code (**in 4 files**) can thus be **removed**:

```
                        // Quick dirty fix for recalcitrant servers. This will cause them to hickup the rest of the responses
                        if (anyNoop) {
                                      m_stream.WriteLine(Encoding, "NOOP");
                        }

                        try {
                                      while (true) {
                                                      var status = GetReply();

                                                      // Fix #387: exhaust any NOOP responses (not guaranteed during file transfers)
                                                      if (anyNoop && status.Message != null && status.Message.Contains("NOOP")) {
                                                                      continue;
                                                      }

                                                     // Fix #387: exhaust any NOOP responses also after "226 Transfer complete."
                                                     if (anyNoop) {
                                                                     ReadStaleData(false, true, "after download");
                                                     }

                                                     break;
                                       }

                       // absorb "System.TimeoutException: Timed out trying to read data from the socket stream!" at GetReply()
                       catch (Exception) { }

```
3. **Better and more debugging output in verbose logs**

GetReply informs which command was executed (if any), counts down the seconds in non-blocking mode and outputs the `NOOP` vs. `valid response` sequence to aid in finding problems.

Here is a sample of a transfer with `NOOP`s enabled:
```
>         DownloadFile("D:\temp\test11.bin", "/temp/test1.bin", Overwrite, None)
>         GetFileSize("/temp/test1.bin")
Command:  SIZE /temp/test1.bin
Status:   Waiting for response to: SIZE /temp/test1.bin
Response: 213 1073741824
>         OpenRead("/temp/test1.bin", Binary, 0, 1073741824)
>         OpenPassiveDataStream(PASV, "RETR /temp/test1.bin", 0)
Command:  PASV
Status:   Waiting for response to: PASV
Response: 227 Entering Passive Mode (127,0,0,1,229,243)
Status:   Connecting to ***:58867
Command:  RETR /temp/test1.bin
Status:   Waiting for response to: RETR /temp/test1.bin
Response: 150 Starting data transfer.
Status:   FTPS authentication successful, protocol = Tls12
Status:   Time to activate encryption: 0h 0m 0s.  Total Seconds: 0,0030007.
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Command:  NOOP
Status:   Disposing FtpSocketStream...
Status:   Waiting for a response
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Skipped:  200 Noop ok.
Status:   Waiting - 8 seconds left
Status:   Waiting - 7 seconds left
Status:   Waiting - 6 seconds left
Status:   Waiting - 5 seconds left
Status:   Waiting - 4 seconds left
Status:   Waiting - 3 seconds left
Status:   Waiting - 2 seconds left
Status:   Waiting - 1 seconds left
Status:   Waiting - 0 seconds left
Status:   GetReply(...) sequence: 226,200,200,200,200,200,200,200,200,200,200
Response: 226 Operation successful
```
