### PR TITLE
Add new API function "DownloadUriBytes"

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadUriBytes.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadUriBytes.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
+
+namespace FluentFTP {
+	public partial class AsyncFtpClient {
+
+		/// <summary>
+		/// Downloads the specified uri and return the raw byte array.
+		/// </summary>
+		/// <param name="uri">The uri of the item to download</param>
+		/// <param name="progress">Provide a callback to track download progress.</param>
+		/// <returns>A byte array containing the contents of the downloaded file if successful, otherwise null.</returns>
+		public async Task<byte[]> DownloadUriBytes(string uri, IProgress<FtpProgress> progress = null, CancellationToken token = default(CancellationToken)) {
+			// verify args
+			if (uri.IsBlank()) {
+				throw new ArgumentException("Required parameter is null or blank.", nameof(uri));
+			}
+
+			LogFunction(nameof(DownloadUriBytes), new object[] { uri });
+
+			// Example:
+			// "ftp[s]://username:password@host:port/path"
+
+			var formalUri = new Uri(uri);
+
+			this.Host = formalUri.DnsSafeHost;
+			this.Port = formalUri.Port;
+			string[] userInfo = formalUri.UserInfo.Split(':');
+			this.Credentials.UserName = userInfo[0];
+			this.Credentials.Password = userInfo[1];
+
+			await AutoConnect();
+
+			string remotePath = formalUri.AbsolutePath;
+
+			bool ok;
+			var outStream = new MemoryStream();
+
+			ok = await DownloadFileInternalAsync(null, remotePath, outStream, 0, progress, token, new FtpProgress(1, 0), 0, false, 0);
+
+			await Disconnect();
+
+			return ok ? outStream.ToArray() : null;
+		}
+
+	}
+}

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -12,7 +12,7 @@ namespace FluentFTP {
 		/// <param name="command">The command to execute</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <returns>The servers reply to the command</returns>
-		public async Task<FtpReply> Execute(string command, CancellationToken token) {
+		public async Task<FtpReply> Execute(string command, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 
 			bool reconnect = false;

--- a/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
@@ -97,6 +97,7 @@ namespace FluentFTP {
 		Task<bool> DownloadStream(Stream outStream, string remotePath, long restartPosition = 0, IProgress<FtpProgress> progress = null, CancellationToken token = default(CancellationToken), long stopPosition = 0);
 		Task<byte[]> DownloadBytes(string remotePath, long restartPosition = 0, IProgress<FtpProgress> progress = null, CancellationToken token = default(CancellationToken), long stopPosition = 0);
 		Task<byte[]> DownloadBytes(string remotePath, CancellationToken token = default(CancellationToken));
+		Task<byte[]> DownloadUriBytes(string uri, IProgress<FtpProgress> progress = null, CancellationToken token = default(CancellationToken));
 
 		Task<List<FtpResult>> DownloadDirectory(string localFolder, string remoteFolder, FtpFolderSyncMode mode = FtpFolderSyncMode.Update, FtpLocalExists existsMode = FtpLocalExists.Skip, FtpVerify verifyOptions = FtpVerify.None, List<FtpRule> rules = null, IProgress<FtpProgress> progress = null, CancellationToken token = default(CancellationToken));
 		Task<List<FtpResult>> UploadDirectory(string localFolder, string remoteFolder, FtpFolderSyncMode mode = FtpFolderSyncMode.Update, FtpRemoteExists existsMode = FtpRemoteExists.Skip, FtpVerify verifyOptions = FtpVerify.None, List<FtpRule> rules = null, IProgress<FtpProgress> progress = null, CancellationToken token = default(CancellationToken));

--- a/FluentFTP/Client/Interfaces/IFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IFtpClient.cs
@@ -88,6 +88,7 @@ namespace FluentFTP {
 		FtpStatus DownloadFile(string localPath, string remotePath, FtpLocalExists existsMode = FtpLocalExists.Overwrite, FtpVerify verifyOptions = FtpVerify.None, Action<FtpProgress> progress = null);
 		bool DownloadStream(Stream outStream, string remotePath, long restartPosition = 0, Action<FtpProgress> progress = null, long stopPosition = 0);
 		bool DownloadBytes(out byte[] outBytes, string remotePath, long restartPosition = 0, Action<FtpProgress> progress = null, long stopPosition = 0);
+		bool DownloadUriBytes(out byte[] outBytes, string uri, Action<FtpProgress> progress = null);
 
 		List<FtpResult> DownloadDirectory(string localFolder, string remoteFolder, FtpFolderSyncMode mode = FtpFolderSyncMode.Update, FtpLocalExists existsMode = FtpLocalExists.Skip, FtpVerify verifyOptions = FtpVerify.None, List<FtpRule> rules = null, Action<FtpProgress> progress = null);
 		List<FtpResult> UploadDirectory(string localFolder, string remoteFolder, FtpFolderSyncMode mode = FtpFolderSyncMode.Update, FtpRemoteExists existsMode = FtpRemoteExists.Skip, FtpVerify verifyOptions = FtpVerify.None, List<FtpRule> rules = null, Action<FtpProgress> progress = null);

--- a/FluentFTP/Client/SyncClient/DownloadUriBytes.cs
+++ b/FluentFTP/Client/SyncClient/DownloadUriBytes.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+
+using FluentFTP.Helpers;
+
+namespace FluentFTP {
+	public partial class FtpClient {
+
+		/// <summary>
+		/// Downloads the specified uri and return the raw byte array.
+		/// </summary>
+		/// <param name="outBytes">The variable that will receive the bytes.</param>
+		/// <param name="uri">The uri of the item to download</param>
+		/// <param name="progress">Provide a callback to track download progress.</param>
+		/// <returns>Downloaded byte array</returns>
+		public bool DownloadUriBytes(out byte[] outBytes, string uri, Action<FtpProgress> progress = null) {
+			// verify args
+			if (uri.IsBlank()) {
+				throw new ArgumentException("Required parameter is null or blank.", nameof(uri));
+			}
+
+			LogFunction(nameof(DownloadUriBytes), new object[] { uri });
+
+			// Example:
+			// "ftp[s]://username:password@host:port/path"
+
+			var formalUri = new Uri(uri);
+
+			this.Host = formalUri.DnsSafeHost;
+			this.Port = formalUri.Port;
+			string[] userInfo = formalUri.UserInfo.Split(':');
+			this.Credentials.UserName = userInfo[0];
+			this.Credentials.Password = userInfo[1];
+
+			AutoConnect();
+
+			string remotePath = formalUri.AbsolutePath;
+
+			outBytes = null;
+
+			bool ok;
+			using (var outStream = new MemoryStream()) {
+				ok = DownloadFileInternal(null, remotePath, outStream, 0, progress, new FtpProgress(1, 0), 0, false, 0);
+				if (ok) {
+					outBytes = outStream.ToArray();
+				}
+			}
+
+			Disconnect();
+
+			return ok; 
+		}
+
+	}
+}


### PR DESCRIPTION
After a rather strange discourse on issue #1320, from which one small idea stands out:

"It would be nice to have a (more or less) one-liner replacement for ...GetBytes(ftp_uri) as seen in .NET with HttpClient".

Apart from the fact that Microsoft is neglecting, deprecating or dropping most of its interfaces to ftp, this approach is not as flexible as having full control over the way an ftp server is accessed.

Nonetheless, here is a quick way to get something from an ftp url and let's add it to the API (the code to do this is simple, I wonder what the TO was ranting about):

**`DownloadUriBytes(...)`**

Sample code shows up the functionality and ease of use:

```cs
using (var client = new FtpClient()) {

	// Add config statements as needed, for example:
	client.Config.ValidateAnyCertificate = true;

	byte[] outBytes;

	// Just do the download, no need to connect, disconnect, it will be done for you.
	client.DownloadUriBytes(out outBytes, "ftps://myuser:mypass@myftpserver.com:21/var/log/test1.log");

}
```