### PR TITLE
Allow config parameter "LocalFileShareOption" to be configured. 

### DIFF
--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -4,6 +4,7 @@ using FluentFTP.Streams;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Security.Authentication;
@@ -426,6 +427,12 @@ namespace FluentFTP {
 		/// and all the other file and directory transfer methods.
 		/// </summary>
 		public int LocalFileBufferSize { get; set; } = 4096;
+
+		/// <summary>
+		/// Gets or sets the FileShare setting to be used when opening a FileReadStream for uploading to the server,
+		/// which needs to be set to FileShare.ReadWrite in special cases to avoid denied access.
+		/// </summary>
+		public FileShare LocalFileShareOption { get; set; } = FileShare.Read;
 
 		protected int _retryAttempts = 3;
 

--- a/FluentFTP/Streams/FtpFileStream.cs
+++ b/FluentFTP/Streams/FtpFileStream.cs
@@ -58,7 +58,8 @@ namespace FluentFTP.Streams {
 
 			// normal slow mode, return a FileStream
 			var bufferSize = client != null ? client.Config.LocalFileBufferSize : 4096;
-			return new FileStream(localPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, isAsync);
+			var shareOption = client != null ? client.Config.LocalFileShareOption : FileShare.Read;
+			return new FileStream(localPath, FileMode.Open, FileAccess.Read, shareOption, bufferSize, isAsync);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Default is of course FileShare.Read.

See #1257