### PR TITLE
Separate clean command and postexecute functionality

### DIFF
--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -7,6 +7,7 @@ using System.Net;
 using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentFTP.Client.Modules;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
@@ -41,9 +42,9 @@ namespace FluentFTP {
 			}
 
 			// hide sensitive data from logs
-			string commandTxt = OnPostExecute(command);
+			string commandClean = LogMaskModule.MaskCommand(this, command);
 
-			Log(FtpTraceLevel.Info, "Command:  " + commandTxt);
+			Log(FtpTraceLevel.Info, "Command:  " + commandClean);
 
 			// send command to FTP server
 			await m_stream.WriteLineAsync(m_textEncoding, command, token);

--- a/FluentFTP/Client/AsyncClient/GetReply.cs
+++ b/FluentFTP/Client/AsyncClient/GetReply.cs
@@ -8,6 +8,7 @@ using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using FluentFTP.Client.Modules;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
@@ -62,7 +63,7 @@ namespace FluentFTP {
 				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for a response");
 			}
 			else {
-				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + OnPostExecute(command));
+				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + LogMaskModule.MaskCommand(this, command));
 			}
 
 			if (!IsConnected) {

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -64,7 +64,7 @@ namespace FluentFTP.Client.BaseClient {
 					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for a response");
 				}
 				else {
-					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + OnPostExecute(command));
+					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + LogMaskModule.MaskCommand(this, command));
 				}
 
 				if (!IsConnected) {


### PR DESCRIPTION
In preparation for fixing #1030 - fix reconnect problems

Cleaning the command to be logged is a separate functionality from updating stored values, which should only happen on command success


Cannot do the command cleaning in this block:
```
				if (reply.Success) {
					OnPostExecute(command);
				}
```