### PR TITLE
Better log message for stream dispose

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -40,6 +40,7 @@ namespace FluentFTP {
 
 			if (m_stream == null) {
 				m_stream = new FtpSocketStream(this);
+				m_stream.IsControlConnection = true;
 				m_stream.ValidateCertificate += new FtpSocketStreamSslValidation(FireValidateCertficate);
 			}
 			else {

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -70,7 +70,6 @@ namespace FluentFTP {
 				await m_stream.ActivateEncryptionAsync(Host,
 					Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
 					Config.SslProtocols,
-					true,
 					token);
 			}
 
@@ -96,7 +95,6 @@ namespace FluentFTP {
 					await m_stream.ActivateEncryptionAsync(Host,
 						Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
 						Config.SslProtocols,
-						true,
 						token);
 				}
 			}

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -40,7 +40,6 @@ namespace FluentFTP {
 
 			if (m_stream == null) {
 				m_stream = new FtpSocketStream(this);
-				m_stream.IsControlConnection = true;
 				m_stream.ValidateCertificate += new FtpSocketStreamSslValidation(FireValidateCertficate);
 			}
 			else {

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -41,6 +41,7 @@ namespace FluentFTP {
 
 				if (m_stream == null) {
 					m_stream = new FtpSocketStream(this);
+					m_stream.IsControlConnection = true;
 					m_stream.ValidateCertificate += new FtpSocketStreamSslValidation(FireValidateCertficate);
 				}
 				else {

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -41,7 +41,6 @@ namespace FluentFTP {
 
 				if (m_stream == null) {
 					m_stream = new FtpSocketStream(this);
-					m_stream.IsControlConnection = true;
 					m_stream.ValidateCertificate += new FtpSocketStreamSslValidation(FireValidateCertficate);
 				}
 				else {

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -70,8 +70,7 @@ namespace FluentFTP {
 				if (Config.EncryptionMode == FtpEncryptionMode.Implicit) {
 					m_stream.ActivateEncryption(Host,
 						Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
-						Config.SslProtocols,
-						true);
+						Config.SslProtocols);
 				}
 
 				Handshake();
@@ -95,8 +94,7 @@ namespace FluentFTP {
 					else {
 						m_stream.ActivateEncryption(Host,
 							Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
-							Config.SslProtocols,
-							true);
+							Config.SslProtocols);
 					}
 				}
 

--- a/FluentFTP/Streams/FtpDataStream.cs
+++ b/FluentFTP/Streams/FtpDataStream.cs
@@ -149,6 +149,8 @@ namespace FluentFTP {
 			ValidateCertificate += new FtpSocketStreamSslValidation(delegate (FtpSocketStream obj, FtpSslValidationEventArgs e) { e.Accept = true; });
 
 			m_position = 0;
+
+			IsControlConnection = false;
 		}
 
 		/// <summary>

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -143,7 +143,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Is this stream the control connection?
 		/// </summary>
-		public bool IsControlConnection { get; set; }
+		public bool IsControlConnection { get; set; } = true;
 
 
 		/// <summary>

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -141,6 +141,12 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
+		/// Is this stream the control connection?
+		/// </summary>
+		public bool IsControlConnection { get; set; }
+
+
+		/// <summary>
 		/// The negotiated SSL/TLS protocol version. Will have a valid value after connection is complete.
 		/// </summary>
 		public SslProtocols SslProtocolActive {

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -705,7 +705,8 @@ namespace FluentFTP {
 			try {
 				// ensure null exceptions don't occur here
 				if (Client != null) {
-					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing FtpSocketStream...");
+					string connText = this.IsControlConnection ? "control" : "data";
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing FtpSocketStream(" + connText + " connection)");
 				}
 			}
 			catch (Exception) {

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1058,9 +1058,8 @@ namespace FluentFTP {
 		/// <param name="targethost">The host to authenticate the certificate against</param>
 		/// <param name="clientCerts">A collection of client certificates to use when authenticating the SSL stream</param>
 		/// <param name="sslProtocols">A bitwise parameter for supported encryption protocols.</param>
-		/// <param name="isControlConnection"></param>
 		/// <exception cref="AuthenticationException">Thrown when authentication fails</exception>
-		public void ActivateEncryption(string targethost, X509CertificateCollection clientCerts, SslProtocols sslProtocols, bool isControlConnection = false) {
+		public void ActivateEncryption(string targethost, X509CertificateCollection clientCerts, SslProtocols sslProtocols) {
 			if (!IsConnected) {
 				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
 			}
@@ -1077,7 +1076,7 @@ namespace FluentFTP {
 				DateTime auth_start;
 				TimeSpan auth_time_total;
 
-				CreateBufferStream(isControlConnection);
+				CreateBufferStream();
 				CreateSslStream();
 
 				auth_start = DateTime.Now;
@@ -1133,10 +1132,9 @@ namespace FluentFTP {
 		/// <param name="targethost">The host to authenticate the certificate against</param>
 		/// <param name="clientCerts">A collection of client certificates to use when authenticating the SSL stream</param>
 		/// <param name="sslProtocols">A bitwise parameter for supported encryption protocols.</param>
-		/// <param name="isControlConnection"></param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <exception cref="AuthenticationException">Thrown when authentication fails</exception>
-		public async Task ActivateEncryptionAsync(string targethost, X509CertificateCollection clientCerts, SslProtocols sslProtocols, bool isControlConnection = false, CancellationToken token = default) {
+		public async Task ActivateEncryptionAsync(string targethost, X509CertificateCollection clientCerts, SslProtocols sslProtocols, CancellationToken token = default) {
 			if (!IsConnected) {
 				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
 			}
@@ -1153,7 +1151,7 @@ namespace FluentFTP {
 				DateTime auth_start;
 				TimeSpan auth_time_total;
 
-				CreateBufferStream(isControlConnection);
+				CreateBufferStream();
 				CreateSslStream();
 
 				auth_start = DateTime.Now;
@@ -1205,7 +1203,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Conditionally create a SSL BufferStream based on the configuration in FtpClient.SslBuffering.
 		/// </summary>
-		private void CreateBufferStream(bool isControlConnection) {
+		private void CreateBufferStream() {
 			// Even if SSL Bufferstream is requested, it is force-disabled automatically when
 			// Fix: using FTP proxies
 			// Fix: user needs NOOPs - See #823
@@ -1219,7 +1217,7 @@ namespace FluentFTP {
 #else
 			if ((Client.Config.SslBuffering == FtpsBuffering.On || Client.Config.SslBuffering == FtpsBuffering.Auto) &&
 				 (!Client.IsProxy()) &&
-				 (!isControlConnection || Client.Config.NoopInterval == 0)) {
+				 (!IsControlConnection || Client.Config.NoopInterval == 0)) {
 				m_bufStream = new BufferedStream(NetworkStream, 81920);
 			}
 			else {


### PR DESCRIPTION
To help debugging, it is useful to know **which** stream is suddenly being disposed.

The needed flag for `IsControlConnection`: First I set that in `connect()`, but later on I realised it would be much cleaner to put that into the stream constructor.

A very nice side effect of adding this flag was to take back the parameter passing of the `isControlConnection` flag in the `CreateBufferStream` process.
