### PR TITLE
More null checks of `Reply.InfoMessages`

### DIFF
--- a/FluentFTP/Client/AsyncClient/GetListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetListing.cs
@@ -288,10 +288,12 @@ namespace FluentFTP {
 
 						Log(FtpTraceLevel.Verbose, "+---------------------------------------+");
 
-						foreach (var line in reply.InfoMessages.Split('\n')) {
-							if (!Strings.IsNullOrWhiteSpace(line)) {
-								rawlisting.Add(line);
-								Log(FtpTraceLevel.Verbose, "Listing:  " + line);
+						if (reply.InfoMessages != null) {
+							foreach (var line in reply.InfoMessages.Split('\n')) {
+								if (!Strings.IsNullOrWhiteSpace(line)) {
+									rawlisting.Add(line);
+									Log(FtpTraceLevel.Verbose, "Listing:  " + line);
+								}
 							}
 						}
 

--- a/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
+++ b/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
@@ -40,7 +40,6 @@ namespace FluentFTP {
 			LogFunction(nameof(GetObjectInfo), new object[] { path, dateModified });
 
 			FtpReply reply;
-			string[] res;
 
 			var supportsMachineList = HasFeature(FtpCapability.MLSD);
 
@@ -50,15 +49,17 @@ namespace FluentFTP {
 				// USE MACHINE LISTING TO GET INFO FOR A SINGLE FILE
 
 				if ((reply = await Execute("MLST " + path, token)).Success) {
-					res = reply.InfoMessages?.Split('\n');
-					if (res?.Length > 1) {
-						var info = new StringBuilder();
+					if (reply.InfoMessages != null) {
+						string[] res = reply.InfoMessages.Split('\n');
+						if (res.Length > 1) {
+							var info = new StringBuilder();
 
-						for (var i = 1; i < res.Length; i++) {
-							info.Append(res[i]);
+							for (var i = 1; i < res.Length; i++) {
+								info.Append(res[i]);
+							}
+
+							result = CurrentListParser.ParseSingleLine(null, info.ToString(), m_capabilities, true);
 						}
-
-						result = CurrentListParser.ParseSingleLine(null, info.ToString(), m_capabilities, true);
 					}
 				}
 				else {

--- a/FluentFTP/Client/AsyncClient/GetZOSListRealm.cs
+++ b/FluentFTP/Client/AsyncClient/GetZOSListRealm.cs
@@ -38,8 +38,7 @@ namespace FluentFTP {
 			// 250-The working directory may be a load library                          
 			// 250 The working directory "GEEK.PRODUCTS.LOADLIB" is a partitioned data set
 
-			if (reply.InfoMessages != null &&
-				reply.InfoMessages.Contains("may be a load library")) {
+			if (reply.InfoMessages?.Contains("may be a load library") == true) {
 				return FtpZOSListRealm.MemberU;
 			}
 

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -163,7 +163,7 @@ namespace FluentFTP.Client.BaseClient {
 		}
 
 		void IInternalFtpClient.ConnectInternal(bool reConnect) {
-        }
+		}
 		void IInternalFtpClient.ConnectInternal(bool reConnect, CancellationToken token) {
 		}
 

--- a/FluentFTP/Client/SyncClient/GetListing.cs
+++ b/FluentFTP/Client/SyncClient/GetListing.cs
@@ -184,10 +184,12 @@ namespace FluentFTP {
 					if (reply.Success) {
 						Log(FtpTraceLevel.Verbose, "+---------------------------------------+");
 
-						foreach (var line in reply.InfoMessages.Split('\n')) {
-							if (!Strings.IsNullOrWhiteSpace(line)) {
-								rawlisting.Add(line);
-								Log(FtpTraceLevel.Verbose, "Listing:  " + line);
+						if (reply.InfoMessages != null) {
+							foreach (var line in reply.InfoMessages.Split('\n')) {
+								if (!Strings.IsNullOrWhiteSpace(line)) {
+									rawlisting.Add(line);
+									Log(FtpTraceLevel.Verbose, "Listing:  " + line);
+								}
 							}
 						}
 

--- a/FluentFTP/Client/SyncClient/GetObjectInfo.cs
+++ b/FluentFTP/Client/SyncClient/GetObjectInfo.cs
@@ -32,7 +32,6 @@ namespace FluentFTP {
 			LogFunction(nameof(GetObjectInfo), new object[] { path, dateModified });
 
 			FtpReply reply;
-			string[] res;
 
 			var supportsMachineList = HasFeature(FtpCapability.MLSD);
 
@@ -42,15 +41,17 @@ namespace FluentFTP {
 				// USE MACHINE LISTING TO GET INFO FOR A SINGLE FILE
 
 				if ((reply = Execute("MLST " + path)).Success) {
-					res = reply.InfoMessages.Split('\n');
-					if (res.Length > 1) {
-						var info = new StringBuilder();
+					if (reply.InfoMessages != null) {
+						string[] res = reply.InfoMessages.Split('\n');
+						if (res.Length > 1) {
+							var info = new StringBuilder();
 
-						for (var i = 1; i < res.Length; i++) {
-							info.Append(res[i]);
+							for (var i = 1; i < res.Length; i++) {
+								info.Append(res[i]);
+							}
+
+							result = CurrentListParser.ParseSingleLine(null, info.ToString(), m_capabilities, true);
 						}
-
-						result = CurrentListParser.ParseSingleLine(null, info.ToString(), m_capabilities, true);
 					}
 				}
 				else {

--- a/FluentFTP/Client/SyncClient/GetZOSListRealm.cs
+++ b/FluentFTP/Client/SyncClient/GetZOSListRealm.cs
@@ -41,8 +41,7 @@ namespace FluentFTP {
 			// 250-The working directory may be a load library                          
 			// 250 The working directory "GEEK.PRODUCT.LOADLIB" is a partitioned data set
 
-			if (reply.InfoMessages != null &&
-				reply.InfoMessages.Contains("may be a load library")) {
+			if (reply.InfoMessages?.Contains("may be a load library") == true) {
 				return FtpZOSListRealm.MemberU;
 			}
 

--- a/FluentFTP/Model/FtpReply.cs
+++ b/FluentFTP/Model/FtpReply.cs
@@ -88,7 +88,7 @@ namespace FluentFTP {
 					return message;
 				}
 
-				if (InfoMessages != null && InfoMessages.Length > 0) {
+				if (!string.IsNullOrEmpty(InfoMessages)) {
 					foreach (var s in InfoMessages.Split('\n')) {
 						var m = Regex.Replace(s, "^[0-9]{3}-", "");
 						message += m.Trim() + "; ";


### PR DESCRIPTION
I can't tell the flow of what happens, but if we hit one of these `breaks` in `GetReplyInternal` we could skip writing to `reply.InfoMessages`.
![image](https://user-images.githubusercontent.com/919634/225337246-51cc6ab8-221e-4fff-bab8-a8d35df139f5.png)

Supersedes #1235.