### PR TITLE
Revert "FluentFTP nuget updates needed to run our integration tests"

### DIFF
--- a/FluentFTP.Logging/FluentFTP.Logging.csproj
+++ b/FluentFTP.Logging/FluentFTP.Logging.csproj
@@ -37,7 +37,7 @@
 
     <ItemGroup>
         <!-- Reference the first version of FluentFTP that exposes IFluentLogger. Do not change this version. -->
-        <PackageReference Include="FluentFTP" Version="47.0.0" />
+        <PackageReference Include="FluentFTP" Version="43.0.1" />
         <!-- Reference the oldest version of MELA possible. Do not change this version. -->
         <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     </ItemGroup>

--- a/FluentFTP.Tests/FluentFTP.Tests.csproj
+++ b/FluentFTP.Tests/FluentFTP.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentFTP.GnuTLS" Version="1.0.20" />
+    <PackageReference Include="FluentFTP.GnuTLS" Version="1.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
This reverts commit f3cad9000a35a336688bec68c496901f7771fd06.

It was only supposed to change FluentFTP.Tests, not Logging also. I need to redo this.