### PR TITLE
Logging exceptions

### DIFF
--- a/FluentFTP/Client/AsyncClient/Disconnect.cs
+++ b/FluentFTP/Client/AsyncClient/Disconnect.cs
@@ -17,7 +17,7 @@ namespace FluentFTP {
 					}
 				}
 				catch (Exception ex) {
-					LogWithPrefix(FtpTraceLevel.Warn, "AsyncFtpClient.Disconnect(): Exception caught and discarded while closing control connection: " + ex.ToString());
+					LogWithPrefix(FtpTraceLevel.Warn, "AsyncFtpClient.Disconnect(): Exception caught and discarded while closing control connection", ex);
 				}
 				finally {
 					m_stream.Close();

--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -128,7 +128,7 @@ namespace FluentFTP {
 						throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
 					}
 					catch (IOException ex) {
-						LogWithPrefix(FtpTraceLevel.Verbose, "IOException: " + ex.Message);
+						LogWithPrefix(FtpTraceLevel.Verbose, "IOException", ex);
 
 						FtpReply exStatus = await GetReplyAsyncInternal(token, "*IOException*", anyNoop, 10);
 						if (exStatus.Code == "226") {
@@ -222,7 +222,7 @@ namespace FluentFTP {
 				}
 
 				if (ex1 is IOException) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
+					LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath, ex1);
 					return false;
 				}
 
@@ -233,7 +233,7 @@ namespace FluentFTP {
 
 				// absorb "file does not exist" exceptions and simply return false
 				if (ex1.Message.ContainsAnyCI(ServerStringModule.fileNotFound)) {
-					LogWithPrefix(FtpTraceLevel.Error, "File does not exist: " + ex1.Message);
+					LogWithPrefix(FtpTraceLevel.Error, "File does not exist", ex1);
 					return false;
 				}
 

--- a/FluentFTP/Client/AsyncClient/DownloadFiles.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFiles.cs
@@ -130,7 +130,7 @@ namespace FluentFTP {
 					File.Delete(localFile);
 				}
 				catch (Exception ex) {
-					LogWithPrefix(FtpTraceLevel.Warn, "AsyncFtpClient : Exception caught and discarded while attempting to delete file '" + localFile + "' : " + ex.ToString());
+					LogWithPrefix(FtpTraceLevel.Warn, "AsyncFtpClient : Exception caught and discarded while attempting to delete file '" + localFile + "'", ex);
 				}
 			}
 		}

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -279,7 +279,7 @@ namespace FluentFTP {
 				}
 
 				if (ex1 is IOException) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
+					LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath, ex1);
 					return FtpStatus.Failed;
 				}
 

--- a/FluentFTP/Client/AsyncClient/UploadFiles.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFiles.cs
@@ -110,7 +110,7 @@ namespace FluentFTP {
 					}
 
 					//suppress all other upload exceptions (errors are still written to FtpTrace)
-					LogWithPrefix(FtpTraceLevel.Error, "Upload Failure for " + localPath + ": " + ex);
+					LogWithPrefix(FtpTraceLevel.Error, "Upload Failure for " + localPath, ex);
 					if (errorHandling.HasFlag(FtpError.Stop)) {
 						errorEncountered = true;
 						break;

--- a/FluentFTP/Client/AsyncClient/VerifyTransfer.cs
+++ b/FluentFTP/Client/AsyncClient/VerifyTransfer.cs
@@ -39,7 +39,7 @@ namespace FluentFTP {
 				return true;
 			}
 			catch (IOException ex) {
-				LogWithPrefix(FtpTraceLevel.Warn, "Failed to verify file " + localPath + " : " + ex.Message);
+				LogWithPrefix(FtpTraceLevel.Warn, "Failed to verify file " + localPath, ex);
 				return false;
 			}
 		}

