### PR TITLE
FluentFTP wrapper for SslStream

### DIFF
--- a/FluentFTP/Streams/FluentSslStream.cs
+++ b/FluentFTP/Streams/FluentSslStream.cs
@@ -1,0 +1,223 @@
+﻿using System.Collections.Generic;
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Security;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace FluentSslLib {
+	/// <summary>
+	/// FluentSslStream is an SslStream that properly sends a close_notify message when closing
+	/// the connection. This is required per RFC 5246 to avoid truncation attacks.
+	/// For more information, see https://tools.ietf.org/html/rfc5246#section-7.2.1
+	///
+	/// Inspired by: https://stackoverflow.com/questions/237807/net-sslstream-doesnt-close-tls-connection-properly/22626756#22626756
+	///
+	/// See: https://learn.microsoft.com/en-us/windows/win32/secauthn/shutting-down-an-schannel-connection
+	/// See: https://learn.microsoft.com/en-us/windows/win32/secauthn/using-sspi-with-a-windows-sockets-client?source=recommendations
+	/// 
+	/// </summary>
+	public class FluentSslStream : SslStream {
+		public FluentSslStream(Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback)
+			: base(innerStream, leaveInnerStreamOpen, userCertificateValidationCallback) {
+		}
+
+		private bool _Closed = false;
+
+		protected override void Dispose(bool disposing) {
+			try {
+				if (!_Closed) {
+					_Closed = true;
+					SslDirectCall.CloseNotify(this);
+				}
+			}
+			finally {
+				base.Dispose(disposing);
+			}
+		}
+
+		public override string ToString() {
+			return $"{SslProtocol} stream ({CipherAlgorithm}, {KeyExchangeAlgorithm}, {KeyExchangeStrength})";
+		}
+	}
+
+	internal unsafe static class SslDirectCall {
+		public static void CloseNotify(SslStream sslStream) {
+			if (!sslStream.IsAuthenticated) {
+				return;
+			}
+
+			byte[] result;
+			int resultSize;
+
+			byte[] sChannelShutdown = new byte[4] { 0x01, 0x00, 0x00, 0x00 };
+
+			NativeApi.SSPIHandle securityContextHandle = default(NativeApi.SSPIHandle);
+			NativeApi.SSPIHandle credentialsHandleHandle = default(NativeApi.SSPIHandle);
+
+#if NETSTANDARD
+			var context = ReflectUtil.GetField(sslStream, "_context");
+
+			var securityContext = ReflectUtil.GetField(context, "_securityContext");
+			var securityContextHandleOriginal = ReflectUtil.GetField(securityContext, "_handle");
+
+			securityContextHandle.HandleHi = (IntPtr)ReflectUtil.GetField(securityContextHandleOriginal, "dwLower");
+			securityContextHandle.HandleLo = (IntPtr)ReflectUtil.GetField(securityContextHandleOriginal, "dwUpper");
+
+			var credentialsHandle = ReflectUtil.GetField(context, "_credentialsHandle");
+			var credentialsHandleHandleOriginal = ReflectUtil.GetField(credentialsHandle, "_handle");
+
+			credentialsHandleHandle.HandleHi = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "dwLower");
+			credentialsHandleHandle.HandleLo = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "dwUpper");
+#else
+			var sslstate = ReflectUtil.GetField(sslStream, "_SslState");
+			var context = ReflectUtil.GetProperty(sslstate, "Context");
+
+			var securityContext = ReflectUtil.GetField(context, "m_SecurityContext");
+			var securityContextHandleOriginal = ReflectUtil.GetField(securityContext, "_handle");
+
+			securityContextHandle.HandleHi = (IntPtr)ReflectUtil.GetField(securityContextHandleOriginal, "HandleHi");
+			securityContextHandle.HandleLo = (IntPtr)ReflectUtil.GetField(securityContextHandleOriginal, "HandleLo");
+
+			var credentialsHandle = ReflectUtil.GetField(context, "m_CredentialsHandle");
+			var credentialsHandleHandleOriginal = ReflectUtil.GetField(credentialsHandle, "_handle");
+
+			credentialsHandleHandle.HandleHi = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "HandleHi");
+			credentialsHandleHandle.HandleLo = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "HandleLo");
+#endif
+
+			NativeApi.SecurityBufferDescriptor securityBufferDescriptor = new NativeApi.SecurityBufferDescriptor();
+			NativeApi.SecurityBufferStruct[] unmanagedBuffer = new NativeApi.SecurityBufferStruct[1];
+
+			fixed (NativeApi.SecurityBufferStruct* ptr = unmanagedBuffer)
+
+			fixed (void* workArrayPtr = sChannelShutdown) {
+				securityBufferDescriptor.UnmanagedPointer = (void*)ptr;
+
+				unmanagedBuffer[0].token = (IntPtr)workArrayPtr;
+				unmanagedBuffer[0].count = 4;
+				unmanagedBuffer[0].type = 2;
+
+				int status;
+
+				status = NativeApi.ApplyControlToken(
+					ref securityContextHandle,
+					securityBufferDescriptor);
+
+				if (status != 0) {
+					throw new InvalidOperationException(string.Format("ApplyControlToken returned [{0}] during CloseNotify.", status));
+				}
+
+				unmanagedBuffer[0].token = IntPtr.Zero;
+				unmanagedBuffer[0].count = 0;
+				unmanagedBuffer[0].type = 2;
+
+				NativeApi.SSPIHandle contextHandleOut = default(NativeApi.SSPIHandle);
+
+				int inflags = 0x811c;
+				int outflags = 0;
+
+				status = NativeApi.InitializeSecurityContextW(
+					ref credentialsHandleHandle,
+					ref securityContextHandle,
+					null,
+					inflags,
+					0,
+					16,
+					null,
+					0,
+					ref contextHandleOut,
+					securityBufferDescriptor,
+					ref outflags,
+					out _);
+
+				if (status != 0) {
+					throw new InvalidOperationException(string.Format("InitializeSecurityContextW returned [{0}] during CloseNotify.", status));
+				}
+
+				byte[] resultArr = new byte[unmanagedBuffer[0].count];
+				Marshal.Copy(unmanagedBuffer[0].token, resultArr, 0, resultArr.Length);
+				Marshal.FreeCoTaskMem(unmanagedBuffer[0].token);
+				result = resultArr;
+				resultSize = resultArr.Length;
+			}
+
+#if NETSTANDARD
+			var innerStream = (Stream)ReflectUtil.GetProperty(sslStream, "InnerStream");
+#else
+			var innerStream = (Stream)ReflectUtil.GetProperty(sslstate, "InnerStream");
+#endif
+			innerStream.Write(result, 0, resultSize);
+		}
+	}
+
+	internal unsafe static class NativeApi {
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		internal struct SSPIHandle {
+			public IntPtr HandleHi;
+			public IntPtr HandleLo;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		internal class SecurityBufferDescriptor {
+			public readonly int Version;
+			public readonly int Count;
+			public unsafe void* UnmanagedPointer;
+
+			public SecurityBufferDescriptor() {
+				Version = 0;
+				Count = 1;
+				UnmanagedPointer = null;
+			}
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		internal struct SecurityBufferStruct {
+			public int count;
+			public int type;
+			public IntPtr token;
+			public static readonly int Size = sizeof(SecurityBufferStruct);
+		}
+
+		[DllImport("secur32.dll", ExactSpelling = true, SetLastError = true)]
+		internal static extern int ApplyControlToken(ref SSPIHandle contextHandle, [In][Out] SecurityBufferDescriptor outputBuffer);
+
+		[DllImport("secur32.dll", ExactSpelling = true, SetLastError = true)]
+		internal unsafe static extern int InitializeSecurityContextW(ref SSPIHandle credentialHandle, ref SSPIHandle contextHandle, [In] byte* targetName, [In] int inFlags, [In] int reservedI, [In] int endianness, [In] SecurityBufferDescriptor inputBuffer, [In] int reservedII, ref SSPIHandle outContextPtr, [In][Out] SecurityBufferDescriptor outputBuffer, [In][Out] ref int attributes, out long timeStamp);
+	}
+
+	internal static class ReflectUtil {
+
+		private static BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+
+		public static object GetField(object obj, string fieldName) {
+			var tp = obj.GetType();
+			var info = GetAllFields(tp).Where(f => f.Name == fieldName).Single();
+			return info.GetValue(obj);
+		}
+
+		public static object GetProperty(object obj, string propertyName) {
+			var tp = obj.GetType();
+			var info = GetAllProperties(tp).Where(f => f.Name == propertyName).Single();
+			return info.GetValue(obj, null);
+		}
+
+		private static IEnumerable<FieldInfo> GetAllFields(Type t) {
+			if (t == null) {
+				return Enumerable.Empty<FieldInfo>();
+			}
+			return t.GetFields(flags).Concat(GetAllFields(t.BaseType));
+		}
+
+		private static IEnumerable<PropertyInfo> GetAllProperties(Type t) {
+			if (t == null) {
+				return Enumerable.Empty<PropertyInfo>();
+			}
+			return t.GetProperties(flags).Concat(GetAllProperties(t.BaseType));
+		}
+
+	}
+
+}

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -156,7 +156,7 @@ namespace FluentFTP {
 
 		private BufferedStream m_bufStream = null;
 
-		private SslStream m_sslStream = null;
+		private FluentSslLib.FluentSslStream m_sslStream = null;
 
 		/// <summary>
 		/// Gets the underlying stream, could be a NetworkStream or SslStream
@@ -1039,7 +1039,7 @@ namespace FluentFTP {
 				TimeSpan auth_time_total;
 
 				CreateBufferStream(isControlConnection);
-				CreateSSlStream();
+				CreateSslStream();
 
 				auth_start = DateTime.Now;
 				try {
@@ -1070,6 +1070,8 @@ namespace FluentFTP {
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Error, "FTPS Authentication Failed");
 				throw;
 			}
+
+			((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "SslStream: " + m_sslStream.ToString());
 		}
 
 		/// <summary>
@@ -1101,7 +1103,7 @@ namespace FluentFTP {
 				TimeSpan auth_time_total;
 
 				CreateBufferStream(isControlConnection);
-				CreateSSlStream();
+				CreateSslStream();
 
 				auth_start = DateTime.Now;
 				try {
@@ -1138,11 +1140,13 @@ namespace FluentFTP {
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Error, "FTPS Authentication Failed");
 				throw;
 			}
+
+			((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "SslStream: " + m_sslStream.ToString());
 		}
 
-		private void CreateSSlStream() {
+		private void CreateSslStream() {
 
-			m_sslStream = new SslStream(GetBufferStream(), true, new RemoteCertificateValidationCallback(
+			m_sslStream = new FluentSslLib.FluentSslStream(GetBufferStream(), true, new RemoteCertificateValidationCallback(
 				delegate (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return OnValidateCertificate(certificate, chain, sslPolicyErrors); }
 			));
 		}


### PR DESCRIPTION
Send your own close notify. See #996.

This wraps SslStream, takes Dispose and goes into marshalled unsafe code to produce an encrypted message to send on the socket that will be decrypted on the server that then reads correctly as an alert to close notify.

Note: When (someday) TLS 1.3 is taken a step further and this might have been fixed by MS, one might need to programmatically disable the sending of the close notify unless TLS 1.2 is being used.