### PR TITLE
Make resume logic the same for upload/download sync/async

### DIFF
--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -288,14 +288,12 @@ namespace FluentFTP {
 		}
 
 		protected async Task<Tuple<bool, Stream>> ResumeUploadAsync(string remotePath, Stream upStream, long remotePosition, IOException ex, CancellationToken token = default) {
-
 			try {
-
 				// if resume possible
 				if (ex.IsResumeAllowed()) {
-
 					// dispose the old bugged out stream
 					upStream.Dispose();
+					LogWithPrefix(FtpTraceLevel.Info, "Attempting upload resume at position " + remotePosition);
 
 					// create and return a new stream starting at the current remotePosition
 					var returnStream = await OpenAppend(remotePath, Config.UploadDataType, 0, token);
@@ -305,10 +303,8 @@ namespace FluentFTP {
 
 				// resume not allowed
 				return Tuple.Create(false, (Stream)null);
-
 			}
 			catch (Exception resumeEx) {
-
 				throw new AggregateException("Additional error occured while trying to resume uploading the file '" + remotePath + "' at position " + remotePosition, new Exception[] { ex, resumeEx });
 			}
 		}


### PR DESCRIPTION
ResumeDownload Sync and Async look good, but they are missing the try catch that can be seen in ResumeUpload Async,

ResumeUpload Sync is missing, although there is a ResumeUpload Async.

1. Make a nice try catch aggregate exception (using ResumeDownloadAsync as a model) in the other three cases
2. Code the missing ResumeUpload for Sync using the others as a model.
3. Add a log message so that the resume operation is actually noticed by users
