### PR TITLE
Model Auto Detect with config object, first draft, works fine.

### DIFF
--- a/FluentFTP.Tests/Integration/Tests/ConnectTests.cs
+++ b/FluentFTP.Tests/Integration/Tests/ConnectTests.cs
@@ -62,14 +62,14 @@ namespace FluentFTP.Tests.Integration.Tests {
 
 		public void AutoDetect() {
 			using var ftpClient = GetClient();
-			var profiles = ftpClient.AutoDetect();
+			var profiles = ftpClient.AutoDetect(new FtpAutoDetectConfig());
 			Assert.NotEmpty(profiles);
 		}
 
 
 		public async Task AutoDetectAsync() {
 			using var ftpClient = await GetAsyncClient();
-			var profiles = await ftpClient.AutoDetect(false);
+			var profiles = await ftpClient.AutoDetect(new FtpAutoDetectConfig());
 			Assert.NotEmpty(profiles);
 		}
 

--- a/FluentFTP/Client/AsyncClient/AutoConnect.cs
+++ b/FluentFTP/Client/AsyncClient/AutoConnect.cs
@@ -16,7 +16,10 @@ namespace FluentFTP {
 			LogFunction(nameof(AutoConnect));
 
 			// connect to the first available connection profile
-			var results = await AutoDetect(true, false, token);
+			var results = await AutoDetect(new FtpAutoDetectConfig() {
+				FirstOnly = true,
+				CloneConnection = false,
+			}, token);
 			if (results.Count > 0) {
 				var profile = results[0];
 

--- a/FluentFTP/Client/AsyncClient/AutoDetect.cs
+++ b/FluentFTP/Client/AsyncClient/AutoDetect.cs
@@ -13,17 +13,16 @@ namespace FluentFTP {
 		/// You can then generate code for the profile using the FtpProfile.ToCode method.
 		/// If no successful profiles are found, a blank list is returned.
 		/// </summary>
-		/// <param name="firstOnly">Find all successful profiles (false) or stop after finding the first successful profile (true)</param>
-		/// <param name="cloneConnection">Use a new cloned AsyncFtpClient for testing connection profiles (true) or use the source AsyncFtpClient (false)</param>
+		/// <param name="config">The coresponding config object for this API</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <returns></returns>
-		public async Task<List<FtpProfile>> AutoDetect(bool firstOnly, bool cloneConnection = true, CancellationToken token = default(CancellationToken)) {
+		public async Task<List<FtpProfile>> AutoDetect(FtpAutoDetectConfig config, CancellationToken token = default(CancellationToken)) {
 			var results = new List<FtpProfile>();
 
-			LogFunction(nameof(AutoDetect), new object[] { firstOnly, cloneConnection });
+			//LogFunction(nameof(AutoDetect), new object[] { firstOnly, cloneConnection });
 			ValidateAutoDetect();
 
-			return await ConnectModule.AutoDetectAsync(this, firstOnly, cloneConnection, token);
+			return await ConnectModule.AutoDetectAsync(this, config, token);
 		}
 
 	}

--- a/FluentFTP/Client/Config/AutoDetect.cs
+++ b/FluentFTP/Client/Config/AutoDetect.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using SysSslProtocols = System.Security.Authentication.SslProtocols;
+
+namespace FluentFTP {
+
+	public class FtpAutoDetectConfig {
+
+		/// <summary>
+		/// Use a new cloned FtpClient for testing connection profiles (true) or use the source FtpClient (false)
+		/// </summary>
+		public bool CloneConnection { get; set; } = true;
+
+		/// <summary>
+		/// Find all successful profiles (false) or stop after finding the first successful profile (true)
+		/// </summary>
+		public bool FirstOnly { get; set; } = true;
+
+		/// <summary>
+		/// Also try the very seldom used Implicit mode
+		/// Default is try implicit, otherwise many would need a code change
+		/// as per the previous versions of AutoDetect.
+		/// Recommendation: Change this default to "false"
+		/// </summary>
+		public bool IncludeImplicit { get; set; } = true;
+
+		/// <summary>
+		/// Do not try the insecure unencrypted mode (even if it might work)
+		/// Default is allow insecure, otherwise many would need a code change
+		/// as per the previous versions of AutoDetect.
+		/// </summary>
+		public bool RequireEncryption { get; set; } = false;
+		/// Recommendation: Change this default to "true"
+
+		public List<SysSslProtocols> ProtocolPriority = new List<SysSslProtocols> {
+			SysSslProtocols.Tls11 | SysSslProtocols.Tls12,
+			// Do not EVER use "Default". It boils down to "SSL or TLS1.0" or worse.
+			// Do not use "None" - it can connect to TLS13, but Session Resume won't work, so a successful AutoDetect will be a false truth.
+		};
+
+
+	}
+}

--- a/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
@@ -27,7 +27,7 @@ namespace FluentFTP {
 		void DisableUTF8();
 
 		Task<FtpProfile> AutoConnect(CancellationToken token = default(CancellationToken));
-		Task<List<FtpProfile>> AutoDetect(bool firstOnly = true, bool cloneConnection = true, CancellationToken token = default(CancellationToken));
+		Task<List<FtpProfile>> AutoDetect(FtpAutoDetectConfig config, CancellationToken token = default(CancellationToken));
 		Task Connect(CancellationToken token = default(CancellationToken));
 		Task Connect(FtpProfile profile, CancellationToken token = default(CancellationToken));
 		Task Connect(bool reConnect, CancellationToken token = default(CancellationToken));

--- a/FluentFTP/Client/Interfaces/IFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IFtpClient.cs
@@ -26,7 +26,7 @@ namespace FluentFTP {
 		bool HasFeature(FtpCapability cap);
 		void DisableUTF8();
 
-		List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true);
+		List<FtpProfile> AutoDetect(FtpAutoDetectConfig config);
 		FtpProfile AutoConnect();
 		void Connect();
 		void Connect(FtpProfile profile);

--- a/FluentFTP/Client/SyncClient/AutoConnect.cs
+++ b/FluentFTP/Client/SyncClient/AutoConnect.cs
@@ -16,7 +16,10 @@ namespace FluentFTP {
 			LogFunction(nameof(AutoConnect));
 
 			// connect to the first available connection profile
-			var results = AutoDetect(true, false);
+			var results = AutoDetect(new FtpAutoDetectConfig() {
+				FirstOnly = true,
+				CloneConnection = false,
+			});
 			if (results.Count > 0) {
 				var profile = results[0];
 

--- a/FluentFTP/Client/SyncClient/AutoDetect.cs
+++ b/FluentFTP/Client/SyncClient/AutoDetect.cs
@@ -13,16 +13,16 @@ namespace FluentFTP {
 		/// You can then generate code for the profile using the FtpProfile.ToCode method.
 		/// If no successful profiles are found, a blank list is returned.
 		/// </summary>
-		/// <param name="firstOnly">Find all successful profiles (false) or stop after finding the first successful profile (true)</param>
-		/// <param name="cloneConnection">Use a new cloned FtpClient for testing connection profiles (true) or use the source FtpClient (false)</param>
+		/// <param name="config">The coresponding config object for this API</param>
 		/// <returns></returns>
-		public List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true) {
+		public List<FtpProfile> AutoDetect(FtpAutoDetectConfig config) {
 
 			lock (m_lock) {
-				LogFunction(nameof(AutoDetect), new object[] { firstOnly, cloneConnection });
+				// LogFunction(nameof(AutoDetect), new object[] { firstOnly, cloneConnection });
+
 				ValidateAutoDetect();
 
-				return ConnectModule.AutoDetect(this, firstOnly, cloneConnection);
+				return ConnectModule.AutoDetect(this, config);
 			}
 		}
 


### PR DESCRIPTION
Waiting for your comments / changes / ideas

Config Object location (for now, first idea of mine):

![image](https://github.com/robinrodricks/FluentFTP/assets/51046875/28f34c9c-2e77-4990-be33-8fe7842c205f)

The config object looks like this:
```cs
using System.Collections.Generic;
using SysSslProtocols = System.Security.Authentication.SslProtocols;

namespace FluentFTP {

	public class FtpAutoDetectConfig {

		/// <summary>
		/// Use a new cloned FtpClient for testing connection profiles (true) or use the source FtpClient (false)
		/// </summary>
		public bool CloneConnection { get; set; } = true;

		/// <summary>
		/// Find all successful profiles (false) or stop after finding the first successful profile (true)
		/// </summary>
		public bool FirstOnly { get; set; } = true;

		/// <summary>
		/// Also try the very seldom used Implicit mode
		/// Default is try implicit, otherwise many would need a code change
		/// as per the previous versions of AutoDetect.
		/// Recommendation: Change this default to "false"
		/// </summary>
		public bool IncludeImplicit { get; set; } = true;

		/// <summary>
		/// Do not try the insecure unencrypted mode (even if it might work)
		/// Default is allow insecure, otherwise many would need a code change
		/// as per the previous versions of AutoDetect.
		/// </summary>
		public bool RequireEncryption { get; set; } = false;
		/// Recommendation: Change this default to "true"

		public List<SysSslProtocols> ProtocolPriority = new List<SysSslProtocols> {
			SysSslProtocols.Tls11 | SysSslProtocols.Tls12,
			// Do not EVER use "Default". It boils down to "SSL or TLS1.0" or worse.
			// Do not use "None" - it can connect to TLS13, but Session Resume won't work, so a successful AutoDetect will be a false truth.
		};


	}
}
```