### PR TITLE
Accept more formats of NOOP messages

### DIFF
--- a/FluentFTP/Client/AsyncClient/GetReply.cs
+++ b/FluentFTP/Client/AsyncClient/GetReply.cs
@@ -142,8 +142,8 @@ namespace FluentFTP {
 				sequence += "," + response.Split(' ')[0];
 
 				if (exhaustNoop &&
-					// NOOP responses can actually come in quite a few flavors
-					(response.StartsWith("200 NOOP") || response.StartsWith("500"))) {
+					((response.StartsWith("200") && (response.IndexOf("NOOP", StringComparison.InvariantCultureIgnoreCase) >= 0)) ||
+					response.StartsWith("500"))) {
 
 					Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
 

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -143,8 +143,8 @@ namespace FluentFTP.Client.BaseClient {
 					sequence += "," + response.Split(' ')[0];
 
 					if (exhaustNoop &&
-						// NOOP responses can actually come in quite a few flavors, so watch out..
-						(response.StartsWith("200 NOOP", StringComparison.InvariantCultureIgnoreCase) || response.StartsWith("500"))) {
+						((response.StartsWith("200") && (response.IndexOf("NOOP", StringComparison.InvariantCultureIgnoreCase) >= 0)) ||
+						response.StartsWith("500"))) {
 
 						Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
 


### PR DESCRIPTION
Example of one that was **not** recognized: `200 Command NOOP okay.` Yet again a new format.

All previous formats were `200 NOOP.......` or `200 Noop.....`.