### PR TITLE
Reset was missing CurrentDataType

### DIFF
--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -74,6 +74,7 @@ namespace FluentFTP {
 			ConnectionFTPSFailure = false;
 			ConnectionUTF8Success = false;
 			AllowCheckStaleData = false;
+			CurrentDataType = FtpDataType.Unknown;
 		}
 
 		/// <summary>


### PR DESCRIPTION
In preparation for fixing #1030 - fix reconnect problems

When connecting with the same client, status is reset - but it was missing the ASCII/BINARY information to be reset.