### PR TITLE
Use expression instead of file for NuGet license

### DIFF
--- a/FluentFTP.Logging/FluentFTP.Logging.csproj
+++ b/FluentFTP.Logging/FluentFTP.Logging.csproj
@@ -6,13 +6,13 @@
         <Description>Small connector library to integrate FluentFTP with MELA Loggers (Microsoft.Extensions.Logging.Abstractions).</Description>
         <Authors>Robin Rodricks, FluentFTP Contributors</Authors>
         <PackageProjectUrl>https://github.com/robinrodricks/FluentFTP</PackageProjectUrl>
-        <Copyright>MIT License</Copyright>
+        <Copyright>Copyright (c) 2015 Robin Rodricks and FluentFTP Contributors</Copyright>
         <PackageTags>log,logger,logging,interface,connector,mela</PackageTags>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\FluentFTP.xml</DocumentationFile>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
         <Version>1.0.0</Version>
-        <PackageLicenseFile>LICENSE.TXT</PackageLicenseFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>logo-nuget.png</PackageIcon>
         <LangVersion>10.0</LangVersion>
     </PropertyGroup>

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -6,13 +6,13 @@
         <Description>An FTP and FTPS client for .NET &amp; .NET Standard, optimized for speed. Provides extensive FTP commands, File uploads/downloads, SSL/TLS connections, Directory listing parsing, File hashing/checksums, File permissions/CHMOD, FTP proxies, FXP transfers, UTF-8 support, Async/await support, Powershell support and more. Written entirely in C#, with no external dependencies.</Description>
         <Authors>Robin Rodricks, FluentFTP Contributors</Authors>
         <PackageProjectUrl>https://github.com/robinrodricks/FluentFTP</PackageProjectUrl>
-        <Copyright>MIT License</Copyright>
+        <Copyright>Copyright (c) 2015 Robin Rodricks and FluentFTP Contributors</Copyright>
         <PackageTags>ftp,ftp-client,ftps,ftps-client,ssl,tls,unix,iis,ftp-proxy</PackageTags>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\FluentFTP.xml</DocumentationFile>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
         <Version>44.0.1</Version>
-        <PackageLicenseFile>LICENSE.TXT</PackageLicenseFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>logo-nuget.png</PackageIcon>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
         <LangVersion>10.0</LangVersion>


### PR DESCRIPTION
You can't set both and expressions are better because it allows tools to automatically determine the license.

Also fix the copyright (copied from LICENSE.TXT)