### PR TITLE
Logging tweak: Message first, then close, same as in SslStream part

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1211,8 +1211,8 @@ namespace FluentFTP {
 					CreateCustomStream(targetHost);
 				}
 				catch (Exception ex) {
-					Close();
 					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Error, "FTPS Authentication failed, lib = " + authType, ex, true);
+					Close();
 					throw;
 				}
 


### PR DESCRIPTION
Consistent log message order when handling exception. Discovered this discrepancy during debugging a different problem.