### PR TITLE
Select fastest nearby debian apt mirror automatically

### DIFF
--- a/FluentFTP.Dockers/bftpd/Dockerfile
+++ b/FluentFTP.Dockers/bftpd/Dockerfile
@@ -2,6 +2,16 @@
 # FluentFTP Integration Test Server: bftpd
 #
 
+FROM	python:3-slim AS prebuild
+
+SHELL	["/bin/bash", "-c"]
+
+WORKDIR	/usr/src/app
+RUN	pip install --user apt-smart
+
+WORKDIR	/root
+RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
+
 #
 # Stage 1: build
 #
@@ -13,7 +23,25 @@ SHELL	["/bin/bash", "-c"]
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
 
+COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
+
 WORKDIR	/
+RUN	mapfile -t lines < /root/deb_mirror && \
+	DEB_MIRROR=${lines[0]} && \
+	echo $DEB_MIRROR && \
+	\
+	printf "\
+	deb $DEB_MIRROR bullseye main\n\
+#	deb-src $DEB_MIRROR bullseye main\n\
+	\n\
+	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
+#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
+	\n\
+	# bullseye-updates, previously known as 'volatile'\n\
+	deb $DEB_MIRROR bullseye-updates main\n\
+#	deb-src $DEB_MIRROR bullseye-updates main\n\
+	" > /etc/apt/sources.list
+
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
 		\
 		$APT_CMD \
@@ -61,8 +89,7 @@ RUN	sed -i -e "s/\r//" /usr/etc/bftpd.conf && \
 	mkdir -p /home/fluentuser/ && \
 	chown -R fluentuser:users /home/fluentuser
 
-VOLUME	/home/fluentuser
-VOLUME	/var/log/bftpd
+VOLUME	["/home/fluentuser", "/var/log/bftpd"]
 
 EXPOSE	20 21
 

--- a/FluentFTP.Dockers/filezilla/Dockerfile
+++ b/FluentFTP.Dockers/filezilla/Dockerfile
@@ -2,6 +2,16 @@
 # FluentFTP Integration Test Server: filezilla-server
 #
 
+FROM	python:3-slim AS prebuild
+
+SHELL	["/bin/bash", "-c"]
+
+WORKDIR	/usr/src/app
+RUN	pip install --user apt-smart
+
+WORKDIR	/root
+RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
+
 #
 # Stage 1: build
 #
@@ -19,7 +29,25 @@ ARG	FILEZILLA_URL=https://download.filezilla-project.org/server/FileZilla_Server
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
 
+COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
+
 WORKDIR	/
+RUN	mapfile -t lines < /root/deb_mirror && \
+	DEB_MIRROR=${lines[0]} && \
+	echo $DEB_MIRROR && \
+	\
+	printf "\
+	deb $DEB_MIRROR bullseye main\n\
+#	deb-src $DEB_MIRROR bullseye main\n\
+	\n\
+	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
+#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
+	\n\
+	# bullseye-updates, previously known as 'volatile'\n\
+	deb $DEB_MIRROR bullseye-updates main\n\
+#	deb-src $DEB_MIRROR bullseye-updates main\n\
+	" > /etc/apt/sources.list
+
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
 		\
 		$APT_CMD \
@@ -150,8 +178,7 @@ RUN	sed -i -e "s/\r//" /usr/sbin/run-filezilla.sh && \
 	mkdir -p /home/fluentuser/ && \
 	chown -R fluentuser:users /home/fluentuser
 
-VOLUME	/home/fluentuser
-VOLUME	/var/log/filezilla
+VOLUME	["/home/fluentuser", "/var/log/filezilla"]
 
 EXPOSE	20 21
 

--- a/FluentFTP.Dockers/glftpd/Dockerfile
+++ b/FluentFTP.Dockers/glftpd/Dockerfile
@@ -2,6 +2,16 @@
 # FluentFTP Integration Test Server: glftpd
 #
 
+FROM	python:3-slim AS prebuild
+
+SHELL	["/bin/bash", "-c"]
+
+WORKDIR	/usr/src/app
+RUN	pip install --user apt-smart
+
+WORKDIR	/root
+RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
+
 #
 # Stage 1: build & production
 #
@@ -18,7 +28,25 @@ ARG	OPENSSL_VERSION=3.0.1
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
 
+COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
+
 WORKDIR	/
+RUN	mapfile -t lines < /root/deb_mirror && \
+	DEB_MIRROR=${lines[0]} && \
+	echo $DEB_MIRROR && \
+	\
+	printf "\
+	deb $DEB_MIRROR bullseye main\n\
+#	deb-src $DEB_MIRROR bullseye main\n\
+	\n\
+	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
+#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
+	\n\
+	# bullseye-updates, previously known as 'volatile'\n\
+	deb $DEB_MIRROR bullseye-updates main\n\
+#	deb-src $DEB_MIRROR bullseye-updates main\n\
+	" > /etc/apt/sources.list
+
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
 		\
 		$APT_CMD \
