### PR TITLE
Do not attempt Reconnect if we have not ever been connected before.

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -43,6 +43,7 @@ namespace FluentFTP {
 			// If we have never been connected before...
 			if (this.Status.CachedHostIpads.Count == 0) {
 				reConnect = false;
+				LogWithPrefix(FtpTraceLevel.Info, "Cannot Re-Connect, never been connected");
 			}
 
 			if (!reConnect) {

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -211,9 +211,7 @@ namespace FluentFTP {
 					await SetWorkingDirectory(Status.LastWorkingDir, token);
 				}
 			}
-			else {
-				_ = await GetWorkingDirectory(token);
-			}
+			_ = await GetWorkingDirectory(token);
 
 			// FIX #922: disable checking for stale data during connection
 			Status.AllowCheckStaleData = true;

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -40,6 +40,11 @@ namespace FluentFTP {
 		public virtual async Task Connect(bool reConnect, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 
+			// If we have never been connected before...
+			if (this.Status.CachedHostIpads.Count == 0) {
+				reConnect = false;
+			}
+
 			if (!reConnect) {
 
 				LogFunction(nameof(ConnectAsync));

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -40,6 +40,11 @@ namespace FluentFTP {
 
 			lock (m_lock) {
 
+				// If we have never been connected before...
+				if (this.Status.CachedHostIpads.Count == 0) {
+					reConnect = false;
+				}
+
 				if (!reConnect) {
 
 					LogFunction(nameof(Connect));

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -208,9 +208,7 @@ namespace FluentFTP {
 						SetWorkingDirectory(Status.LastWorkingDir);
 					}
 				}
-				else {
-					_ = GetWorkingDirectory();
-				}
+				_ = GetWorkingDirectory();
 
 				// FIX #922: disable checking for stale data during connection
 				Status.AllowCheckStaleData = true;

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -42,6 +42,7 @@ namespace FluentFTP {
 
 				// If we have never been connected before...
 				if (this.Status.CachedHostIpads.Count == 0) {
+					LogWithPrefix(FtpTraceLevel.Info, "Cannot Re-Connect, never been connected");
 					reConnect = false;
 				}
 


### PR DESCRIPTION
It would "sort of" work, but fail in other places.  --> Revert back to an implicit Connect().

This happens when a user has not used Connect() (Or AutoConnect()) yet, but attempts to issue an API command, I did this by mistake today, and this would recognize that we are not connected and attempt a re-connect. This re-connect would for example fail to do a FEAT command and other stuff, causing unexpected results. Thus, in such a case, revert back to a normal full fledged connect.

I added a log message to show this happening.

Instead of adding a flag in Status, I just used the IP-Address internal cache having at least on entry. In case we ever invalidate that cache based on DNS time to live data, we would need to use a flag.

So @robinrodricks, should we use a flag?

Also, in case of **repeated** reconnects on a session, the current directory **can** be null on the second and subsequent reconnect. CWD does **not** set the status variable. It needs a specific PWD command to get it.