### PR TITLE
More verbose messages to help debugging

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -151,6 +151,8 @@ namespace FluentFTP {
 					}
 				}
 
+				LogWithPrefix(FtpTraceLevel.Verbose, "Downloaded " + offset + " bytes");
+
 				sw.Stop();
 
 				// disconnect FTP stream before exiting

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -230,6 +230,8 @@ namespace FluentFTP {
 					}
 				}
 
+				LogWithPrefix(FtpTraceLevel.Verbose, "Uploaded " + upStream.Position + " bytes");
+
 				sw.Stop();
 
 				// wait for transfer to get over

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -146,6 +146,8 @@ namespace FluentFTP {
 					}
 				}
 
+				LogWithPrefix(FtpTraceLevel.Verbose, "Downloaded " + offset + " bytes");
+
 				sw.Stop();
 
 				// disconnect FTP stream before exiting

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -221,8 +221,9 @@ namespace FluentFTP {
 					}
 				}
 
-				sw.Stop();
+				LogWithPrefix(FtpTraceLevel.Verbose, "Uploaded " + upStream.Position + " bytes");
 
+				sw.Stop();
 
 				// wait for transfer to get over
 				while (upStream.Position < upStream.Length) {


### PR DESCRIPTION
Whilst searching/checking for correctness of our integration tests, it was a nice quick way to confirm the downloads/uploads were doing what they were supposed to do when changing the lengths and size of the data.