### PR TITLE
Async Connect Timeouts

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -839,7 +839,7 @@ namespace FluentFTP {
 				string addrFamily = ipad.AddressFamily.ToString();
 
 				if (!IsIpVersionAllowed(ipad, ipVersions, out string logFamily)) {
-					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Skipped " + logFamily + "address: " + logIp);
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Skipped " + logFamily + " address: " + logIp);
 					continue;
 				}
 


### PR DESCRIPTION
Fixes #1035.

Also, it brings in some other missing stuff in the async section of Connect.

In the sync section, I tried to make the behaviour for a timeout value of 0 behave the same way as in the async section, which means take the internal socket timeout (about 21 seconds). Otherwise a timeout of 0 would return immediately w/o a connection.

Also, the code to fix #869 was somewhat flaky. Generally, I would refrain from using error texts (in possibly hundreds of different language variants) and try to use socket error codes. Testing for the error text **and** the error code is also quite redundant.