### PR TITLE
DiscoverSslSessionLength

### DIFF
--- a/FluentFTP/Client/SyncClient/DiscoverSslSessionLength.cs
+++ b/FluentFTP/Client/SyncClient/DiscoverSslSessionLength.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
+using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using FluentFTP.Client.Modules;
+using System.Security.Authentication;
+using FluentFTP.Proxy.SyncProxy;
+
+namespace FluentFTP {
+	public partial class FtpClient {
+
+
+		/// <summary>
+		/// Attempt to find out the servers SSL command limit.
+		/// </summary>
+		/// <param name="command">The command to issue</param>
+		/// <param name="maxTrys">Maximum how many commands to issue</param>
+		/// <returns>The detected command limit, 0 if infinite</returns>
+		public int DiscoverSslSessionLength(string command = "PWD", int maxTrys = 2000) {
+			if (!IsEncrypted) {
+				return 0;
+			}
+
+			int connects = Status.ConnectCount;
+
+			int oldLength = Config.SslSessionLength;
+
+			Config.SslSessionLength = 0;
+
+			for (int i = 0; i < maxTrys; i++) {
+				Console.WriteLine("Try " + i);
+				try {
+					Execute(command);
+				}
+				catch {
+					Log(FtpTraceLevel.Verbose, "Exception: ");
+					break;
+				}
+
+				if (Status.ConnectCount > connects) {
+					Log(FtpTraceLevel.Verbose, "Reconnect detected");
+					break;
+				}
+			}
+
+			Execute(command);
+
+			if (Status.ConnectCount > connects) {
+				Log(FtpTraceLevel.Verbose, "Failure ocurred at: " + m_stream.SslSessionLength);
+				return m_stream.SslSessionLength;
+			}
+
+			Config.SslSessionLength = oldLength;
+
+			return 0;
+		}
+	}
+}


### PR DESCRIPTION
As suggested by you, @robinrodricks, this API function will issue  up to `maxTrys=2000` commands `command="PWD"` with an inter-command delay of `delay=50` to help the user find out the recommended setting of `SslSessionLength` fot this server connection.

Usage:

```cs
	ftpClient.Connect();

	Console.WriteLine("Set SslSessionLength to less than: " + ftpClient.DiscoverSslSessionLength());
```
