### PR TITLE
Dockerfiles: No mirror optimisation

### DIFF
--- a/FluentFTP.Dockers/bftpd/Dockerfile
+++ b/FluentFTP.Dockers/bftpd/Dockerfile
@@ -2,16 +2,6 @@
 # FluentFTP Integration Test Server: bftpd
 #
 
-FROM	python:3-slim AS prebuild
-
-SHELL	["/bin/bash", "-c"]
-
-WORKDIR	/usr/src/app
-RUN	pip install --user apt-smart
-
-WORKDIR	/root
-RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
-
 #
 # Stage 1: build
 #
@@ -23,28 +13,10 @@ SHELL	["/bin/bash", "-c"]
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
 
-COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
-
-WORKDIR	/
-RUN	mapfile -t lines < /root/deb_mirror && \
-	DEB_MIRROR=${lines[0]} && \
-	echo $DEB_MIRROR && \
-	\
-	printf "\
-	deb $DEB_MIRROR bullseye main\n\
-#	deb-src $DEB_MIRROR bullseye main\n\
-	\n\
-	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
-#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
-	\n\
-	# bullseye-updates, previously known as 'volatile'\n\
-	deb $DEB_MIRROR bullseye-updates main\n\
-#	deb-src $DEB_MIRROR bullseye-updates main\n\
-	" > /etc/apt/sources.list
-
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
 		\
 		$APT_CMD \
+			ca-certificates \
 			wget \
 			build-essential
 

--- a/FluentFTP.Dockers/filezilla/Dockerfile
+++ b/FluentFTP.Dockers/filezilla/Dockerfile
@@ -2,16 +2,6 @@
 # FluentFTP Integration Test Server: filezilla-server
 #
 
-FROM	python:3-slim AS prebuild
-
-SHELL	["/bin/bash", "-c"]
-
-WORKDIR	/usr/src/app
-RUN	pip install --user apt-smart
-
-WORKDIR	/root
-RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
-
 #
 # Stage 1: build
 #
@@ -29,30 +19,11 @@ ARG	FILEZILLA_URL=https://download.filezilla-project.org/server/FileZilla_Server
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
 
-COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
-
-WORKDIR	/
-RUN	mapfile -t lines < /root/deb_mirror && \
-	DEB_MIRROR=${lines[0]} && \
-	echo $DEB_MIRROR && \
-	\
-	printf "\
-	deb $DEB_MIRROR bullseye main\n\
-#	deb-src $DEB_MIRROR bullseye main\n\
-	\n\
-	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
-#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
-	\n\
-	# bullseye-updates, previously known as 'volatile'\n\
-	deb $DEB_MIRROR bullseye-updates main\n\
-#	deb-src $DEB_MIRROR bullseye-updates main\n\
-	" > /etc/apt/sources.list
-
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
 		\
 		$APT_CMD \
-			curl \
 			ca-certificates \
+			curl \
 			bzip2 \
 			binutils \
 			build-essential \

--- a/FluentFTP.Dockers/glftpd/Dockerfile
+++ b/FluentFTP.Dockers/glftpd/Dockerfile
@@ -2,16 +2,6 @@
 # FluentFTP Integration Test Server: glftpd
 #
 
-FROM	python:3-slim AS prebuild
-
-SHELL	["/bin/bash", "-c"]
-
-WORKDIR	/usr/src/app
-RUN	pip install --user apt-smart
-
-WORKDIR	/root
-RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
-
 #
 # Stage 1: build & production
 #
@@ -28,35 +18,15 @@ ARG	OPENSSL_VERSION=3.0.1
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
 
-COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
-
-WORKDIR	/
-RUN	mapfile -t lines < /root/deb_mirror && \
-	DEB_MIRROR=${lines[0]} && \
-	echo $DEB_MIRROR && \
-	\
-	printf "\
-	deb $DEB_MIRROR bullseye main\n\
-#	deb-src $DEB_MIRROR bullseye main\n\
-	\n\
-	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
-#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
-	\n\
-	# bullseye-updates, previously known as 'volatile'\n\
-	deb $DEB_MIRROR bullseye-updates main\n\
-#	deb-src $DEB_MIRROR bullseye-updates main\n\
-	" > /etc/apt/sources.list
-
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
 		\
 		$APT_CMD \
 			ca-certificates \
-			libpsl5 \
-			openssl \
-			publicsuffix \
 			wget \
-			zip unzip \
 			build-essential \
+			libpsl5 \
+			publicsuffix \
+			zip unzip \
 			xinetd \
 			ftp && \
 	\

