### PR TITLE
Further optimise follow up for #1124

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1087,9 +1087,6 @@ namespace FluentFTP {
 					await EnableCancellation(m_socket.ConnectAsync(ipad, port), timeoutSrc.Token, () => DisposeSocket());
 				}
 			}
-			catch (SocketException ex) when (ex.SocketErrorCode is SocketError.OperationAborted or SocketError.TimedOut) {
-				throw new TimeoutException("Timed out trying to connect!");
-			}
 #else
 			try {
 				using (var timeoutSrc = CancellationTokenSource.CreateLinkedTokenSource(token)) {
@@ -1103,13 +1100,13 @@ namespace FluentFTP {
 #endif
 				}
 			}
-			catch (SocketException ex) when (ex.SocketErrorCode is SocketError.OperationAborted or SocketError.TimedOut) {
-				throw new TimeoutException("Timed out trying to connect!");
-			}
 			catch (ObjectDisposedException) {
 				throw new TimeoutException("Timed out trying to connect!");
 			}
 #endif
+			catch (SocketException ex) when (ex.SocketErrorCode is SocketError.OperationAborted or SocketError.TimedOut) {
+				throw new TimeoutException("Timed out trying to connect!");
+			}
 			return m_socket.Connected;
 		}
 


### PR DESCRIPTION
@jnyrup So, look at this, if I rearrange the catch I can have a single common one at the end.

Too bad I cannot bring in the `ObjectDisposedException` as well, as it is encased in the outer #else-#endif