### PR TITLE
Check for async proxy

### DIFF
--- a/FluentFTP/Client/AsyncClient/GetListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetListing.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using FluentFTP.Client.Modules;
 using System.Security.Authentication;
-using FluentFTP.Proxy.SyncProxy;
+using FluentFTP.Proxy.AsyncProxy;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
@@ -304,7 +304,7 @@ namespace FluentFTP {
 					try {
 						using (FtpDataStream stream = await OpenDataStreamAsync(listcmd, 0, token)) {
 							try {
-								if (this is FtpClientSocks4Proxy || this is FtpClientSocks4aProxy) {
+								if (this is AsyncFtpClientSocks4Proxy || this is AsyncFtpClientSocks4aProxy) {
 									// first 6 bytes contains 2 bytes of unknown (to me) purpose and 4 ip address bytes
 									// we need to skip them otherwise they will be downloaded to the file
 									// moreover, these bytes cause "Failed to get the EPSV port" error

--- a/FluentFTP/Client/BaseClient/IsProxy.cs
+++ b/FluentFTP/Client/BaseClient/IsProxy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using FluentFTP.Proxy.AsyncProxy;
 using FluentFTP.Proxy.SyncProxy;
 
 namespace FluentFTP.Client.BaseClient {
@@ -8,7 +9,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// Checks if this FTP/FTPS connection is made through a proxy.
 		/// </summary>
 		public bool IsProxy() {
-			return this is FtpClientProxy;
+			return this is FtpClientProxy or AsyncFtpClientProxy;
 		}
 
 	}


### PR DESCRIPTION
Visual Studio warned that `AsyncFtpClient` could never be of type `FtpClientSocks4Proxy` or `FtpClientSocks4aProxy`.

I have not tested this is any way.