### PR TITLE
Ability to run test server containers as FTP or FTPS servers

### DIFF
--- a/FluentFTP.Dockers/proftpd/run-proftpd.sh
+++ b/FluentFTP.Dockers/proftpd/run-proftpd.sh
@@ -12,7 +12,12 @@ cat << EOB
 	---------------
 	· FTP User: fluentuser
 	· FTP Password: fluentpass
+	  SSL: $USE_SSL
 EOB
+
+if [[ -n "${USE_SSL}" ]]; then
+  sed -i "s/^\(# \)\?TLSEngine.*$/TLSEngine on/" /etc/proftpd/tls.conf
+fi
 
 # Run proftpd:
 &>/dev/null /usr/sbin/proftpd -n

--- a/FluentFTP.Dockers/proftpd/tls.conf
+++ b/FluentFTP.Dockers/proftpd/tls.conf
@@ -7,7 +7,13 @@
 #
 
 <IfModule mod_tls.c>
-TLSEngine                               on
+#
+# The following will be enabled if needed by the docker run sh
+#
+TLSEngine                               off
+#
+#
+#
 TLSLog                                  /var/log/proftpd/tls.log
 TLSProtocol                             TLSv1.2 TLSv1.3
 #

--- a/FluentFTP.Dockers/vsftpd/run-vsftpd.sh
+++ b/FluentFTP.Dockers/vsftpd/run-vsftpd.sh
@@ -12,7 +12,12 @@ cat << EOB
 	---------------
 	· FTP User: fluentuser
 	· FTP Password: fluentpass
+	  SSL: $USE_SSL
 EOB
+
+if [[ -n "${USE_SSL}" ]]; then
+  sed -i "s/^\(# \)\?ssl_enable=.*$/ssl_enable=YES/" /etc/vsftpd.conf
+fi
 
 # Run vsftpd:
 &>/dev/null /usr/sbin/vsftpd /etc/vsftpd.conf

--- a/FluentFTP.Dockers/vsftpd/vsftpd.conf
+++ b/FluentFTP.Dockers/vsftpd/vsftpd.conf
@@ -155,16 +155,18 @@ pam_service_name=vsftpd
 
 #
 # This option specifies the location of the RSA certificate to use for SSL
-# encrypted connections.
+# encrypted connections. Generated in the dockerfile
+#
 rsa_cert_file=/etc/ssl/certs/vsftpd.crt
 rsa_private_key_file=/etc/ssl/private/vsftpd.key
-ssl_enable=YES
 
-# session resume
-require_ssl_reuse=YES
-
-# avoid 426 Failure reading network stream (incorrect ssl shutdown)
-strict_ssl_read_eof=YES
+#
+# The following will be enabled if needed by the docker run sh
+#
+ssl_enable=NO
+#
+#
+#
 
 # Enable passive mode
 pasv_enable=YES
@@ -177,3 +179,10 @@ pasv_addr_resolve=NO
 port_enable=YES
 connect_from_port_20=YES
 ftp_data_port=20
+
+#
+# session resume
+require_ssl_reuse=YES
+
+# 426 Failure reading network stream (incorrect ssl shutdown)
+strict_ssl_read_eof=YES

