### PR TITLE
Tidy up the conditional compiles and test for each target in FtpSslStream.cs

### DIFF
--- a/FluentFTP/Streams/FtpSslStream.cs
+++ b/FluentFTP/Streams/FtpSslStream.cs
@@ -18,7 +18,7 @@ namespace FluentFTP.Streams {
 	/// See: https://learn.microsoft.com/en-us/windows/win32/secauthn/using-sspi-with-a-windows-sockets-client?source=recommendations
 	///
 	/// Note:
-	/// Here is quote from: https://github.com/dotnet/standard/issues/598#issuecomment-352148072
+	/// Here is a quote from: https://github.com/dotnet/standard/issues/598#issuecomment-352148072
 	/// "The SslStream.ShutdownAsync API was added to .NET Core 2.0. It was also added to .NET Framework 4.7.
 	/// Logically, since .NET Core 2.0 and .NET Framework 4.7.1 are aligned with NETStandard2.0, it could
 	/// have been part of the NETStandard20 definition. But it wasn't due to when the NETStandard2.0 spec


### PR DESCRIPTION
I decided to clean up the conditional compiles and check each one for validity.

It turns out that .NET Framework supports ShutDownAsync since .NET 4.7 ( !!! ) which we somehow didn't really see so clearly at the time.

Therefore the only one of our build targets left over would be .NET 4.6.2, which needs the ugly reflection hack to send a close notify.

**BUT** Beware: .NET Standard 2.0 **also does not have this capability** which means theoretically we should develop the same hack for this target as for .NET 4.6.2. So I added that.

If this ever becomes an issue for someone, this will be needed.

I stumbled across this whilst searching for solution to #1251 

Read this:
Here is a quote from: https://github.com/dotnet/standard/issues/598#issuecomment-352148072
"The SslStream.ShutdownAsync API was added to .NET Core 2.0. It was also added to .NET Framework 4.7. Logically, since .NET Core 2.0 and .NET Framework 4.7.1 are aligned with NETStandard2.0, it could
have been part of the NETStandard20 definition. But it wasn't due to when the NETStandard2.0 spec
was originally designed."