### PR TITLE
Catch control connection loss and retry once

### DIFF
--- a/FluentFTP/Client/AsyncClient/GetListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetListing.cs
@@ -361,7 +361,19 @@ namespace FluentFTP {
 				}
 			}
 			catch (IOException ioEx) {
-				// Some FTP servers forcibly close the connection, we absorb these errors
+				// Some FTP servers forcibly close the connection, we absorb these errors,
+				// unless we have lost the control connection itself
+				if (m_stream.IsConnected == false) {
+					if (retry) {
+						// retry once more, but do not go into a infinite recursion loop here
+						// note: this will cause an automatic reconnect in Execute(...)
+						Log(FtpTraceLevel.Verbose, "Warning:  Retry GetListing once more due to control connection disconnect");
+						return await GetListingInternal(listcmd, options, false, token);
+					}
+					else {
+						throw;
+					}
+				}
 
 				// Fix #410: Retry if its a temporary failure ("Received an unexpected EOF or 0 bytes from the transport stream")
 				if (retry && ioEx.Message.ContainsAnyCI(ServerStringModule.unexpectedEOF)) {


### PR DESCRIPTION
This should hopefully fix #1080.

An alternative would be to catch the failure of the EPRT, PORT, PASV etc. failure, i.e. `OpenActiveDataStream`s or `OpenPassiveDataStream`s failure to open such a stream.