@@ -62,8 +90,7 @@ RUN	sed -i -e "s/\r//" /etc/xinetd.conf && \
 	mkdir -p /home/fluentuser/ && \
 	chown -R fluentuser:users /home/fluentuser
 	
-VOLUME	/home/fluentuser
-VOLUME	/var/log/glftpd
+VOLUME	["/home/fluentuser", "/var/log/glftpd"]
 
 EXPOSE	20 21
 

--- a/FluentFTP.Dockers/proftpd/Dockerfile
+++ b/FluentFTP.Dockers/proftpd/Dockerfile
@@ -2,6 +2,16 @@
 # FluentFTP Integration Test Server: proftpd
 #
 
+FROM	python:3-slim AS prebuild
+
+SHELL	["/bin/bash", "-c"]
+
+WORKDIR	/usr/src/app
+RUN	pip install --user apt-smart
+
+WORKDIR	/root
+RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
+
 #
 # Stage 1: build & production
 #
@@ -15,7 +25,25 @@ SHELL	["/bin/bash", "-c"]
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
 
+COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
+
 WORKDIR	/
+RUN	mapfile -t lines < /root/deb_mirror && \
+	DEB_MIRROR=${lines[0]} && \
+	echo $DEB_MIRROR && \
+	\
+	printf "\
+	deb $DEB_MIRROR bullseye main\n\
+#	deb-src $DEB_MIRROR bullseye main\n\
+	\n\
+	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
+#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
+	\n\
+	# bullseye-updates, previously known as 'volatile'\n\
+	deb $DEB_MIRROR bullseye-updates main\n\
+#	deb-src $DEB_MIRROR bullseye-updates main\n\
+	" > /etc/apt/sources.list
+
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
 		\
 		$APT_CMD \
@@ -48,8 +76,7 @@ RUN	sed -i -e "s/\r//" /etc/proftpd/proftpd.conf && \
 	chmod 0600 /etc/ssl/private/proftpd.key && \
 	chmod 0640 /etc/ssl/private/proftpd.key
 
-VOLUME	/home/fluentuser
-VOLUME	/var/log/proftpd
+VOLUME	["/home/fluentuser", "/var/log/proftpd"]
 
 EXPOSE	20 21
 

--- a/FluentFTP.Dockers/vsftpd/Dockerfile
+++ b/FluentFTP.Dockers/vsftpd/Dockerfile
@@ -2,6 +2,16 @@
 # FluentFTP Integration Test Server: vsftpd
 #
 
+FROM	python:3-slim AS prebuild
+
+SHELL	["/bin/bash", "-c"]
+
+WORKDIR	/usr/src/app
+RUN	pip install --user apt-smart
+
+WORKDIR	/root
+RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
+
 #
 # Stage 1: build & production
 #
@@ -14,6 +24,25 @@ SHELL	["/bin/bash", "-c"]
 
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
+
+COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
+
+WORKDIR	/
+RUN	mapfile -t lines < /root/deb_mirror && \
+	DEB_MIRROR=${lines[0]} && \
+	echo $DEB_MIRROR && \
+	\
+	printf "\
+	deb $DEB_MIRROR bullseye main\n\
+#	deb-src $DEB_MIRROR bullseye main\n\
+	\n\
+	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
+#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
+	\n\
+	# bullseye-updates, previously known as 'volatile'\n\
+	deb $DEB_MIRROR bullseye-updates main\n\
+#	deb-src $DEB_MIRROR bullseye-updates main\n\
+	" > /etc/apt/sources.list
 
 WORKDIR	/
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
@@ -30,7 +59,7 @@ RUN	sed -i -e "s/\r//" /usr/sbin/run-vsftpd.sh && \
 	sed -i -e "s/\r//" /etc/vsftpd.conf
 
 WORKDIR	/
-RUN	sed -i -e "s/\r//" /usr/etc/vsftpd.conf && \
+RUN	sed -i -e "s/\r//" /etc/vsftpd.conf && \
 	sed -i -e "s/\r//" /usr/sbin/run-vsftpd.sh && \
 	chmod +x /usr/sbin/run-vsftpd.sh && \
 	\
@@ -47,8 +76,7 @@ RUN	sed -i -e "s/\r//" /usr/etc/vsftpd.conf && \
 	chmod 0600 /etc/ssl/private/vsftpd.key && \
 	chmod 0640 /etc/ssl/private/vsftpd.key
 
-VOLUME	/home/fluentuser
-VOLUME	/var/log/vsftpd
+VOLUME	["/home/fluentuser", "/var/log/vsftpd"]
 
 EXPOSE	20 21
 


### PR DESCRIPTION
To reduce build times, use a python script to select the debian mirror for the apt build steps