### PR TITLE
Fix #1059 Early 226 Success Message

### DIFF
--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -12,232 +12,285 @@ using System.Threading.Tasks;
 using FluentFTP.Proxy.SyncProxy;
 using System.Security.Authentication;
 
-namespace FluentFTP {
-	public partial class FtpClient {
+namespace FluentFTP
+{
+    public partial class FtpClient
+    {
 
-		/// <summary>
-		/// Download a file from the server and write the data into the given stream.
-		/// Reads data in chunks. Retries if server disconnects midway.
-		/// </summary>
-		protected bool DownloadFileInternal(string localPath, string remotePath, Stream outStream, long restartPosition,
-			Action<FtpProgress> progress, FtpProgress metaProgress, long knownFileSize, bool isAppend) {
+        /// <summary>
+        /// Download a file from the server and write the data into the given stream.
+        /// Reads data in chunks. Retries if server disconnects midway.
+        /// </summary>
+        protected bool DownloadFileInternal(string localPath, string remotePath, Stream outStream, long restartPosition,
+            Action<FtpProgress> progress, FtpProgress metaProgress, long knownFileSize, bool isAppend)
+        {
 
-			Stream downStream = null;
-			var disposeOutStream = false;
+            Stream downStream = null;
+            var disposeOutStream = false;
 
-			try {
-				// get file size if progress requested
-				long fileLen = 0;
+            try
+            {
+                // get file size if progress requested
+                long fileLen = 0;
 
-				if (progress != null) {
-					fileLen = knownFileSize > 0 ? knownFileSize : GetFileSize(remotePath);
-				}
+                if (progress != null)
+                {
+                    fileLen = knownFileSize > 0 ? knownFileSize : GetFileSize(remotePath);
+                }
 
-				// open the file for reading
-				downStream = OpenRead(remotePath, Config.DownloadDataType, restartPosition, fileLen);
-				// workaround for SOCKS4 and SOCKS4a proxies
-				if (restartPosition == 0) {
-					if (this is FtpClientSocks4Proxy || this is FtpClientSocks4aProxy) {
-						// first 6 bytes contains 2 bytes of unknown (to me) purpose and 4 ip address bytes
-						// we need to skip them otherwise they will be downloaded to the file
-						// moreover, these bytes cause "Failed to get the EPSV port" error
-						downStream.Read(new byte[6], 0, 6);
-					}
-				}
+                // open the file for reading
+                downStream = OpenRead(remotePath, Config.DownloadDataType, restartPosition, fileLen);
+                // workaround for SOCKS4 and SOCKS4a proxies
+                if (restartPosition == 0)
+                {
+                    if (this is FtpClientSocks4Proxy || this is FtpClientSocks4aProxy)
+                    {
+                        // first 6 bytes contains 2 bytes of unknown (to me) purpose and 4 ip address bytes
+                        // we need to skip them otherwise they will be downloaded to the file
+                        // moreover, these bytes cause "Failed to get the EPSV port" error
+                        downStream.Read(new byte[6], 0, 6);
+                    }
+                }
 
-				// if the server has not provided a length for this file or
-				// if the mode is ASCII or
-				// if the server is IBM z/OS
-				// we read until EOF instead of reading a specific number of bytes
-				var readToEnd = (fileLen <= 0) ||
-								(Config.DownloadDataType == FtpDataType.ASCII) ||
-								(ServerHandler != null && ServerHandler.AlwaysReadToEnd(remotePath));
+                // if the server has not provided a length for this file or
+                // if the mode is ASCII or
+                // if the server is IBM z/OS
+                // we read until EOF instead of reading a specific number of bytes
+                var readToEnd = (fileLen <= 0) ||
+                                (Config.DownloadDataType == FtpDataType.ASCII) ||
+                                (ServerHandler != null && ServerHandler.AlwaysReadToEnd(remotePath));
 
-				const int rateControlResolution = 100;
-				var rateLimitBytes = Config.DownloadRateLimit != 0 ? (long)Config.DownloadRateLimit * 1024 : 0;
-				var chunkSize = CalculateTransferChunkSize(rateLimitBytes, rateControlResolution);
+                const int rateControlResolution = 100;
+                var rateLimitBytes = Config.DownloadRateLimit != 0 ? (long)Config.DownloadRateLimit * 1024 : 0;
+                var chunkSize = CalculateTransferChunkSize(rateLimitBytes, rateControlResolution);
 
-				// loop till entire file downloaded
-				var buffer = new byte[chunkSize];
-				var offset = restartPosition;
+                // loop till entire file downloaded
+                var buffer = new byte[chunkSize];
+                var offset = restartPosition;
 
-				var transferStarted = DateTime.Now;
-				var sw = new Stopwatch();
+                var transferStarted = DateTime.Now;
+                var sw = new Stopwatch();
 
-				var anyNoop = false;
+                var anyNoop = false;
+                var earlySuccess = false;
 
-				// Fix #554: ability to download zero-byte files
-				if (Config.DownloadZeroByteFiles && outStream == null && localPath != null) {
-					outStream = FtpFileStream.GetFileWriteStream(this, localPath, false, 0, knownFileSize, isAppend, restartPosition);
-					disposeOutStream = true;
-				}
+                // Fix #554: ability to download zero-byte files
+                if (Config.DownloadZeroByteFiles && outStream == null && localPath != null)
+                {
+                    outStream = FtpFileStream.GetFileWriteStream(this, localPath, false, 0, knownFileSize, isAppend, restartPosition);
+                    disposeOutStream = true;
+                }
 
-				while (offset < fileLen || readToEnd) {
-					try {
-						// read a chunk of bytes from the FTP stream
-						var readBytes = 1;
-						long limitCheckBytes = 0;
-						long bytesProcessed = 0;
+                while (offset < fileLen || readToEnd)
+                {
+                    try
+                    {
+                        // read a chunk of bytes from the FTP stream
+                        var readBytes = 1;
+                        long limitCheckBytes = 0;
+                        long bytesProcessed = 0;
 
-						sw.Start();
-						while ((readBytes = downStream.Read(buffer, 0, buffer.Length)) > 0) {
+                        sw.Start();
+                        while ((readBytes = downStream.Read(buffer, 0, buffer.Length)) > 0)
+                        {
 
-							// Fix #552: only create outstream when first bytes downloaded
-							if (outStream == null && localPath != null) {
-								outStream = FtpFileStream.GetFileWriteStream(this, localPath, false, 0, knownFileSize, isAppend, restartPosition);
-								disposeOutStream = true;
-							}
+                            // Fix #552: only create outstream when first bytes downloaded
+                            if (outStream == null && localPath != null)
+                            {
+                                outStream = FtpFileStream.GetFileWriteStream(this, localPath, false, 0, knownFileSize, isAppend, restartPosition);
+                                disposeOutStream = true;
+                            }
 
-							// write chunk to output stream
-							outStream.Write(buffer, 0, readBytes);
-							offset += readBytes;
-							bytesProcessed += readBytes;
-							limitCheckBytes += readBytes;
+                            // write chunk to output stream
+                            outStream.Write(buffer, 0, readBytes);
+                            offset += readBytes;
+                            bytesProcessed += readBytes;
+                            limitCheckBytes += readBytes;
 
-							// send progress reports
-							if (progress != null) {
-								ReportProgress(progress, fileLen, offset, bytesProcessed, DateTime.Now - transferStarted, localPath, remotePath, metaProgress);
-							}
+                            // send progress reports
+                            if (progress != null)
+                            {
+                                ReportProgress(progress, fileLen, offset, bytesProcessed, DateTime.Now - transferStarted, localPath, remotePath, metaProgress);
+                            }
 
-							// Fix #387: keep alive with NOOP as configured and needed
-							anyNoop = Noop() || anyNoop;
+                            // Fix #387: keep alive with NOOP as configured and needed
+                            anyNoop = Noop() || anyNoop;
 
-							// honor the rate limit
-							var swTime = sw.ElapsedMilliseconds;
-							if (rateLimitBytes > 0) {
-								var timeShouldTake = limitCheckBytes * 1000 / rateLimitBytes;
-								if (timeShouldTake > swTime) {
-									Thread.Sleep((int)(timeShouldTake - swTime));
-								}
-								else if (swTime > timeShouldTake + rateControlResolution) {
-									limitCheckBytes = 0;
-									sw.Restart();
-								}
-							}
-						}
+                            // honor the rate limit
+                            var swTime = sw.ElapsedMilliseconds;
+                            if (rateLimitBytes > 0)
+                            {
+                                var timeShouldTake = limitCheckBytes * 1000 / rateLimitBytes;
+                                if (timeShouldTake > swTime)
+                                {
+                                    Thread.Sleep((int)(timeShouldTake - swTime));
+                                }
+                                else if (swTime > timeShouldTake + rateControlResolution)
+                                {
+                                    limitCheckBytes = 0;
+                                    sw.Restart();
+                                }
+                            }
+                        }
 
-						// if we reach here means EOF encountered
-						// stop if we are in "read until EOF" mode
-						if (offset == fileLen || readToEnd) {
-							break;
-						}
+                        // if we reach here means EOF encountered
+                        // stop if we are in "read until EOF" mode
+                        if (offset == fileLen || readToEnd)
+                        {
+                            break;
+                        }
 
-						// zero return value (with no Exception) indicates EOS; so we should fail here and attempt to resume
-						throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
-					}
-					catch (IOException ex) {
+                        // zero return value (with no Exception) indicates EOS; so we should fail here and attempt to resume
+                        throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
+                    }
+                    catch (IOException ex)
+                    {
+                        LogWithPrefix(FtpTraceLevel.Verbose, "IOException: " + ex.Message);
 
-						// resume if server disconnected midway, or throw if there is an exception doing that as well
-						if (!ResumeDownload(remotePath, ref downStream, offset, ex)) {
-							sw.Stop();
-							throw;
-						}
-					}
-					catch (TimeoutException ex) {
+                        FtpReply exStatus = GetReplyInternal("*IOException*", anyNoop, 10);
+                        if (exStatus.Code == "226")
+                        {
+                            sw.Stop();
+                            earlySuccess = true;
+                            break;
+                        }
 
-						// fix: attempting to download data after we reached the end of the stream
-						// often throws a timeout exception, so we silently absorb that here
-						if (offset >= fileLen && !readToEnd) {
-							break;
-						}
-						else {
-							sw.Stop();
-							throw;
-						}
-					}
-				}
+                        // resume if server disconnected midway, or throw if there is an exception doing that as well
+                        if (!ResumeDownload(remotePath, ref downStream, offset, ex))
+                        {
+                            sw.Stop();
+                            throw;
+                        }
+                    }
+                    catch (TimeoutException ex)
+                    {
 
-				LogWithPrefix(FtpTraceLevel.Verbose, "Downloaded " + offset + " bytes");
+                        // fix: attempting to download data after we reached the end of the stream
+                        // often throws a timeout exception, so we silently absorb that here
+                        if (offset >= fileLen && !readToEnd)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            sw.Stop();
+                            throw;
+                        }
+                    }
+                }
 
-				sw.Stop();
+                LogWithPrefix(FtpTraceLevel.Verbose, "Downloaded " + offset + " bytes");
 
-				// disconnect FTP stream before exiting
-				outStream?.Flush();
-				downStream.Dispose();
+                sw.Stop();
 
-				// Fix #552: close the filestream if it was created in this method
-				if (disposeOutStream) {
-					outStream?.Dispose();
-					disposeOutStream = false;
-				}
+                // disconnect FTP stream before exiting
+                outStream?.Flush();
+                downStream.Dispose();
 
-				// send progress reports
-				progress?.Invoke(new FtpProgress(100.0, offset, 0, TimeSpan.Zero, localPath, remotePath, metaProgress));
+                // Fix #552: close the filestream if it was created in this method
+                if (disposeOutStream)
+                {
+                    outStream?.Dispose();
+                    disposeOutStream = false;
+                }
 
-				// listen for a success/failure reply or out of band data (like NOOP responses)
-				// GetReply(true) means: Exhaust any NOOP responses
-				FtpReply status = GetReplyInternal("*DOWNLOAD*", anyNoop);
+                // send progress reports
+                progress?.Invoke(new FtpProgress(100.0, offset, 0, TimeSpan.Zero, localPath, remotePath, metaProgress));
 
-				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
-				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
-				if (status.Code != null && !status.Success) {
-					return false;
-				}
+                if (earlySuccess)
+                {
+                    return true;
+                }
 
-				return true;
-			}
-			catch (AuthenticationException ex) {
-				FtpReply reply = GetReplyInternal("*DOWNLOAD*", false, -1); // no exhaustNoop, but non-blocking
-				if (!reply.Success) {
-					throw new FtpCommandException(reply);
-				}
-				throw;
-			}
-			catch (Exception ex1) {
+                // listen for a success/failure reply or out of band data (like NOOP responses)
+                // GetReply(true) means: Exhaust any NOOP responses
+                FtpReply status = GetReplyInternal("*DOWNLOAD*", anyNoop);
 
-				// close stream before throwing error
-				try {
-					downStream?.Dispose();
-				}
-				catch (Exception) {
-				}
+                // Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
+                // Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
+                if (status.Code != null && !status.Success)
+                {
+                    return false;
+                }
 
-				// Fix #552: close the filestream if it was created in this method
-				if (disposeOutStream) {
-					try {
-						outStream?.Dispose();
-						disposeOutStream = false;
-					}
-					catch (Exception) {
-					}
-				}
+                return true;
+            }
+            catch (AuthenticationException ex)
+            {
+                FtpReply reply = GetReplyInternal("*DOWNLOAD*", false, -1); // no exhaustNoop, but non-blocking
+                if (!reply.Success)
+                {
+                    throw new FtpCommandException(reply);
+                }
+                throw;
+            }
+            catch (Exception ex1)
+            {
 
-				if (ex1 is IOException) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
-					return false;
-				}
+                // close stream before throwing error
+                try
+                {
+                    downStream?.Dispose();
+                }
+                catch (Exception)
+                {
+                }
 
-				// absorb "file does not exist" exceptions and simply return false
-				if (ex1.Message.IsKnownError(ServerStringModule.fileNotFound)) {
-					LogWithPrefix(FtpTraceLevel.Error, "File does not exist: " + ex1.Message);
-					return false;
-				}
+                // Fix #552: close the filestream if it was created in this method
+                if (disposeOutStream)
+                {
+                    try
+                    {
+                        outStream?.Dispose();
+                        disposeOutStream = false;
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
 
-				// catch errors during download
-				throw new FtpException("Error while downloading the file from the server. See InnerException for more info.", ex1);
-			}
-		}
+                if (ex1 is IOException)
+                {
+                    LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
+                    return false;
+                }
 
-		protected bool ResumeDownload(string remotePath, ref Stream downStream, long offset, IOException ex) {
-			try {
-				// if resume possible
-				if (ex.IsResumeAllowed()) {
-					// dispose the old bugged out stream
-					downStream.Dispose();
-					LogWithPrefix(FtpTraceLevel.Info, "Attempting download resume from offset " + offset);
+                // absorb "file does not exist" exceptions and simply return false
+                if (ex1.Message.IsKnownError(ServerStringModule.fileNotFound))
+                {
+                    LogWithPrefix(FtpTraceLevel.Error, "File does not exist: " + ex1.Message);
+                    return false;
+                }
 
-					// create and return a new stream starting at the current remotePosition
-					downStream = OpenRead(remotePath, Config.DownloadDataType, offset);
+                // catch errors during download
+                throw new FtpException("Error while downloading the file from the server. See InnerException for more info.", ex1);
+            }
+        }
 
-					// resume not allowed
-					return true;
-				}
-			}
-			catch (Exception resumeEx) {
-				throw new AggregateException("Additional error occured while trying to resume downloading the file '" + remotePath + "' from offset " + offset, new Exception[] { ex, resumeEx });
-			}
+        protected bool ResumeDownload(string remotePath, ref Stream downStream, long offset, IOException ex)
+        {
+            try
+            {
+                // if resume possible
+                if (ex.IsResumeAllowed())
+                {
+                    // dispose the old bugged out stream
+                    downStream.Dispose();
+                    LogWithPrefix(FtpTraceLevel.Info, "Attempting download resume from offset " + offset);
 
-			return false;
-		}
-	}
+                    // create and return a new stream starting at the current remotePosition
+                    downStream = OpenRead(remotePath, Config.DownloadDataType, offset);
+
+                    // resume not allowed
+                    return true;
+                }
+            }
+            catch (Exception resumeEx)
+            {
+                throw new AggregateException("Additional error occured while trying to resume downloading the file '" + remotePath + "' from offset " + offset, new Exception[] { ex, resumeEx });
+            }
+
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
In case an unexpectedly early `226 Transfer complete` message appears, finish the transfer instead of later on going into an endless wait for a response.