### PR TITLE
Fix the Connect/Disconnect InternalClient calls

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -59,7 +59,7 @@ namespace FluentFTP {
 			}
 			else {
 				if (IsConnected) {
-					((IInternalFtpClient)this).DisconnectInternal();
+					((IInternalFtpClient)this).DisconnectInternal(token);
 				}
 			}
 

--- a/FluentFTP/Client/AsyncFtpClient.cs
+++ b/FluentFTP/Client/AsyncFtpClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Threading;
 using FluentFTP.Client.BaseClient;
 using Microsoft.Extensions.Logging;
 
@@ -92,19 +93,15 @@ namespace FluentFTP {
 
 		#region Destructor
 
-		void IInternalFtpClient.DisconnectInternal() {
-			// TODO: Call DisconnectAsync
-		}
-
-		void IInternalFtpClient.ConnectInternal() {
-			// TODO: Call ConnectAsync
-		}
-
-		void IInternalFtpClient.ConnectInternal(bool reConnect) {
-			// TODO: Call ConnectAsync
-		}
-
 		#endregion
+
+		void IInternalFtpClient.DisconnectInternal(CancellationToken token) {
+			Disconnect(token).GetAwaiter().GetResult();
+		}
+
+		void IInternalFtpClient.ConnectInternal(bool reConnect, CancellationToken token) {
+			Connect(reConnect, token).GetAwaiter().GetResult();
+		}
 
 	}
 }

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FluentFTP.Client.BaseClient {
@@ -148,16 +149,6 @@ namespace FluentFTP.Client.BaseClient {
 			}
 		}
 
-		void IInternalFtpClient.DisconnectInternal() {
-		}
-
-		void IInternalFtpClient.ConnectInternal() {
-		}
-
-        void IInternalFtpClient.ConnectInternal(bool reConnect)
-        {
-        }
-
 		/// <summary>
 		/// Finalizer
 		/// </summary>
@@ -166,6 +157,16 @@ namespace FluentFTP.Client.BaseClient {
 		}
 
 		#endregion
+
+		void IInternalFtpClient.DisconnectInternal() {
+		}
+		void IInternalFtpClient.DisconnectInternal(CancellationToken token) {
+		}
+
+		void IInternalFtpClient.ConnectInternal(bool reConnect) {
+        }
+		void IInternalFtpClient.ConnectInternal(bool reConnect, CancellationToken token) {
+		}
 
 
 

--- a/FluentFTP/Client/FtpClient.cs
+++ b/FluentFTP/Client/FtpClient.cs
@@ -92,19 +92,15 @@ namespace FluentFTP {
 
 		#region Destructor
 
+		#endregion
+
 		void IInternalFtpClient.DisconnectInternal() {
 			Disconnect();
-		}
-
-		void IInternalFtpClient.ConnectInternal() {
-			Connect(false);
 		}
 
 		void IInternalFtpClient.ConnectInternal(bool reConnect) {
 			Connect(reConnect);
 		}
-
-		#endregion
 
 	}
 }

--- a/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
@@ -26,15 +26,14 @@ namespace FluentFTP {
 		bool HasFeature(FtpCapability cap);
 		void DisableUTF8();
 
-		Task<FtpReply> Execute(string command, CancellationToken token = default(CancellationToken));
-		Task<FtpReply> GetReply(CancellationToken token = default(CancellationToken));
+		Task<FtpProfile> AutoConnect(CancellationToken token = default(CancellationToken));
+		Task<List<FtpProfile>> AutoDetect(bool firstOnly = true, bool cloneConnection = true, CancellationToken token = default(CancellationToken));
 		Task Connect(CancellationToken token = default(CancellationToken));
 		Task Connect(FtpProfile profile, CancellationToken token = default(CancellationToken));
         Task Connect(bool reConnect, CancellationToken token = default(CancellationToken));
-		Task<List<FtpProfile>> AutoDetect(bool firstOnly = true, bool cloneConnection = true, CancellationToken token = default(CancellationToken));
-		Task<FtpProfile> AutoConnect(CancellationToken token = default(CancellationToken));
-
 		Task Disconnect(CancellationToken token = default(CancellationToken));
+		Task<FtpReply> Execute(string command, CancellationToken token = default(CancellationToken));
+		Task<FtpReply> GetReply(CancellationToken token = default(CancellationToken));
 
 
 

--- a/FluentFTP/Client/Interfaces/IFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IFtpClient.cs
@@ -26,14 +26,14 @@ namespace FluentFTP {
 		bool HasFeature(FtpCapability cap);
 		void DisableUTF8();
 
-		FtpReply Execute(string command);
-		FtpReply GetReply();
+		List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true);
+		FtpProfile AutoConnect();
 		void Connect();
 		void Connect(FtpProfile profile);
         void Connect(bool reConnect);
-		List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true);
-		FtpProfile AutoConnect();
 		void Disconnect();
+		FtpReply Execute(string command);
+		FtpReply GetReply();
 
 
 		// MANAGEMENT

--- a/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FluentFTP {
@@ -13,9 +14,10 @@ namespace FluentFTP {
 		FtpReply ExecuteInternal(string command);
 
 		void DisconnectInternal();
+		void DisconnectInternal(CancellationToken token);
 
-		void ConnectInternal();
-        void ConnectInternal(bool reConnect);
+		void ConnectInternal(bool reConnect);
+		void ConnectInternal(bool reConnect, CancellationToken token);
 
 		FtpReply CloseDataStreamInternal(FtpDataStream stream);
 


### PR DESCRIPTION
This will make the interface implementations for ConnectInternal and DisconnectInternal complete for Async.

Any internal client calls to Connect and Disconnect will need these. They were missing for Async.

ConnectInternal can only be used in the `Connect....(bool reConnect.....)` mode. There is no need for a `Connect()` underload.