### PR TITLE
CloseSocket->DisposeSocket and remove Config.DisconnectWithShutdown

### DIFF
--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -171,11 +171,6 @@ namespace FluentFTP {
 		public bool DisconnectWithQuit { get; set; } = true;
 
 		/// <summary>
-		/// Before we disconnect from the server, send the Shutdown signal on the socket stream.
-		/// </summary>
-		public bool DisconnectWithShutdown { get; set; } = false;
-
-		/// <summary>
 		/// Gets or sets the length of time in milliseconds to wait for a connection 
 		/// attempt to succeed before giving up. Default is 15000 (15 seconds).
 		/// </summary>
@@ -548,7 +543,6 @@ namespace FluentFTP {
 			write.NoopInterval = read.NoopInterval;
 			write.DataConnectionType = read.DataConnectionType;
 			write.DisconnectWithQuit = read.DisconnectWithQuit;
-			write.DisconnectWithShutdown = read.DisconnectWithShutdown;
 			write.ConnectTimeout = read.ConnectTimeout;
 			write.ReadTimeout = read.ReadTimeout;
 			write.DataConnectionConnectTimeout = read.DataConnectionConnectTimeout;

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -407,7 +407,7 @@ namespace FluentFTP {
 				read = await EnableCancellation(
 					Task.Factory.FromAsync(asyncResult, m_socket.EndReceive),
 					token,
-					() => CloseSocket()
+					() => DisposeSocket()
 				);
 			}
 
@@ -736,26 +736,16 @@ namespace FluentFTP {
 				m_netStream = null;
 			}
 
-			CloseSocket();
+			DisposeSocket();
 		}
 
 		/// <summary>
 		/// Safely close the socket if its open
 		/// </summary>
-		internal void CloseSocket() {
+		internal void DisposeSocket() {
 			if (m_socket != null) {
 				try {
-#if NETSTANDARD
 					m_socket.Dispose();
-#else
-					if (m_socket.Connected) {
-						m_socket.Close();
-					}
-#endif
-
-#if NETFRAMEWORK
-					m_socket.Dispose();
-#endif
 				}
 				catch (Exception ex) {
 				}
@@ -953,12 +943,12 @@ namespace FluentFTP {
 					if (this.ConnectTimeout > 0) {
 						using (var timeoutSrc = CancellationTokenSource.CreateLinkedTokenSource(token)) {
 							timeoutSrc.CancelAfter(this.ConnectTimeout);
-							await EnableCancellation(m_socket.ConnectAsync(addresses[i], port), timeoutSrc.Token, () => CloseSocket());
+							await EnableCancellation(m_socket.ConnectAsync(addresses[i], port), timeoutSrc.Token, () => DisposeSocket());
 							break;
 						}
 					}
 					else {
-						await EnableCancellation(m_socket.ConnectAsync(addresses[i], port), token, () => CloseSocket());
+						await EnableCancellation(m_socket.ConnectAsync(addresses[i], port), token, () => DisposeSocket());
 						break;
 					}
 				}
@@ -978,7 +968,7 @@ namespace FluentFTP {
 				}
 #else
 				var connectResult = m_socket.BeginConnect(addresses[i], port, null, null);
-				await EnableCancellation(Task.Factory.FromAsync(connectResult, m_socket.EndConnect), token, () => CloseSocket());
+				await EnableCancellation(Task.Factory.FromAsync(connectResult, m_socket.EndConnect), token, () => DisposeSocket());
 				break;
 #endif
 			}


### PR DESCRIPTION
A SSL Closure Alert is now always sent when a stream is "terminated". The Socket will get a Dispose. CloseSocket will be renamed to DisposeSocket. This is also to a certain degree for #996.