### PR TITLE
Change comment

### DIFF
--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -171,7 +171,7 @@ namespace FluentFTP {
 		public bool DisconnectWithQuit { get; set; } = true;
 
 		/// <summary>
-		/// Before we disconnect from the server, send the Shutdown signal on the socket stream.
+		/// Deprecated and will be ignored and eventually removed
 		/// </summary>
 		public bool DisconnectWithShutdown { get; set; } = false;
 


### PR DESCRIPTION
Although `DisconnectWithShutdown` is no longer used, keep until V42 so that users builds continue to compile.