### PR TITLE
Show FluentFTP version in log after connect

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -34,7 +34,7 @@ namespace FluentFTP {
 			LogFunction(nameof(ConnectAsync));
 
 			string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
-			LogWithPrefix(FtpTraceLevel.Verbose, "Connection attempted by FluentFTP Version " + applicationVersion);
+			LogWithPrefix(FtpTraceLevel.Verbose, "Connect using FluentFTP " + applicationVersion);
 
 			if (IsDisposed) {
 				throw new ObjectDisposedException("This AsyncFtpClient object has been disposed. It is no longer accessible.");

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -7,7 +7,6 @@ using System.Net.Sockets;
 using System.Text;
 using FluentFTP.Helpers;
 
-
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
 

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -6,6 +6,7 @@ using System;
 using System.Net.Sockets;
 using System.Text;
 using FluentFTP.Helpers;
+using System.Reflection;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
@@ -186,6 +187,9 @@ namespace FluentFTP {
 
 			// FIX #922: disable checking for stale data during connection
 			Status.AllowCheckStaleData = true;
+
+			string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
+			LogWithPrefix(FtpTraceLevel.Verbose, "Connection established by FluentFTP Version " + applicationVersion);
 		}
 
 		/// <summary>

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -33,6 +33,9 @@ namespace FluentFTP {
 
 			LogFunction(nameof(ConnectAsync));
 
+			string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
+			LogWithPrefix(FtpTraceLevel.Verbose, "Connection attempted by FluentFTP Version " + applicationVersion);
+
 			if (IsDisposed) {
 				throw new ObjectDisposedException("This AsyncFtpClient object has been disposed. It is no longer accessible.");
 			}
@@ -98,7 +101,6 @@ namespace FluentFTP {
 						token);
 				}
 			}
-
 
 			if (m_credentials != null) {
 				await Authenticate(token);
@@ -187,9 +189,6 @@ namespace FluentFTP {
 
 			// FIX #922: disable checking for stale data during connection
 			Status.AllowCheckStaleData = true;
-
-			string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
-			LogWithPrefix(FtpTraceLevel.Verbose, "Connection established by FluentFTP Version " + applicationVersion);
 		}
 
 		/// <summary>

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -6,7 +6,7 @@ using System;
 using System.Net.Sockets;
 using System.Text;
 using FluentFTP.Helpers;
-using System.Reflection;
+
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
@@ -33,8 +33,7 @@ namespace FluentFTP {
 
 			LogFunction(nameof(ConnectAsync));
 
-			string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
-			LogWithPrefix(FtpTraceLevel.Verbose, "Connect using FluentFTP " + applicationVersion);
+			LogVersion();
 
 			if (IsDisposed) {
 				throw new ObjectDisposedException("This AsyncFtpClient object has been disposed. It is no longer accessible.");

--- a/FluentFTP/Client/BaseClient/Logger.cs
+++ b/FluentFTP/Client/BaseClient/Logger.cs
@@ -1,11 +1,22 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using FluentFTP.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace FluentFTP.Client.BaseClient {
 	public partial class BaseFtpClient {
+
+		/// <summary>
+		/// Log the version of the running assembly
+		/// </summary>
+		protected void LogVersion() {
+
+			string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
+			LogWithPrefix(FtpTraceLevel.Verbose, "FluentFTP " + applicationVersion);
+
+		}
 
 		/// <summary>
 		/// Log a function call with relevant arguments

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -6,7 +6,6 @@ using System;
 using System.Net.Sockets;
 using System.Text;
 using FluentFTP.Helpers;
-using System.Reflection;
 
 namespace FluentFTP {
 	public partial class FtpClient {
@@ -34,8 +33,7 @@ namespace FluentFTP {
 
 				LogFunction(nameof(Connect));
 
-				string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
-				LogWithPrefix(FtpTraceLevel.Verbose, "Connect using FluentFTP " + applicationVersion);
+				LogVersion();
 
 				if (IsDisposed) {
 					throw new ObjectDisposedException("This FtpClient object has been disposed. It is no longer accessible.");

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -34,6 +34,9 @@ namespace FluentFTP {
 
 				LogFunction(nameof(Connect));
 
+				string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
+				LogWithPrefix(FtpTraceLevel.Verbose, "Connection attempted by FluentFTP Version " + applicationVersion);
+
 				if (IsDisposed) {
 					throw new ObjectDisposedException("This FtpClient object has been disposed. It is no longer accessible.");
 				}
@@ -184,9 +187,6 @@ namespace FluentFTP {
 
 				// FIX #922: disable checking for stale data during connection
 				Status.AllowCheckStaleData = true;
-
-				string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
-				LogWithPrefix(FtpTraceLevel.Verbose, "Connection established by FluentFTP Version " + applicationVersion);
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -35,7 +35,7 @@ namespace FluentFTP {
 				LogFunction(nameof(Connect));
 
 				string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
-				LogWithPrefix(FtpTraceLevel.Verbose, "Connection attempted by FluentFTP Version " + applicationVersion);
+				LogWithPrefix(FtpTraceLevel.Verbose, "Connect using FluentFTP " + applicationVersion);
 
 				if (IsDisposed) {
 					throw new ObjectDisposedException("This FtpClient object has been disposed. It is no longer accessible.");

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -6,6 +6,7 @@ using System;
 using System.Net.Sockets;
 using System.Text;
 using FluentFTP.Helpers;
+using System.Reflection;
 
 namespace FluentFTP {
 	public partial class FtpClient {
@@ -184,6 +185,8 @@ namespace FluentFTP {
 				// FIX #922: disable checking for stale data during connection
 				Status.AllowCheckStaleData = true;
 
+				string applicationVersion = Assembly.GetAssembly(MethodBase.GetCurrentMethod().DeclaringType).GetName().Version.ToString();
+				LogWithPrefix(FtpTraceLevel.Verbose, "Connection established by FluentFTP Version " + applicationVersion);
 			}
 		}
 


### PR DESCRIPTION
This might help in case users are secretive

```
...
Status:   Waiting for response to: SYST
Response: 215 UNIX emulated by FileZilla.
Status:   Listing parser set to: Machine
Status:   Connection established by FluentFTP Version 41.0.0.0
...
```