### PR TITLE
Log first, then perhaps throw

### DIFF
--- a/FluentFTP/Client/AsyncClient/GetReply.cs
+++ b/FluentFTP/Client/AsyncClient/GetReply.cs
@@ -58,15 +58,15 @@ namespace FluentFTP {
 
 			var reply = new FtpReply();
 
-			if (!IsConnected) {
-				throw new InvalidOperationException("No connection to the server has been established.");
-			}
-
 			if (string.IsNullOrEmpty(command)) {
 				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for a response");
 			}
 			else {
 				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + OnPostExecute(command));
+			}
+
+			if (!IsConnected) {
+				throw new InvalidOperationException("No connection to the server has been established.");
 			}
 
 			// Implement this: https://lists.apache.org/thread/xzpclw1015qncvczt8hg3nom2p5vtcf5

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -60,15 +60,15 @@ namespace FluentFTP.Client.BaseClient {
 
 			lock (m_lock) {
 
-				if (!IsConnected) {
-					throw new InvalidOperationException("No connection to the server has been established.");
-				}
-
 				if (string.IsNullOrEmpty(command)) {
 					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for a response");
 				}
 				else {
 					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + OnPostExecute(command));
+				}
+
+				if (!IsConnected) {
+					throw new InvalidOperationException("No connection to the server has been established.");
 				}
 
 				// Implement this: https://lists.apache.org/thread/xzpclw1015qncvczt8hg3nom2p5vtcf5


### PR DESCRIPTION
In preparation for fixing #1030 - fix reconnect problems

The log message should appear before the possible throw