### PR TITLE
IBM OS400: Support blanks in filename, add unit test for that

### DIFF
--- a/FluentFTP.Tests/Unit/ParserTests.cs
+++ b/FluentFTP.Tests/Unit/ParserTests.cs
@@ -384,6 +384,7 @@ namespace FluentFTP.Tests.Unit {
 				"CFT                                     *MEM  ASKET7.FILE/ASKET7.MBR",
 				"QSYSOPR         28672 01/12/17 20:08:04 *FILE FPKI45POK5.FILE",
 				"QSYSOPR                                 *MEM FPKI45POK5.FILE/FPKI45POK5.MBR",
+				"TESTUSR         12345 01/12/18 18:34:01 *STMF B0001234567 K",
 			};
 
 			var expected = new FtpListItem[]{
@@ -395,6 +396,7 @@ namespace FluentFTP.Tests.Unit {
 				new FtpListItem("ASKET7.FILE/ASKET7.MBR", 0, FtpObjectType.File, new DateTime(1, 1, 1, 0, 0, 0, 0)),
 				new FtpListItem("FPKI45POK5.FILE", 28672, FtpObjectType.File, new DateTime(2017, 12, 1, 20, 8, 4, 0)),
 				new FtpListItem("FPKI45POK5.FILE/FPKI45POK5.MBR", 0, FtpObjectType.File, new DateTime(1, 1, 1, 0, 0, 0, 0)),
+				new FtpListItem("B0001234567 K", 12345, FtpObjectType.File, new DateTime(2018, 12, 1, 18, 34, 1, 0)),
 			};
 
 			TestParsing(parser, "/", sample, expected);

--- a/FluentFTP/Helpers/Parsers/IBMOS400Parser.cs
+++ b/FluentFTP/Helpers/Parsers/IBMOS400Parser.cs
@@ -71,8 +71,14 @@ namespace FluentFTP.Helpers.Parsers {
 				isDir = true;
 			}
 
+			string name = string.Empty;
 			// If there's no name, it's because we're inside a file.  Fake out a "current directory" name instead.
-			var name = values.Length >= 6 ? values[5] : ".";
+			if (values.Length >= 6) {
+				name = record.Substring(record.TrimEnd().LastIndexOf(values[5]));
+			}
+			else {
+				name = ".";
+			}
 			if (name.EndsWith("/")) {
 				isDir = true;
 				name = name.Substring(0, name.Length - 1);


### PR DESCRIPTION
IBM OS400 filenames can contain blanks.

Motivated by #994 