### PR TITLE
Revert the CWD update change

### DIFF
--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -51,11 +51,8 @@ namespace FluentFTP.Client.BaseClient {
 		protected void OnPostExecute(string command) {
 
 			// Update stored values
-			if (command.TrimEnd() == "CWD") {
+			if (command.TrimEnd() == "CWD" || command.StartsWith("CWD ", StringComparison.Ordinal)) {
 				Status.LastWorkingDir = null;
-			}
-			else if (command.StartsWith("CWD ", StringComparison.Ordinal)) {
-				Status.LastWorkingDir = command.Substring(4).Trim();
 			}
 			else if (command.StartsWith("TYPE I", StringComparison.Ordinal)) {
 				Status.CurrentDataType = FtpDataType.Binary;


### PR DESCRIPTION
The assumption that a CWD command sets the current working directory to the string behind the command was a brain shortcircuit.

Set to null is the way to go.