### PR TITLE
Fix for #1286

### DIFF
--- a/FluentFTP/Helpers/Hashing/HashParser.cs
+++ b/FluentFTP/Helpers/Hashing/HashParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -11,25 +12,22 @@ namespace FluentFTP.Helpers.Hashing {
 		/// </summary>
 		public static FtpHash Parse(string reply) {
 
-			// Current draft says the server should return this:
-			//		SHA-256 0-49 169cd22282da7f147cb491e559e9dd filename.ext
-
-			// Current version of FileZilla returns this:
-			//		SHA-1 21c2ca15cf570582949eb59fb78038b9c27ffcaf 
-
-			// Real reply that was failing:
-			//		213 MD5 0-170500096 3197bf4ec5fa2d441c0f50264ca52f11
-
-
 			var hash = new FtpHash();
 
-			// FIX #722 - remove the FTP status code causing a wrong hash to be returned
-			if (reply.StartsWith("2") && reply.Length > 10) {
-				reply = reply.Substring(4);
-			}
+			// Current draft says the server should return this:
+			//		<algorithm> <bytestart>-<byteend> <hash> <filename>
+
+			// Note: filename might contain blanks.
+
+			// Some servers respond with differing formats:
+
+			//		<algorithm> <hash>							- some FileZilla versions)
+			//		<algorithm> <bytestart>-<byteend> <hash>    - BrickFTP (files.com / Exavault.com)
+
+			// Try to parse these differing formats:
 
 			Match m;
-			if (!(m = Regex.Match(reply, @"^(?<algorithm>\S+)\s(?<bytestart>\d+)-(?<byteend>\d+)\s(?<hash>\S+)\s(?<filename>.+)$")).Success) {
+			if (!(m = Regex.Match(reply, @"^(?<algorithm>\S+)\s(?<bytestart>\d+)-(?<byteend>\d+)\s(?<hash>\S+)\s*(?<filename>.*)$")).Success) {
 				m = Regex.Match(reply, @"(?<algorithm>.+)\s(?<hash>.+)\s");
 			}
 


### PR DESCRIPTION
BrickFTP (files.com / Exavault.com) responds in a non - standard fashion (no filename).

Changed the regex to handle that situation.

Incidentally: The fix for #722 (which was never confirmed) which attempts to remove "213" from the server response as a fix is obsolete (the server response code is removed prior to the call of this function anyway) and not the real reason why #722 was reported. #722 was **another, first** occurrence of **"missing" filename**. And lo and behold, it was the same server type as the one reported here.