### PR TITLE
Prepare for ReConnect PR

### DIFF
--- a/FluentFTP/Client/AsyncClient/Authenticate.cs
+++ b/FluentFTP/Client/AsyncClient/Authenticate.cs
@@ -44,7 +44,7 @@ namespace FluentFTP {
 
 				// fix for #620: some servers send multiple responses that must be read and decoded,
 				// otherwise the connection is aborted and remade and it goes into an infinite loop
-				var staleData = await ReadStaleDataAsync(false, true, "in authentication", token);
+				var staleData = await ReadStaleDataAsync(true, "in authentication", token);
 				if (staleData != null) {
 					var staleReply = new FtpReply();
 					if (DecodeStringToReply(staleData, ref staleReply) && !staleReply.Success) {

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -23,9 +23,9 @@ namespace FluentFTP {
 
 			if (Config.StaleDataCheck && Status.AllowCheckStaleData) {
 #if NETSTANDARD
-				await ReadStaleDataAsync(true, true, "prior to command execution", token);
+				await ReadStaleDataAsync(true, "prior to command execution", token);
 #else
-				ReadStaleData(true, true, "prior to command execution");
+				ReadStaleData(true, "prior to command execution");
 #endif
 			}
 

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -16,7 +16,7 @@ namespace FluentFTP.Client.BaseClient {
 
 			lock (m_lock) {
 				if (Config.StaleDataCheck && Status.AllowCheckStaleData) {
-					ReadStaleData(true, true, "prior to command execution");
+					ReadStaleData(true, "prior to command execution");
 				}
 
 				if (!IsConnected) {

--- a/FluentFTP/Client/BaseClient/ReadStaleData.cs
+++ b/FluentFTP/Client/BaseClient/ReadStaleData.cs
@@ -10,21 +10,18 @@ namespace FluentFTP.Client.BaseClient {
 
 		/// <summary>
 		/// Data shouldn't be on the socket, if it is it probably means we've been disconnected.
-		/// Read and discard whatever is there and optionally close the connection.
+		/// Read and discard whatever is there.
 		/// Returns the stale data as text, if any, or null if none was found.
 		/// </summary>
-		/// <param name="closeStream">close the connection?</param>
 		/// <param name="logData">copy stale data information to logs?</param>
 		/// <param name="logFrom">for the log information</param>
-		protected string ReadStaleData(bool closeStream, bool logData, string logFrom) {
+		protected string ReadStaleData(bool logData, string logFrom) {
 			string staleData = null;
 
 			if (m_stream != null) {
 
-				if (m_stream.SocketDataAvailable > 0) {
-					if (logData) {
-						LogWithPrefix(FtpTraceLevel.Info, "Socket has stale data - " + logFrom);
-					}
+				if (m_stream.SocketDataAvailable > 0 && logData) {
+					LogWithPrefix(FtpTraceLevel.Info, "Control connection has stale data - " + logFrom);
 				}
 
 				while (m_stream.SocketDataAvailable > 0) {
@@ -38,24 +35,14 @@ namespace FluentFTP.Client.BaseClient {
 					staleData += Encoding.GetString(buf).TrimEnd('\0', '\r', '\n') + Environment.NewLine;
 				}
 
-				if (string.IsNullOrEmpty(staleData)) {
-					closeStream = false;
-				}
-				else {
-					if (logData) {
-						LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: ");
-						string[] staleLines = Regex.Split(staleData, Environment.NewLine);
-						foreach (string staleLine in staleLines) {
-							if (!string.IsNullOrWhiteSpace(staleLine)) {
-								Log(FtpTraceLevel.Verbose, "Stale:    " + staleLine);
-							}
+				if (!string.IsNullOrEmpty(staleData) && logData) {
+					LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: ");
+					string[] staleLines = Regex.Split(staleData, Environment.NewLine);
+					foreach (string staleLine in staleLines) {
+						if (!string.IsNullOrWhiteSpace(staleLine)) {
+							Log(FtpTraceLevel.Verbose, "Stale:    " + staleLine);
 						}
 					}
-				}
-
-				if (closeStream) {
-					LogWithPrefix(FtpTraceLevel.Info, "Closing stream because of stale data");
-					m_stream.Close();
 				}
 
 			}
@@ -65,21 +52,18 @@ namespace FluentFTP.Client.BaseClient {
 
 		/// <summary>
 		/// Data shouldn't be on the socket, if it is it probably means we've been disconnected.
-		/// Read and discard whatever is there and optionally close the connection.
+		/// Read and discard whatever is there.
 		/// Returns the stale data as text, if any, or null if none was found.
 		/// </summary>
-		/// <param name="closeStream">close the connection?</param>
 		/// <param name="logData">copy stale data information to logs?</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
-		protected async Task<string> ReadStaleDataAsync(bool closeStream, bool logData, string logFrom, CancellationToken token) {
+		protected async Task<string> ReadStaleDataAsync(bool logData, string logFrom, CancellationToken token) {
 			string staleData = null;
 
 			if (m_stream != null) {
 
-				if (m_stream.SocketDataAvailable > 0) {
-					if (logData) {
-						LogWithPrefix(FtpTraceLevel.Info, "Socket has stale data - " + logFrom);
-					}
+				if (m_stream.SocketDataAvailable > 0 && logData) {
+					LogWithPrefix(FtpTraceLevel.Info, "Socket has stale data - " + logFrom);
 				}
 
 				while (m_stream.SocketDataAvailable > 0) {
@@ -93,24 +77,14 @@ namespace FluentFTP.Client.BaseClient {
 					staleData += Encoding.GetString(buf).TrimEnd('\0', '\r', '\n') + Environment.NewLine;
 				}
 
-				if (string.IsNullOrEmpty(staleData)) {
-					closeStream = false;
-				}
-				else {
-					if (logData) {
-						LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: ");
-						string[] staleLines = Regex.Split(staleData, Environment.NewLine);
-						foreach (string staleLine in staleLines) {
-							if (!string.IsNullOrWhiteSpace(staleLine)) {
-								Log(FtpTraceLevel.Verbose, "Stale:    " + staleLine);
-							}
+				if (!string.IsNullOrEmpty(staleData) && logData) {
+					LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: ");
+					string[] staleLines = Regex.Split(staleData, Environment.NewLine);
+					foreach (string staleLine in staleLines) {
+						if (!string.IsNullOrWhiteSpace(staleLine)) {
+							Log(FtpTraceLevel.Verbose, "Stale:    " + staleLine);
 						}
 					}
-				}
-
-				if (closeStream) {
-					LogWithPrefix(FtpTraceLevel.Info, "Closing stream because of stale data");
-					m_stream.Close();
 				}
 
 			}

--- a/FluentFTP/Client/SyncClient/Authenticate.cs
+++ b/FluentFTP/Client/SyncClient/Authenticate.cs
@@ -45,7 +45,7 @@ namespace FluentFTP {
 
 				// fix for #620: some servers send multiple responses that must be read and decoded,
 				// otherwise the connection is aborted and remade and it goes into an infinite loop
-				var staleData = ReadStaleData(false, true, "in authentication");
+				var staleData = ReadStaleData(true, "in authentication");
 				if (staleData != null) {
 					var staleReply = new FtpReply();
 					if (DecodeStringToReply(staleData, ref staleReply) && !staleReply.Success) {


### PR DESCRIPTION
`ReadStaleData(...)` shouldn't be the one who closes the connection. This decision belongs into `Execute(...)`, which is the only place where the "reconnection" boolean is ever seen as being true.

So, removing this parameter and making this decision in `Execute(...)` (next PR).