### PR TITLE
Handle edge case and save bandwidth on automatice/forced reconnect

### DIFF
--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -41,6 +41,11 @@ namespace FluentFTP {
 			else if (m_stream.IsEncrypted && Config.SslSessionLength > 0 && !Status.InCriticalSequence && m_stream.SocketReadLineCount > Config.SslSessionLength) {
 				LogWithPrefix(FtpTraceLevel.Info, "Reconnect due to SslSessionLength reached");
 
+				if (Status.LastWorkingDir == null) {
+					Status.InCriticalSequence = true;
+					await GetWorkingDirectory();
+				}
+
 				m_stream.Close();
 				m_stream = null;
 

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -36,7 +36,7 @@ namespace FluentFTP.Client.BaseClient {
 					LogWithPrefix(FtpTraceLevel.Info, "Reconnect due to SslSessionLength reached");
 
 					if (Status.LastWorkingDir == null) {
-						m_stream.SocketReadLineCount = 0;
+						Status.InCriticalSequence = true;
 						((IInternalFtpClient)this).GetWorkingDirectoryInternal();
 					}
 

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -35,6 +35,11 @@ namespace FluentFTP.Client.BaseClient {
 				else if (m_stream.IsEncrypted && Config.SslSessionLength > 0 && !Status.InCriticalSequence && m_stream.SocketReadLineCount > Config.SslSessionLength) {
 					LogWithPrefix(FtpTraceLevel.Info, "Reconnect due to SslSessionLength reached");
 
+					if (Status.LastWorkingDir == null) {
+						m_stream.SocketReadLineCount = 0;
+						((IInternalFtpClient)this).GetWorkingDirectoryInternal();
+					}
+
 					m_stream.Close();
 					m_stream = null;
 

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -131,7 +131,7 @@ namespace FluentFTP {
 				// so save some bandwidth and CPU time and skip executing this again.
 				// otherwise clear the capabilities in case connection is reused to 
 				// a different server 
-				if (!m_isClone && Config.CheckCapabilities) {
+				if (!reConnect && !m_isClone && Config.CheckCapabilities) {
 					m_capabilities.Clear();
 				}
 				bool assumeCaps = false;


### PR DESCRIPTION
No need to issue a new `FEAT` command on reconnect. Save some bandwidth, just like with clone.

If the CWD is null for some reason (for example, if just previously, there was a CWD command), there would be no CWD to return to on reconnect, which is erroneous.

So, in such a case the CWD is retrieved by issuing one last command: A PWD via `GetWorkingDirectory/Internal`. To avoid an infinite recursive loop, the reconnect criteria are reset before doing this.