### PR TITLE
Ignore stale data after OpenRead/OpenWrite

### DIFF
--- a/FluentFTP/Client/AsyncClient/Authenticate.cs
+++ b/FluentFTP/Client/AsyncClient/Authenticate.cs
@@ -45,7 +45,7 @@ namespace FluentFTP {
 
 				// fix for #620: some servers send multiple responses that must be read and decoded,
 				// otherwise the connection is aborted and remade and it goes into an infinite loop
-				var staleData = await ReadStaleDataAsync(true, "in authentication", token);
+				var staleData = await ReadStaleDataAsync("in authentication", token);
 				if (staleData != null) {
 					var staleReply = new FtpReply();
 					if (DecodeStringToReply(staleData, ref staleReply) && !staleReply.Success) {

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -41,9 +41,9 @@ namespace FluentFTP {
 			// Check for stale data on the socket?
 			else if (Config.StaleDataCheck && Status.AllowCheckStaleData) {
 #if NETSTANDARD
-				var staleData = await ReadStaleDataAsync(true, "prior to command execution of \"" + command.Split()[0] + "\"", token);
+				var staleData = await ReadStaleDataAsync("prior to command execution of \"" + command.Split()[0] + "\"", token);
 #else
-				var staleData = ReadStaleData(true, "prior to command execution of \"" + command.Split()[0] + "\"");
+				var staleData = ReadStaleData("prior to command execution of \"" + command.Split()[0] + "\"");
 #endif
 
 				if (staleData != null) {

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -41,9 +41,9 @@ namespace FluentFTP {
 			// Check for stale data on the socket?
 			else if (Config.StaleDataCheck && Status.AllowCheckStaleData) {
 #if NETSTANDARD
-				var staleData = await ReadStaleDataAsync(true, "prior to command execution", token);
+				var staleData = await ReadStaleDataAsync(true, "prior to command execution of \"" + command.Split()[0] + "\"", token);
 #else
-				var staleData = ReadStaleData(true, "prior to command execution");
+				var staleData = ReadStaleData(true, "prior to command execution of \"" + command.Split()[0] + "\"");
 #endif
 
 				if (staleData != null) {

--- a/FluentFTP/Client/AsyncClient/OpenRead.cs
+++ b/FluentFTP/Client/AsyncClient/OpenRead.cs
@@ -72,6 +72,8 @@ namespace FluentFTP {
 				}
 			}
 
+			Status.IgnoreStaleData = true;
+
 			return stream;
 		}
 

--- a/FluentFTP/Client/AsyncClient/OpenWrite.cs
+++ b/FluentFTP/Client/AsyncClient/OpenWrite.cs
@@ -62,6 +62,8 @@ namespace FluentFTP {
 				stream.SetLength(length);
 			}
 
+			Status.IgnoreStaleData = true;
+
 			return stream;
 		}
 

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -38,7 +38,7 @@ namespace FluentFTP.Client.BaseClient {
 				}
 				// Check for stale data on the socket?
 				else if (Config.StaleDataCheck && Status.AllowCheckStaleData) {
-					var staleData = ReadStaleData(true, "prior to command execution");
+					var staleData = ReadStaleData(true, "prior to command execution of \"" + command.Split()[0] + "\"");
 
 					if (staleData != null) {
 						reconnect = true;

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -38,7 +38,7 @@ namespace FluentFTP.Client.BaseClient {
 				}
 				// Check for stale data on the socket?
 				else if (Config.StaleDataCheck && Status.AllowCheckStaleData) {
-					var staleData = ReadStaleData(true, "prior to command execution of \"" + command.Split()[0] + "\"");
+					var staleData = ReadStaleData("prior to command execution of \"" + command.Split()[0] + "\"");
 
 					if (staleData != null) {
 						reconnect = true;

--- a/FluentFTP/Client/BaseClient/ReadStaleData.cs
+++ b/FluentFTP/Client/BaseClient/ReadStaleData.cs
@@ -15,12 +15,12 @@ namespace FluentFTP.Client.BaseClient {
 		/// </summary>
 		/// <param name="logData">copy stale data information to logs?</param>
 		/// <param name="logFrom">for the log information</param>
-		protected string ReadStaleData(bool logData, string logFrom) {
+		protected string ReadStaleData(string logFrom) {
 			string staleData = null;
 
 			if (m_stream != null) {
 
-				if (m_stream.SocketDataAvailable > 0 && logData) {
+				if (m_stream.SocketDataAvailable > 0) {
 					LogWithPrefix(FtpTraceLevel.Info, "Control connection has stale data - " + logFrom);
 				}
 
@@ -35,7 +35,7 @@ namespace FluentFTP.Client.BaseClient {
 					staleData += Encoding.GetString(buf).TrimEnd('\0', '\r', '\n') + Environment.NewLine;
 				}
 
-				if (!string.IsNullOrEmpty(staleData) && logData) {
+				if (!string.IsNullOrEmpty(staleData)) {
 					LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: ");
 					string[] staleLines = Regex.Split(staleData, Environment.NewLine);
 					foreach (string staleLine in staleLines) {
@@ -66,12 +66,12 @@ namespace FluentFTP.Client.BaseClient {
 		/// <param name="logData">copy stale data information to logs?</param>
 		/// <param name="logFrom">called from where (text)</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
-		protected async Task<string> ReadStaleDataAsync(bool logData, string logFrom, CancellationToken token) {
+		protected async Task<string> ReadStaleDataAsync(string logFrom, CancellationToken token) {
 			string staleData = null;
 
 			if (m_stream != null) {
 
-				if (m_stream.SocketDataAvailable > 0 && logData) {
+				if (m_stream.SocketDataAvailable > 0) {
 					LogWithPrefix(FtpTraceLevel.Info, "Socket has stale data - " + logFrom);
 				}
 
@@ -86,7 +86,7 @@ namespace FluentFTP.Client.BaseClient {
 					staleData += Encoding.GetString(buf).TrimEnd('\0', '\r', '\n') + Environment.NewLine;
 				}
 
-				if (!string.IsNullOrEmpty(staleData) && logData) {
+				if (!string.IsNullOrEmpty(staleData)) {
 					LogWithPrefix(FtpTraceLevel.Verbose, "The stale data was: ");
 					string[] staleLines = Regex.Split(staleData, Environment.NewLine);
 					foreach (string staleLine in staleLines) {

--- a/FluentFTP/Client/BaseClient/ReadStaleData.cs
+++ b/FluentFTP/Client/BaseClient/ReadStaleData.cs
@@ -45,6 +45,12 @@ namespace FluentFTP.Client.BaseClient {
 					}
 				}
 
+				if (Status.IgnoreStaleData) {
+					Status.IgnoreStaleData = false;
+					LogWithPrefix(FtpTraceLevel.Verbose, "Stale data ignored");
+					return null;
+				}
+
 			}
 
 			return staleData;
@@ -88,6 +94,12 @@ namespace FluentFTP.Client.BaseClient {
 					}
 				}
 
+			}
+
+			if (Status.IgnoreStaleData) {
+				Status.IgnoreStaleData = false;
+				LogWithPrefix(FtpTraceLevel.Verbose, "Stale data ignored");
+				return null;
 			}
 
 			return staleData;

--- a/FluentFTP/Client/BaseClient/ReadStaleData.cs
+++ b/FluentFTP/Client/BaseClient/ReadStaleData.cs
@@ -45,12 +45,14 @@ namespace FluentFTP.Client.BaseClient {
 					}
 				}
 
-				if (Status.IgnoreStaleData) {
-					Status.IgnoreStaleData = false;
-					LogWithPrefix(FtpTraceLevel.Verbose, "Stale data ignored");
-					return null;
-				}
+			}
 
+			if (Status.IgnoreStaleData) {
+				Status.IgnoreStaleData = false;
+				if (staleData != null) {
+					LogWithPrefix(FtpTraceLevel.Verbose, "Stale data ignored");
+					staleData = null;
+				}
 			}
 
 			return staleData;
@@ -98,8 +100,10 @@ namespace FluentFTP.Client.BaseClient {
 
 			if (Status.IgnoreStaleData) {
 				Status.IgnoreStaleData = false;
-				LogWithPrefix(FtpTraceLevel.Verbose, "Stale data ignored");
-				return null;
+				if (staleData != null) {
+					LogWithPrefix(FtpTraceLevel.Verbose, "Stale data ignored");
+					staleData = null;
+				}
 			}
 
 			return staleData;

--- a/FluentFTP/Client/SyncClient/Authenticate.cs
+++ b/FluentFTP/Client/SyncClient/Authenticate.cs
@@ -46,7 +46,7 @@ namespace FluentFTP {
 
 				// fix for #620: some servers send multiple responses that must be read and decoded,
 				// otherwise the connection is aborted and remade and it goes into an infinite loop
-				var staleData = ReadStaleData(true, "in authentication");
+				var staleData = ReadStaleData("in authentication");
 				if (staleData != null) {
 					var staleReply = new FtpReply();
 					if (DecodeStringToReply(staleData, ref staleReply) && !staleReply.Success) {

--- a/FluentFTP/Client/SyncClient/OpenRead.cs
+++ b/FluentFTP/Client/SyncClient/OpenRead.cs
@@ -71,6 +71,8 @@ namespace FluentFTP {
 				}
 			}
 
+			Status.IgnoreStaleData = true;
+
 			return stream;
 		}
 

--- a/FluentFTP/Client/SyncClient/OpenWrite.cs
+++ b/FluentFTP/Client/SyncClient/OpenWrite.cs
@@ -63,6 +63,9 @@ namespace FluentFTP {
 				}
 
 			}
+
+			Status.IgnoreStaleData = true;
+
 			return stream;
 		}
 

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -78,6 +78,12 @@ namespace FluentFTP {
 		/// </summary>
 		public int ConnectCount { get; set; } = 0;
 
+		/// <summary>
+		/// Stale date will be on the control connection
+		/// Ignore it
+		/// </summary>
+		public bool IgnoreStaleData { get; set; } = false;
+
         /// <summary>
 		/// These flags must be reset every time we connect, to allow for users to connect to
 		/// different FTP servers with the same client object.

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -630,8 +630,12 @@ namespace FluentFTP {
 		internal bool ShouldAutoNavigate(string absPath) {
 			var navToDir = Navigate.HasFlag(FtpNavigate.Auto) || Navigate.HasFlag(FtpNavigate.SemiAuto);
 			var navOnlyIfBlanks = Navigate.HasFlag(FtpNavigate.Conditional);
-			var autoNav = navToDir && (!navOnlyIfBlanks || (navOnlyIfBlanks && absPath.Contains(" ")));
-			return autoNav;
+			if (!navOnlyIfBlanks) {
+				return navToDir;
+			}
+			else {
+				return absPath.Contains(" ");
+			}
 		}
 		internal bool ShouldAutoRestore(string absPath) {
 			if (Navigate.HasFlag(FtpNavigate.SemiAuto)) {


### PR DESCRIPTION
This will alleviate problems caused by users **still** using the obsolete OpenRead API function.

In the beginning, OpenRead would leave stale data (its success or failure response) on the socket. Users would typically just leave it there, or some might pick it up with a `GetReply(...)`.

Then, someone decided to handle stale data which occasionaly caused commands and replys to go out of sync, and decided to reconnect. Which didn't work initially anyway.

As things got fixed, stale data was handled more and more strictly, thus OpenRead was now causing real problems.

This fix alleviates this, but it does not recognize any failures.

