### PR TITLE
FluentFTP nuget updates needed to run our integration tests (corrected)

### DIFF
--- a/FluentFTP.Tests/FluentFTP.Tests.csproj
+++ b/FluentFTP.Tests/FluentFTP.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentFTP.GnuTLS" Version="1.0.5" />
+    <PackageReference Include="FluentFTP.GnuTLS" Version="1.0.20" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
![image](https://github.com/robinrodricks/FluentFTP/assets/51046875/22b8acda-9bf3-4773-8457-454013da0e5c)

Integration tests involving FluentFTP.GnuTLS were failing.

1.0.5 -> 1.0.20 and also lib version 3.7.8 -> 3.8.0

** This is the corrected commit / merge. The previous one was incorrect and was reverted. **