--- a/FluentFTP.Tests/Integration/IntegrationTests.cs
+++ b/FluentFTP.Tests/Integration/IntegrationTests.cs
@@ -9,10 +9,26 @@ using FluentFTP.Tests.Integration.System;
 namespace FluentFTP.Tests.Integration {
 	public class IntegrationTests {
 
+		private static bool UseSsl = true;
+
+		[Fact]
+		public async Task VsFtpd() {
+			await IntegrationTestRunner.Run(FtpServer.VsFTPd);
+		}
+		[Fact]
+		public async Task VsFtpdSsl() {
+			await IntegrationTestRunner.Run(FtpServer.VsFTPd, UseSsl);
+		}
 		[Fact]
 		public async Task ProFtpd() {
 			await IntegrationTestRunner.Run(FtpServer.ProFTPD);
 		}
+		[Fact]
+		public async Task ProFtpdSsl() {
+			await IntegrationTestRunner.Run(FtpServer.ProFTPD, UseSsl);
+		}
+
+		// Still need SSL variants of these
 		[Fact]
 		public async Task PureFtpd() {
 			await IntegrationTestRunner.Run(FtpServer.PureFTPd);
@@ -20,10 +36,6 @@ namespace FluentFTP.Tests.Integration {
 		[Fact]
 		public async Task PyFtpdLib() {
 			await IntegrationTestRunner.Run(FtpServer.PyFtpdLib);
-		}
-		[Fact]
-		public async Task VsFtpd() {
-			await IntegrationTestRunner.Run(FtpServer.VsFTPd);
 		}
 
 	}

--- a/FluentFTP.Tests/Integration/System/IntegrationTestRunner.cs
+++ b/FluentFTP.Tests/Integration/System/IntegrationTestRunner.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace FluentFTP.Tests.Integration.System {
 	internal static class IntegrationTestRunner {
 
-		public static async Task Run(FtpServer serverType) {
+		public static async Task Run(FtpServer serverType, bool useSsl = false) {
 
 			// If we are in CI pipeline
 			if (DockerFtpConfig.IsCI) {
@@ -20,7 +20,7 @@ namespace FluentFTP.Tests.Integration.System {
 			}
 
 			// spin up a new docker
-			using var server = new DockerFtpServer(serverType);
+			using var server = new DockerFtpServer(serverType, useSsl);
 
 			try {
 

--- a/FluentFTP.Xunit/Docker/Containers/ProFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/ProFtpdContainer.cs
@@ -13,13 +13,18 @@ namespace FluentFTP.Xunit.Docker.Containers {
 			ServerType = FtpServer.ProFTPD;
 			ServerName = "proftpd";
 			DockerImage = "proftpd:fluentftp";
-			//RunCommand = "docker run -d --net host proftpd:fluentftp";
+			//without SSL:
+			// RunCommand = "docker run -d --net host proftpd:fluentftp";
+			//with SSL:
+			// RunCommand = "docker run -d --net host -e USE_SSL=YES proftpd:fluentftp";
 		}
 
 		/// <summary>
 		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
 		/// </summary>
 		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
+
+			builder = builder.WithPortBinding(20);
 
 			builder = ExposePortRange(builder, 21100, 21110);
 

--- a/FluentFTP.Xunit/Docker/Containers/VsFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/VsFtpdContainer.cs
@@ -13,7 +13,10 @@ namespace FluentFTP.Xunit.Docker.Containers {
 			ServerType = FtpServer.VsFTPd;
 			ServerName = "vsftpd";
 			DockerImage = "vsftpd:fluentftp";
-			//RunCommand = "docker run --rm -it -p 21:21 -p 21100-21110:21100-21110 vsftpd:fluentftp";
+			//without SSL:
+			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21110:21100-21110 vsftpd:fluentftp";
+			//with SSL:
+			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21110:21100-21110 -e USE_SSL=YES vsftpd:fluentftp";
 		}
 
 		/// <summary>
@@ -29,4 +32,5 @@ namespace FluentFTP.Xunit.Docker.Containers {
 		}
 
 	}
+
 }

--- a/FluentFTP.Xunit/Docker/DockerFtpContainer.cs
+++ b/FluentFTP.Xunit/Docker/DockerFtpContainer.cs
@@ -22,7 +22,7 @@ namespace FluentFTP.Xunit.Docker {
 			return builder;
 		}
 
-		public virtual TestcontainersContainer Build() {
+		public virtual TestcontainersContainer Build(bool useSsl = false) {
 
 			var builder = new TestcontainersBuilder<TestcontainersContainer>()
 				.WithImage(DockerImage)
@@ -32,6 +32,10 @@ namespace FluentFTP.Xunit.Docker {
 			builder = this.Configure(builder);
 
 			builder = builder.WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(21));
+
+			if (useSsl) {
+				builder = builder.WithEnvironment("USE_SSL", "YES");
+			}
 
 			var container = builder.Build();
 

--- a/FluentFTP.Xunit/Docker/DockerFtpServer.cs
+++ b/FluentFTP.Xunit/Docker/DockerFtpServer.cs
@@ -14,14 +14,17 @@ namespace FluentFTP.Xunit.Docker {
 	public class DockerFtpServer : IDisposable {
 		internal DockerFtpContainer _server;
 		internal TestcontainersContainer _container;
+		internal bool _useSsl;
 
-		public DockerFtpServer(FtpServer serverType) {
+		public DockerFtpServer(FtpServer serverType, bool useSsl) {
 
 			// find the server
 			_server = DockerFtpContainerIndex.Index.FirstOrDefault(s => s.ServerType == serverType);
 			if (_server == null) {
 				throw new ArgumentException("Server type '" + serverType + "' cannot be found! You can contribute support for this server! See https://github.com/robinrodricks/FluentFTP/wiki/Automated-Testing.");
 			}
+
+			_useSsl = useSsl;
 
 			// build and start the container image
 			StartContainer();
@@ -61,7 +64,7 @@ namespace FluentFTP.Xunit.Docker {
 					_container?.DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
 					// build the container image
-					_container = _server.Build();
+					_container = _server.Build(_useSsl);
 
 					// start the container
 					_container.StartAsync().ConfigureAwait(false).GetAwaiter().GetResult();


### PR DESCRIPTION
Those servers capable of this (currently vsftpd and proftpd) can be run from a single docker image, a single docker file etc. as either an FTP or an FTPS server. This is controlled by an environment variable (`$USE_SSL`).