### PR TITLE
Prepare for ReConnect PR

### DIFF
--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -476,16 +476,16 @@ namespace FluentFTP.Client.Modules {
 		/// </summary>
 		public static void SetDefaultCertificateValidation(BaseFtpClient client, FtpProfile profile) {
 			if (profile.Encryption != FtpEncryptionMode.None) {
-				//if (client.ValidateCertificate == null) {
-				client.ValidateCertificate += new FtpSslValidation(delegate (BaseFtpClient c, FtpSslValidationEventArgs e) {
-					if (e.PolicyErrors != System.Net.Security.SslPolicyErrors.None) {
-						e.Accept = false;
-					}
-					else {
-						e.Accept = true;
-					}
-				});
-				//}
+				if (client.ValidateCertificateHandlerExists == null) {
+					client.ValidateCertificate += new FtpSslValidation(delegate (BaseFtpClient c, FtpSslValidationEventArgs e) {
+						if (e.PolicyErrors != System.Net.Security.SslPolicyErrors.None) {
+							e.Accept = false;
+						}
+						else {
+							e.Accept = true;
+						}
+					});
+				}
 			}
 		}
 


### PR DESCRIPTION
Absolutely needed for a functioning ReConnect if SSL is to be used. Check for an existing Certificate Handler  was wrong and probably that was why it was commented out.