### PR TITLE
GetReply, if used after OpenRead, should turn off ignoreStaleData

### DIFF
--- a/FluentFTP/Client/AsyncClient/GetReply.cs
+++ b/FluentFTP/Client/AsyncClient/GetReply.cs
@@ -14,7 +14,7 @@ namespace FluentFTP {
 		/// </summary>
 		/// <param name="token">The token that can be used to cancel the entire process.</param>
 		/// <returns>FtpReply representing the response from the server</returns>
-		public async Task<FtpReply> GetReply(CancellationToken token) {
+		public async Task<FtpReply> GetReply(CancellationToken token = default(CancellationToken)) {
 			return await GetReplyAsyncInternal(token, null, false, 0);
 		}
 
@@ -63,6 +63,8 @@ namespace FluentFTP {
 			else {
 				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + LogMaskModule.MaskCommand(this, command));
 			}
+
+			Status.IgnoreStaleData = false;
 
 			string sequence = string.Empty;
 

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -65,6 +65,8 @@ namespace FluentFTP.Client.BaseClient {
 					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + LogMaskModule.MaskCommand(this, command));
 				}
 
+				Status.IgnoreStaleData = false;
+
 				string sequence = string.Empty;
 
 				string response;


### PR DESCRIPTION
As a final final touch, if a user executes `GetReply(...)` himself after using `OpenRead(...)`, we can turn off the boolen `Status.IgnoreStaleData`, as a reply will not be forthcoming.