### PR TITLE
Issue #1205 Repair logic to support proxy connections

### DIFF
--- a/FluentFTP/Client/BaseClient/GetPassivePort.cs
+++ b/FluentFTP/Client/BaseClient/GetPassivePort.cs
@@ -33,16 +33,22 @@ namespace FluentFTP.Client.BaseClient {
 					throw new FtpException("Failed to get the EPSV port from: " + reply.Message);
 				}
 			}
-			// If ESPV is responded with Entering Extended Passive. The IP must remain the same.
+			// If ESPV is responded with Entering Extended Passive. The IP must remain the same as the control connection.
+
 			/* Example:
+
 			Command: EPSV
 			Response: 229 Entering Extended Passive Mode(|||10016|)
 
-			If we set the host to ftp.host.com and ftp.host.com has multiple ip's we may end up with the wrong ip.
-			Making sure that we use the same IP.
-			host = m_host; 
+			If the server (per hostname DNS query) has multiple ip's we will **NOT** end up with the wrong ip, because:
+			On the connect we have stored the previously used IPAD in the hostname/IPAD cache, replacing the list of IPADs
+			that DNS gave us by the single one that we successfully connected to.
+
+			Therefore the subsequent connects will use this single stored IPAD instead of querying DNS and getting a list of IPADs.
 			*/
-			host = SocketRemoteEndPoint.Address.ToString();
+
+			host = m_host;
+
 			port = int.Parse(m.Groups["port"].Value);
 		}
 


### PR DESCRIPTION
Ever since (some months ago) we have a DNS cache, where we store the SINGLE IPAD that we have successfully connected to, even if the server has multiple IP Addresses, we can rely on our own connect logic to pick up this **same** IPAD again on EPSV requests.

So therefore, the previous fix, by getting the IPAD from the socket endpoint, is no longer needed. Trouble was: On EPSV, this broke the proxy connect logic, where the proxy expects a DNS name and cannot make head not tail of the socket endpoint IP address.

Fixes issue #1205