--- a/FluentFTP.Dockers/proftpd/Dockerfile
+++ b/FluentFTP.Dockers/proftpd/Dockerfile
@@ -2,16 +2,6 @@
 # FluentFTP Integration Test Server: proftpd
 #
 
-FROM	python:3-slim AS prebuild
-
-SHELL	["/bin/bash", "-c"]
-
-WORKDIR	/usr/src/app
-RUN	pip install --user apt-smart
-
-WORKDIR	/root
-RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
-
 #
 # Stage 1: build & production
 #
@@ -24,25 +14,6 @@ SHELL	["/bin/bash", "-c"]
 
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
-
-COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
-
-WORKDIR	/
-RUN	mapfile -t lines < /root/deb_mirror && \
-	DEB_MIRROR=${lines[0]} && \
-	echo $DEB_MIRROR && \
-	\
-	printf "\
-	deb $DEB_MIRROR bullseye main\n\
-#	deb-src $DEB_MIRROR bullseye main\n\
-	\n\
-	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
-#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
-	\n\
-	# bullseye-updates, previously known as 'volatile'\n\
-	deb $DEB_MIRROR bullseye-updates main\n\
-#	deb-src $DEB_MIRROR bullseye-updates main\n\
-	" > /etc/apt/sources.list
 
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
 		\

--- a/FluentFTP.Dockers/pureftpd/Dockerfile
+++ b/FluentFTP.Dockers/pureftpd/Dockerfile
@@ -2,16 +2,6 @@
 # FluentFTP Integration Test Server: pureftpd
 #
 
-FROM	python:3-slim AS prebuild
-
-SHELL	["/bin/bash", "-c"]
-
-WORKDIR	/usr/src/app
-RUN	pip install --user apt-smart
-
-WORKDIR	/root
-RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
-
 #
 # Stage 1: build & production
 #
@@ -24,25 +14,6 @@ SHELL	["/bin/bash", "-c"]
 
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
-
-COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
-
-WORKDIR	/
-RUN	mapfile -t lines < /root/deb_mirror && \
-	DEB_MIRROR=${lines[0]} && \
-	echo $DEB_MIRROR && \
-	\
-	printf "\
-	deb $DEB_MIRROR bullseye main\n\
-#	deb-src $DEB_MIRROR bullseye main\n\
-	\n\
-	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
-#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
-	\n\
-	# bullseye-updates, previously known as 'volatile'\n\
-	deb $DEB_MIRROR bullseye-updates main\n\
-#	deb-src $DEB_MIRROR bullseye-updates main\n\
-	" > /etc/apt/sources.list
 
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \
 		\

--- a/FluentFTP.Dockers/vsftpd/Dockerfile
+++ b/FluentFTP.Dockers/vsftpd/Dockerfile
@@ -2,16 +2,6 @@
 # FluentFTP Integration Test Server: vsftpd
 #
 
-FROM	python:3-slim AS prebuild
-
-SHELL	["/bin/bash", "-c"]
-
-WORKDIR	/usr/src/app
-RUN	pip install --user apt-smart
-
-WORKDIR	/root
-RUN	python3 /root/.local/bin/apt-smart -b > deb_mirror
-
 #
 # Stage 1: build & production
 #
@@ -24,25 +14,6 @@ SHELL	["/bin/bash", "-c"]
 
 ARG	DEBIAN_FRONTEND=noninteractive
 ARG	APT_CMD='apt install -y --no-install-recommends'
-
-COPY	--from=prebuild /root/deb_mirror /root/deb_mirror
-
-WORKDIR	/
-RUN	mapfile -t lines < /root/deb_mirror && \
-	DEB_MIRROR=${lines[0]} && \
-	echo $DEB_MIRROR && \
-	\
-	printf "\
-	deb $DEB_MIRROR bullseye main\n\
-#	deb-src $DEB_MIRROR bullseye main\n\
-	\n\
-	deb http://deb.debian.org/debian-security bullseye-security main contrib\n\
-#	deb-src http://deb.debian.org/debian-security bullseye-security main contrib\n\
-	\n\
-	# bullseye-updates, previously known as 'volatile'\n\
-	deb $DEB_MIRROR bullseye-updates main\n\
-#	deb-src $DEB_MIRROR bullseye-updates main\n\
-	" > /etc/apt/sources.list
 
 WORKDIR	/
 RUN	apt update && apt upgrade -y && apt install -y apt-utils && \


### PR DESCRIPTION
In some locations there are not enough mirrors to allow python smart-apt to generate a sources.list for debian without throwing an error. The author seems unresponsive. Therefore using this very valueable method to make a docker build process run **significantly** faster is not viable.

Here is the step back down to the default debian sources.list and **rather** slow central repo.

Tested and runs.

