### PR TITLE
FluentFTP nuget updates needed to run our integration tests

### DIFF
--- a/FluentFTP.Logging/FluentFTP.Logging.csproj
+++ b/FluentFTP.Logging/FluentFTP.Logging.csproj
@@ -37,7 +37,7 @@
 
     <ItemGroup>
         <!-- Reference the first version of FluentFTP that exposes IFluentLogger. Do not change this version. -->
-        <PackageReference Include="FluentFTP" Version="43.0.1" />
+        <PackageReference Include="FluentFTP" Version="47.0.0" />
         <!-- Reference the oldest version of MELA possible. Do not change this version. -->
         <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     </ItemGroup>

--- a/FluentFTP.Tests/FluentFTP.Tests.csproj
+++ b/FluentFTP.Tests/FluentFTP.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentFTP.GnuTLS" Version="1.0.5" />
+    <PackageReference Include="FluentFTP.GnuTLS" Version="1.0.20" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
![image](https://github.com/robinrodricks/FluentFTP/assets/51046875/2fa3e68f-b27d-451f-b68c-3f48c61d36d1)

Integration test involving FluentFTP.GnuTLS were failing.

43.0.1 -> 47.0.0 and 1.0.5 -> 1.0.20 and also lib version 3.7.8 -> 3.8.0