### PR TITLE
Fix regression: Premature AutoDetect termination

### DIFF
--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -399,11 +399,6 @@ namespace FluentFTP.Client.Modules {
 				}
 			}
 
-			// generic permanent authentication failure leftover: probably wrong FTPS certificate
-			if (ex is AuthenticationException certEx) {
-				return new FtpInvalidCertificateException(certEx);
-			}
-
 			// Network related failures
 
 			// catch error "no such host is known" and hard abort


### PR DESCRIPTION
This is a regression introduced (by me, alas) some time ago and it causes a premature termination of the AutoDetect logic whenever SSL Authentication (i.e. switching to encrypted traffic) fails.

There will be some more separate changes to AutoDetect in the course of further testing re. issue #1289