### PR TITLE
Add requireEncryption and includeImplicit

### DIFF
--- a/FluentFTP/Client/Interfaces/IFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IFtpClient.cs
@@ -26,7 +26,7 @@ namespace FluentFTP {
 		bool HasFeature(FtpCapability cap);
 		void DisableUTF8();
 
-		List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true);
+		List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true, bool requireEncryption = false, bool includeImplicit = true);
 		FtpProfile AutoConnect();
 		void Connect();
 		void Connect(FtpProfile profile);

--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -17,9 +17,6 @@ namespace FluentFTP.Client.Modules {
 
 		private static List<FtpEncryptionMode> DefaultEncryptionPriority = new List<FtpEncryptionMode> {
 			FtpEncryptionMode.Auto,
-
-			// Do we really want to AutoDetect non encrypted connections?
-			FtpEncryptionMode.None, // Yes! It seems we do.
 		};
 
 		private static List<SysSslProtocols> DefaultProtocolPriority = new List<SysSslProtocols> {
@@ -35,8 +32,16 @@ namespace FluentFTP.Client.Modules {
 		/// You can then generate code for the profile using the FtpProfile.ToCode method.
 		/// If no successful profiles are found, a blank list is returned.
 		/// </summary>
-		public static List<FtpProfile> AutoDetect(FtpClient client, bool firstOnly, bool cloneConnection) {
+		public static List<FtpProfile> AutoDetect(FtpClient client, bool firstOnly, bool cloneConnection, bool requireEncryption, bool includeImplicit) {
 			var results = new List<FtpProfile>();
+
+			if (!requireEncryption) {
+				DefaultEncryptionPriority.Add(FtpEncryptionMode.None);
+			}
+
+			if (includeImplicit) {
+				DefaultEncryptionPriority.Add(FtpEncryptionMode.Implicit);
+			}
 
 			// get known working connection profile based on the host (if any)
 			List<FtpEncryptionMode> encryptionsToTry;

--- a/FluentFTP/Client/SyncClient/AutoDetect.cs
+++ b/FluentFTP/Client/SyncClient/AutoDetect.cs
@@ -16,13 +16,13 @@ namespace FluentFTP {
 		/// <param name="firstOnly">Find all successful profiles (false) or stop after finding the first successful profile (true)</param>
 		/// <param name="cloneConnection">Use a new cloned FtpClient for testing connection profiles (true) or use the source FtpClient (false)</param>
 		/// <returns></returns>
-		public List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true) {
+		public List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true, bool requireEncryption = false, bool includeImplicit = true) {
 
 			lock (m_lock) {
-				LogFunction(nameof(AutoDetect), new object[] { firstOnly, cloneConnection });
+				LogFunction(nameof(AutoDetect), new object[] { firstOnly, cloneConnection, requireEncryption, includeImplicit });
 				ValidateAutoDetect();
 
-				return ConnectModule.AutoDetect(this, firstOnly, cloneConnection);
+				return ConnectModule.AutoDetect(this, firstOnly, cloneConnection, requireEncryption, includeImplicit);
 			}
 		}
 


### PR DESCRIPTION
Add two more parms (defaulting so that no code changes are needed in the user base) to `AutoDetect`.

**`bool requireEncryption`** ( = false )
**`bool includeImplicit`** ( = true )

These defaults reflects the previous codes **intentions** ( even if it didn't work so well... ).

I would actually **recommend** 

**`bool requireEncryption`** ( = **true** )
**`bool includeImplicit`** ( = **false** )

Can we do that?
