### PR TITLE
SSL Buffering: Update explanatory texts and refactor slightly

### DIFF
--- a/FluentFTP/Enums/FtpsBuffering.cs
+++ b/FluentFTP/Enums/FtpsBuffering.cs
@@ -6,7 +6,11 @@ namespace FluentFTP {
 	/// </summary>
 	public enum FtpsBuffering {
 		/// <summary>
-		/// Enables buffering in all cases except when using FTP proxies.
+		/// Enables SSL Buffering to massively speed up FTPS operations except when:
+		/// Under .NET 5.0 and later due to platform issues (see issue 682 in FluentFTP issue tracker).
+		/// On the control connection
+		/// For proxy connections
+		/// If NOOPs are configured to be used
 		/// </summary>
 		Auto,
 
@@ -16,7 +20,7 @@ namespace FluentFTP {
 		Off,
 
 		/// <summary>
-		/// Always enables SSL Buffering to massively speed up FTPS operations.
+		/// Same as "Auto"
 		/// </summary>
 		On
 	}

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -241,6 +241,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Whether to use SSL Buffering to speed up data transfer during FTP operations.
 		/// SSL Buffering is always disabled on .NET 5.0 and later due to platform issues (see issue 682 in FluentFTP issue tracker).
+		/// Also disabled on the control connection, for proxy connections and if NOOPs are configured to be used
 		/// </summary>
 		public FtpsBuffering SslBuffering { get; set; } = FtpsBuffering.Auto;
 


### PR DESCRIPTION
Update all the config texts and other place to reflect the actual behaviour of the config parameters.

Since a year or so, "Auto" and "On" have effectively been the same. We have **always** turned **off** SslBuffering in special cases, even if the user had specified "On".

The special cases are:

- Under .NET 5.0 and later due to platform issues (see issue 682 in FluentFTP issue tracker).
- On the control connection
- For proxy connections
- If NOOPs are configured to be used

