### PR TITLE
Better granularity on CAP settings for pure-ftpd

### DIFF
--- a/FluentFTP.Xunit/Docker/Containers/PureFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/PureFtpdContainer.cs
@@ -31,7 +31,8 @@ namespace FluentFTP.Xunit.Docker.Containers {
 
 			builder = builder.WithCreateContainerParametersModifier(x => {
 				x.HostConfig.CapAdd = new List<string> {
-					"ALL"
+					"SYS_NICE",
+					"DAC_READ_SEARCH"
 				};
 			});
 


### PR DESCRIPTION
Instead of brutally enabling "ALL", why not just enable those that are **actually** needed...