### PR TITLE
Custom Stream: PolicyErrors not being set correctly

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -383,6 +383,7 @@ namespace FluentFTP {
 				var e = new FtpSslValidationEventArgs() {
 					Certificate = certificate,
 					Chain = chain,
+					PolicyErrors = String.IsNullOrEmpty(errorMessage) ? SslPolicyErrors.None : SslPolicyErrors.RemoteCertificateNameMismatch,
 					PolicyErrorMessage = errorMessage,
 					Accept = errorMessage == string.Empty,
 				};


### PR DESCRIPTION
The custom stream validation callback provides some information to decide ACCEPT/NOT ACCEPT. The varaible "`PolicyErrors`" was set to be "`SslPolicyErrors.None`" by default and not set by the callback.

Sadly, whenever you do not want this to be "NONE", you have only a very few values to choose from, that do not really reflect the very detailed error possibilites available in other Ssl stream implementations.