### PR TITLE
Update CWD to null on special case of CWD command

### DIFF
--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -51,7 +51,10 @@ namespace FluentFTP.Client.BaseClient {
 		protected void OnPostExecute(string command) {
 
 			// Update stored values
-			if (command.StartsWith("CWD ", StringComparison.Ordinal)) {
+			if (command.TrimEnd() == "CWD") {
+				Status.LastWorkingDir = null;
+			}
+			else if (command.StartsWith("CWD ", StringComparison.Ordinal)) {
 				Status.LastWorkingDir = command.Substring(4).Trim();
 			}
 			else if (command.StartsWith("TYPE I", StringComparison.Ordinal)) {


### PR DESCRIPTION
Nobody should ever do this, but if a CWD **without any parms or just blanks** is generated, different servers will react differently. 

- a server might refuse and reply with an error code without changing the current working directory
In this case, this code won't even get entered. It only runs on command success.

In case of a command success :
- z/OS or some other servers will go to the users home dir or to the root dir
-  a server might ignore the CWD command without changing the current working directory

So, let's set the current working directory stored value to **null** in this case.