### PR TITLE
Boolean! Compare to false and not to null.

### DIFF
--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -476,17 +476,15 @@ namespace FluentFTP.Client.Modules {
 		/// Create a default ValidateCertificate handler that accepts valid certificates.
 		/// </summary>
 		public static void SetDefaultCertificateValidation(BaseFtpClient client, FtpProfile profile) {
-			if (profile.Encryption != FtpEncryptionMode.None) {
-				if (client.ValidateCertificateHandlerExists == null) {
-					client.ValidateCertificate += new FtpSslValidation(delegate (BaseFtpClient c, FtpSslValidationEventArgs e) {
-						if (e.PolicyErrors != System.Net.Security.SslPolicyErrors.None) {
-							e.Accept = false;
-						}
-						else {
-							e.Accept = true;
-						}
-					});
-				}
+			if (profile.Encryption != FtpEncryptionMode.None && client.ValidateCertificateHandlerExists == false) {
+				client.ValidateCertificate += new FtpSslValidation(delegate (BaseFtpClient c, FtpSslValidationEventArgs e) {
+					if (e.PolicyErrors != System.Net.Security.SslPolicyErrors.None) {
+						e.Accept = false;
+					}
+					else {
+						e.Accept = true;
+					}
+				});
 			}
 		}
 


### PR DESCRIPTION
`client.ValidateCertificateHandlerExists == null` is a typo. Boolean == null is always false.

Merge with outer if statement and correct the typo:

`profile.Encryption != FtpEncryptionMode.None && client.ValidateCertificateHandlerExists == false`

Much better.