--- a/FluentFTP/Client/BaseClient/Logger.cs
+++ b/FluentFTP/Client/BaseClient/Logger.cs
@@ -47,9 +47,7 @@ namespace FluentFTP.Client.BaseClient {
 		protected void Log(FtpTraceLevel eventType, string message) {
 
 			// log to modern logger if given
-			if (m_logger != null) {
-				m_logger.Log(eventType, message);
-			}
+			m_logger?.Log(eventType, message);
 
 			// log to legacy logger if given
 			m_legacyLogger?.Invoke(eventType, message);
@@ -63,12 +61,13 @@ namespace FluentFTP.Client.BaseClient {
 		/// </summary>
 		/// <param name="eventType">The type of tracing event</param>
 		/// <param name="message">The message to write</param>
-		protected void LogWithPrefix(FtpTraceLevel eventType, string message) {
-
+		/// <param name="exception">An optional exeption</param>
+		protected void LogWithPrefix(FtpTraceLevel eventType, string message, Exception exception = null) {
 			// log to attached logger if given
-			if (m_logger != null) {
-				m_logger.Log(eventType, message);
-			}
+			m_logger?.Log(eventType, message, exception);
+
+			var exceptionMessage = exception is not null ? " : " + exception.ToString() : null;
+			var fullMessage = GetLogPrefix(eventType) + message + exceptionMessage;
 
 			var fullMessage = eventType.GetLogPrefix() + message;
 
@@ -101,8 +100,8 @@ namespace FluentFTP.Client.BaseClient {
 		/// <summary>
 		/// To allow for external connected classes to use the attached logger.
 		/// </summary>
-		void IInternalFtpClient.LogStatus(FtpTraceLevel eventType, string message) {
-			this.LogWithPrefix(eventType, message);
+		void IInternalFtpClient.LogStatus(FtpTraceLevel eventType, string message, Exception exception) {
+			this.LogWithPrefix(eventType, message, exception);
 		}
 
 	}

--- a/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
@@ -21,7 +21,7 @@ namespace FluentFTP {
 
 		FtpReply CloseDataStreamInternal(FtpDataStream stream);
 
-		void LogStatus(FtpTraceLevel eventType, string message);
+		void LogStatus(FtpTraceLevel eventType, string message, Exception exception = null);
 
 		void LogLine(FtpTraceLevel eventType, string message);
 

--- a/FluentFTP/Client/SyncClient/Disconnect.cs
+++ b/FluentFTP/Client/SyncClient/Disconnect.cs
@@ -18,7 +18,7 @@ namespace FluentFTP {
 						}
 					}
 					catch (Exception ex) {
-						LogWithPrefix(FtpTraceLevel.Warn, "FtpClient.Disconnect(): Exception caught and discarded while closing control connection: " + ex.ToString());
+						LogWithPrefix(FtpTraceLevel.Warn, "FtpClient.Disconnect(): Exception caught and discarded while closing control connection", ex);
 					}
 					finally {
 						m_stream.Close();

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -127,7 +127,7 @@ namespace FluentFTP {
 						throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
 					}
 					catch (IOException ex) {
-						LogWithPrefix(FtpTraceLevel.Verbose, "IOException: " + ex.Message);
+						LogWithPrefix(FtpTraceLevel.Verbose, "IOException", ex);
 
 						FtpReply exStatus = GetReplyInternal("*IOException*", anyNoop, 10);
 						if (exStatus.Code == "226") {
@@ -216,13 +216,13 @@ namespace FluentFTP {
 				}
 
 				if (ex1 is IOException) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
+					LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath, ex1);
 					return false;
 				}
 
 				// absorb "file does not exist" exceptions and simply return false
 				if (ex1.Message.ContainsAnyCI(ServerStringModule.fileNotFound)) {
-					LogWithPrefix(FtpTraceLevel.Error, "File does not exist: " + ex1.Message);
+					LogWithPrefix(FtpTraceLevel.Error, "File does not exist", ex1);
 					return false;
 				}
 

--- a/FluentFTP/Client/SyncClient/DownloadFiles.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFiles.cs
@@ -76,7 +76,7 @@ namespace FluentFTP {
 					}
 				}
 				catch (Exception ex) {
-					LogWithPrefix(FtpTraceLevel.Error, "Failed to download " + remotePath + ". Error: " + ex);
+					LogWithPrefix(FtpTraceLevel.Error, "Failed to download " + remotePath, ex);
 					if (errorHandling.HasFlag(FtpError.Stop)) {
 						errorEncountered = true;
 						break;
@@ -119,7 +119,7 @@ namespace FluentFTP {
 					File.Delete(localFile);
 				}
 				catch (Exception ex) {
-					LogWithPrefix(FtpTraceLevel.Warn, "FtpClient : Exception caught and discarded while attempting to delete file '" + localFile + "' : " + ex.ToString());
+					LogWithPrefix(FtpTraceLevel.Warn, "FtpClient : Exception caught and discarded while attempting to delete file '" + localFile + "'", ex);
 				}
 			}
 		}

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -270,7 +270,7 @@ namespace FluentFTP {
 				}
 
 				if (ex1 is IOException) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath + " : " + ex1.Message);
+					LogWithPrefix(FtpTraceLevel.Verbose, "IOException for file " + localPath, ex1);
 					return FtpStatus.Failed;
 				}
 

--- a/FluentFTP/Client/SyncClient/UploadFiles.cs
+++ b/FluentFTP/Client/SyncClient/UploadFiles.cs
@@ -99,7 +99,7 @@ namespace FluentFTP {
 					}
 				}
 				catch (Exception ex) {
-					LogWithPrefix(FtpTraceLevel.Error, "Upload Failure for " + localPath + ": " + ex);
+					LogWithPrefix(FtpTraceLevel.Error, "Upload Failure for " + localPath, ex);
 					if (errorHandling.HasFlag(FtpError.Stop)) {
 						errorEncountered = true;
 						break;

--- a/FluentFTP/Client/SyncClient/VerifyTransfer.cs
+++ b/FluentFTP/Client/SyncClient/VerifyTransfer.cs
@@ -38,7 +38,7 @@ namespace FluentFTP {
 				return true;
 			}
 			catch (IOException ex) {
-				LogWithPrefix(FtpTraceLevel.Warn, "Failed to verify file " + localPath + " : " + ex.Message);
+				LogWithPrefix(FtpTraceLevel.Warn, "Failed to verify file " + localPath, ex);
 				return false;
 			}
 		}

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -131,12 +131,12 @@ namespace FluentFTP {
 				}
 				catch (SocketException sockex) {
 					Close();
-					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded SocketException while testing for connectivity: " + sockex.ToString());
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded SocketException while testing for connectivity", sockex);
 					return false;
 				}
 				catch (IOException ioex) {
 					Close();
-					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded IOException while testing for connectivity: " + ioex.ToString());
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded IOException while testing for connectivity", ioex);
 					return false;
 				}
 
@@ -924,7 +924,7 @@ namespace FluentFTP {
 						throw;
 					}
 					else {
-						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "...error connecting to IP #" + iPlusOne + "= " + logIp + ":" + port + " " + ex.Message);
+						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "...error connecting to IP #" + iPlusOne + "= " + logIp + ":" + port, ex);
 					}
 				}
 			}
@@ -1062,7 +1062,7 @@ namespace FluentFTP {
 						throw;
 					}
 					else {
-						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "...error connecting to IP #" + iPlusOne + "= " + logIp + ":" + port + " " + ex.Message);
+						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "...error connecting to IP #" + iPlusOne + "= " + logIp + ":" + port, ex);
 					}
 				}
 			}
@@ -1196,8 +1196,7 @@ namespace FluentFTP {
 				// ssl stream in an unusable state so cleanup needs
 				// to be done and the exception can be re-thrown for
 				// handling down the chain.
-				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Error, "FTPS Authentication Failed:");
-				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Error, ex.Message.Trim());
+				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Error, "FTPS Authentication Failed", ex);
 				Close();
 				throw;
 			}


### PR DESCRIPTION
Many logging frameworks separate the logging message from any other data, e.g. exceptions.
In visualization of logs logging message and exception then have separate columns.
This is similar to how parameterized SQL queries separates the query from the parameters.

Also for `ILogger`s it should not be necessary to explicitly prefix the logging message with the loglevel, as that is controlled in the logging format template.
E.g. for [serilog](https://github.com/serilog/serilog/wiki/Formatting-Output)