### PR TITLE
Fix #1358 Bug 2... NLST reports 450 on empty folder

### DIFF
--- a/FluentFTP/Client/SyncClient/GetNameListing.cs
+++ b/FluentFTP/Client/SyncClient/GetNameListing.cs
@@ -76,8 +76,9 @@ namespace FluentFTP {
 					// and the connection fails because no communication socket is provided by the server
 				}
 				catch (FtpCommandException ftpEx) {
-					// Some FTP servers throw 550 for empty folders. Absorb these.
-					if (ftpEx.CompletionCode == null || !ftpEx.CompletionCode.StartsWith("550")) {
+					// Some FTP servers throw 450 or 550 for empty folders. Absorb these.
+					if (ftpEx.CompletionCode == null ||
+						(!ftpEx.CompletionCode.StartsWith("450") && !ftpEx.CompletionCode.StartsWith("550")) {
 						throw ftpEx;
 					}
 				}


### PR DESCRIPTION
"Some FTP servers throw 550 for empty folders. Absorb these..."

Well, now here is one that issues "450".

Added to the IF statement.