### PR TITLE
Cater to #1054

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1087,19 +1087,16 @@ namespace FluentFTP {
 			}
 #else
 			try {
-// fix #1054
-#if v472
 			    using (var timeoutSrc = CancellationTokenSource.CreateLinkedTokenSource(token)) {
 					timeoutSrc.CancelAfter(ctmo);
+// fix #1054
+#if v472
 			        await EnableCancellation(m_socket.ConnectAsync(ipad, port), timeoutSrc.Token, () => DisposeSocket());
-				}
 #else
-				using (var timeoutSrc = CancellationTokenSource.CreateLinkedTokenSource(token)) {
-					timeoutSrc.CancelAfter(ctmo);
 					var connectResult = m_socket.BeginConnect(ipad, port, null, null);
 					await EnableCancellation(Task.Factory.FromAsync(connectResult, m_socket.EndConnect), timeoutSrc.Token, () => DisposeSocket());
-				}
 #endif
+				}
 			}
 			catch (SocketException ex) {
 				if (ex.SocketErrorCode == SocketError.OperationAborted ||


### PR DESCRIPTION
In case a source compile targets NET Framework 4.6.2, as reported in #1054, there is a compile error.

It used to be in the old code, I had removed it when working on the connect timeouts.

Of course, just using the nuget package will work fine, but those of us who need to use the source might like this to be fixed.

Merging this is optional IMO, but perhaps for the sake of completeness one should include this in the code.