### PR TITLE
Fix #1082 (Re)Connect goes to nirvana

### DIFF
--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -61,7 +61,7 @@ namespace FluentFTP {
 					m_stream.Close();
 					m_stream = null;
 
-					((IInternalFtpClient)this).ConnectInternal(true);
+					await Connect(true, token);
 				}
 			}
 


### PR DESCRIPTION
Simple fix. The AsyncFtpClient still does not redirect calls.

```
		void IInternalFtpClient.DisconnectInternal() {
			// TODO: Call DisconnectAsync
		}

		void IInternalFtpClient.ConnectInternal() {
			// TODO: Call ConnectAsync
		}

		void IInternalFtpClient.ConnectInternal(bool reConnect) {
			// TODO: Call ConnectAsync
		}
```
This is still a todo item since V40 refactor, so this fix to workaround for now.