### PR TITLE
Get object info

### DIFF
--- a/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
+++ b/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
@@ -61,6 +61,9 @@ namespace FluentFTP {
 							result = CurrentListParser.ParseSingleLine(null, info.ToString(), m_capabilities, true);
 						}
 					}
+					else {
+						LogWithPrefix(FtpTraceLevel.Warn, "Failed to get object info for path " + path + " with error: Null response");
+					}
 				}
 				else {
 					LogWithPrefix(FtpTraceLevel.Warn, "Failed to get object info for path " + path + " with error " + reply.ErrorMessage);
@@ -79,7 +82,9 @@ namespace FluentFTP {
 					}
 				}
 
-				LogWithPrefix(FtpTraceLevel.Warn, "Failed to get object info for path " + path + " since MLST not supported and GetListing() fails to list file/folder.");
+				if (result == null) {
+					LogWithPrefix(FtpTraceLevel.Warn, "Failed to get object info for path " + path + " using \"GetListing(...)\", MLST not supported.");
+				}
 			}
 
 			// Get the accurate date modified using another MDTM command

--- a/FluentFTP/Client/SyncClient/GetObjectInfo.cs
+++ b/FluentFTP/Client/SyncClient/GetObjectInfo.cs
@@ -53,6 +53,9 @@ namespace FluentFTP {
 							result = CurrentListParser.ParseSingleLine(null, info.ToString(), m_capabilities, true);
 						}
 					}
+					else {
+						LogWithPrefix(FtpTraceLevel.Warn, "Failed to get object info for path " + path + " with error: Null response");
+					}
 				}
 				else {
 					LogWithPrefix(FtpTraceLevel.Warn, "Failed to get object info for path " + path + " with error " + reply.ErrorMessage);
@@ -71,7 +74,9 @@ namespace FluentFTP {
 					}
 				}
 
-				LogWithPrefix(FtpTraceLevel.Warn, "Failed to get object info for path " + path + " since MLST not supported and GetListing() fails to list file/folder.");
+				if (result == null) {
+					LogWithPrefix(FtpTraceLevel.Warn, "Failed to get object info for path " + path + " using \"GetListing(...)\", MLST not supported.");
+				}
 			}
 
 			// Get the accurate date modified using another MDTM command


### PR DESCRIPTION
When MLSD is not supported, GetListing is used.

That's fine, but even if this is successfull, a warning message is issued anyway, saying that the GetLising failed.

Helpful for (but not a fix for) issue #1324