### PR TITLE
Auto-print config file properties

### DIFF
--- a/FluentFTP/Client/AsyncClient/AutoDetect.cs
+++ b/FluentFTP/Client/AsyncClient/AutoDetect.cs
@@ -18,10 +18,10 @@ namespace FluentFTP {
 		/// <param name="config">The coresponding config object for this API</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <returns></returns>
-		public async Task<List<FtpProfile>> AutoDetect(FtpAutoDetectConfig config, CancellationToken token = default(CancellationToken)) {
+		public async Task<List<FtpProfile>> AutoDetect(FtpAutoDetectConfig config = null, CancellationToken token = default(CancellationToken)) {
 			var results = new List<FtpProfile>();
 
-			LogFunction(nameof(AutoDetect), new object[] { config });
+			LogFunction(nameof(AutoDetect), config);
 			ValidateAutoDetect();
 
 			return await ConnectModule.AutoDetectAsync(this, config, token);

--- a/FluentFTP/Client/BaseClient/Logger.cs
+++ b/FluentFTP/Client/BaseClient/Logger.cs
@@ -94,9 +94,11 @@ namespace FluentFTP.Client.BaseClient {
 		/// </summary>
 		/// <param name="function">The name of the API function</param>
 		/// <param name="args">The args passed to the function</param>
-		protected void LogFunction(string function, object[] args = null) {
+		protected void LogFunction(string function, object args) {
 
-			var fullMessage = (">         " + function + "(" + args.ItemsToString().Join(", ") + ")");
+			var funcCallString = function + "(" + args.ObjectPropsToString() + ")";
+
+			var fullMessage = ">         " + funcCallString;
 
 			// log to modern logger if given
 			m_logger?.Log(FtpTraceLevel.Info, fullMessage);
@@ -106,7 +108,30 @@ namespace FluentFTP.Client.BaseClient {
 
 			// log to system
 			LogToDebugOrConsole("");
-			LogToDebugOrConsole("# " + function + "(" + args.ItemsToString().Join(", ") + ")");
+			LogToDebugOrConsole("# " + funcCallString);
+
+		}
+
+		/// <summary>
+		/// Log a function call with relevant arguments
+		/// </summary>
+		/// <param name="function">The name of the API function</param>
+		/// <param name="args">The args passed to the function</param>
+		protected void LogFunction(string function, object[] args = null) {
+
+			var funcCallString = function + "(" + args.ItemsToString().Join(", ") + ")";
+
+			var fullMessage = ">         " + funcCallString;
+
+			// log to modern logger if given
+			m_logger?.Log(FtpTraceLevel.Info, fullMessage);
+
+			// log to legacy logger if given
+			m_legacyLogger?.Invoke(FtpTraceLevel.Verbose, fullMessage);
+
+			// log to system
+			LogToDebugOrConsole("");
+			LogToDebugOrConsole("# " + funcCallString);
 
 		}
 

--- a/FluentFTP/Client/SyncClient/AutoDetect.cs
+++ b/FluentFTP/Client/SyncClient/AutoDetect.cs
@@ -19,7 +19,7 @@ namespace FluentFTP {
 		public List<FtpProfile> AutoDetect(FtpAutoDetectConfig config = null) {
 
 			lock (m_lock) {
-				LogFunction(nameof(AutoDetect), new object[] { config });
+				LogFunction(nameof(AutoDetect), config.ToArray());
 
 				ValidateAutoDetect();
 

--- a/FluentFTP/Client/SyncClient/AutoDetect.cs
+++ b/FluentFTP/Client/SyncClient/AutoDetect.cs
@@ -19,7 +19,7 @@ namespace FluentFTP {
 		public List<FtpProfile> AutoDetect(FtpAutoDetectConfig config = null) {
 
 			lock (m_lock) {
-				LogFunction(nameof(AutoDetect), new object[] { config });
+				LogFunction(nameof(AutoDetect), config);
 
 				ValidateAutoDetect();
 
@@ -39,7 +39,7 @@ namespace FluentFTP {
 		/// <param name="firstOnly">Find all successful profiles (false) or stop after finding the first successful profile (true)</param>
 		/// <param name="cloneConnection">Use a new cloned FtpClient for testing connection profiles (true) or use the source FtpClient (false)</param>
 		/// <returns></returns>
-		public List<FtpProfile> AutoDetect(bool firstOnly, bool cloneConnection = true) {
+		public List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true) {
 
 			lock (m_lock) {
 				LogFunction(nameof(AutoDetect), new object[] { firstOnly, cloneConnection });

--- a/FluentFTP/Client/SyncClient/AutoDetect.cs
+++ b/FluentFTP/Client/SyncClient/AutoDetect.cs
@@ -19,7 +19,7 @@ namespace FluentFTP {
 		public List<FtpProfile> AutoDetect(FtpAutoDetectConfig config = null) {
 
 			lock (m_lock) {
-				LogFunction(nameof(AutoDetect), config.ToArray());
+				LogFunction(nameof(AutoDetect), new object[] { config });
 
 				ValidateAutoDetect();
 

--- a/FluentFTP/Model/Functions/FtpAutoDetectConfig.cs
+++ b/FluentFTP/Model/Functions/FtpAutoDetectConfig.cs
@@ -35,6 +35,16 @@ namespace FluentFTP.Model.Functions {
 			// Do not use "None" - it can connect to TLS13, but Session Resume won't work, so a successful AutoDetect will be a false truth.
 		};
 
+		public object[] ToArray() {
+			return new object[] {
+				"CloneConnection="+CloneConnection,
+				"FirstOnly="+FirstOnly,
+				"IncludeImplicit="+IncludeImplicit,
+				"RequireEncryption="+RequireEncryption,
+				"ProtocolPriority="+ProtocolPriority,
+			};
+		}
 
-	}
+
+}
 }

--- a/FluentFTP/Model/Functions/FtpAutoDetectConfig.cs
+++ b/FluentFTP/Model/Functions/FtpAutoDetectConfig.cs
@@ -29,22 +29,11 @@ namespace FluentFTP.Model.Functions {
 		/// <summary>
 		/// List of protocols to be tried, and the order they should be tried in.
 		/// </summary>
-		public List<SysSslProtocols> ProtocolPriority = new List<SysSslProtocols> {
+		public List<SysSslProtocols> ProtocolPriority { get; set; } = new List<SysSslProtocols> {
 			SysSslProtocols.Tls11 | SysSslProtocols.Tls12,
 			// Do not EVER use "Default". It boils down to "SSL or TLS1.0" or worse.
 			// Do not use "None" - it can connect to TLS13, but Session Resume won't work, so a successful AutoDetect will be a false truth.
 		};
 
-		public object[] ToArray() {
-			return new object[] {
-				"CloneConnection="+CloneConnection,
-				"FirstOnly="+FirstOnly,
-				"IncludeImplicit="+IncludeImplicit,
-				"RequireEncryption="+RequireEncryption,
-				"ProtocolPriority="+ProtocolPriority,
-			};
-		}
-
-
-}
+	}
 }


### PR DESCRIPTION
This is my take on how to do this.

So there is no need to put the 
```cs
		public object[] ToArray() {
			return new object[] {
				"CloneConnection="+CloneConnection,
				"FirstOnly="+FirstOnly,
				"IncludeImplicit="+IncludeImplicit,
				"RequireEncryption="+RequireEncryption,
				"ProtocolPriority="+ProtocolPriority,
			};
```
array as duplicate typing into the config file.

The output is generated automagically (here is an example):
```txt
>         AutoDetect(CloneConnection=true, FirstOnly=false, IncludeImplicit=true, RequireEncryption=false, ProtocolPriority=Tls11 Tls12, ProtocolPriority=Default)
>         AutoConnect()
>         AutoDetect(CloneConnection=false, FirstOnly=true, IncludeImplicit=true, RequireEncryption=false, ProtocolPriority=Tls11 Tls12, ProtocolPriority=Default)
Status:   Auto-Detect trying encryption mode "Auto" with "Tls11, Tls12"
>         Connect(False)
```
**Note:** To show how it works for arrays or lists, I have added a second protocol into the list, which normally contains only one. **it is just an example, one should not use "Default"**

Hopefully, config file objects do not become incredibly complex, as then the serializer must be improved to handle 2nd, 3rd or however deep subchilding.

The simple idea was to use XML serializing outwards on the config object. Then to read it back in as an XML document and to examine the nodes, which lo-and-behold have now been formatted for us.

Since this would be overkill for primitive types (coming from the legacy API call formatting) this is only executed if a true "object" is passed.