### PR TITLE
Timeouts during auto detection

### DIFF
--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -115,7 +115,7 @@ namespace FluentFTP.Client.Modules {
 						}
 
 						// check if permanent failures and hard abort
-						var permaEx = IsPermanentConnectionFailure(ex);
+						var permaEx = IsPermanentConnectionFailure(ex, config.AbortOnTimeout);
 						if (permaEx != null) {
 							if (config.CloneConnection) {
 								conn.Dispose();
@@ -209,7 +209,7 @@ namespace FluentFTP.Client.Modules {
 
 				// try each SSL protocol
 				foreach (var protocol in config.ProtocolPriority) {
-					// Only check the first combination for FtpEncryptionMode.None 
+					// Only check the first combination for FtpEncryptionMode.None
 					if (encryption == FtpEncryptionMode.None && config.ProtocolPriority.IndexOf(protocol) > 0) {
 						continue;
 					}
@@ -250,7 +250,7 @@ namespace FluentFTP.Client.Modules {
 						}
 
 						// check if permanent failures and hard abort
-						var permaEx = IsPermanentConnectionFailure(ex);
+						var permaEx = IsPermanentConnectionFailure(ex, config.AbortOnTimeout);
 						if (permaEx != null) {
 							if (config.CloneConnection) {
 								conn.Dispose();
@@ -374,7 +374,7 @@ namespace FluentFTP.Client.Modules {
 		/// so that we don't need to retry all the connection config combinations and can hard-abort the AutoConnect.
 		/// Return the exception if it is a hard failure, or null if no issue is found.
 		/// </summary>
-		private static Exception IsPermanentConnectionFailure(Exception ex) {
+		private static Exception IsPermanentConnectionFailure(Exception ex, bool treatTimeoutAsPermanent) {
 
 			// Authentication related failures
 
@@ -396,7 +396,7 @@ namespace FluentFTP.Client.Modules {
 			}
 
 			// catch error "timed out trying to connect" and hard abort
-			if (ex is TimeoutException) {
+			if (ex is TimeoutException && treatTimeoutAsPermanent) {
 				return ex;
 			}
 

--- a/FluentFTP/Model/Functions/FtpAutoDetectConfig.cs
+++ b/FluentFTP/Model/Functions/FtpAutoDetectConfig.cs
@@ -21,6 +21,11 @@ namespace FluentFTP.Model.Functions {
 		public bool IncludeImplicit { get; set; } = true;
 
 		/// <summary>
+		/// If true, timeouts will lead to an exception, otherwise we will try the next profile.
+		/// </summary>
+		public bool AbortOnTimeout { get; set; } = true;
+
+		/// <summary>
 		/// If true, then we will not try the insecure FTP unencrypted mode, and only try FTPS.
 		/// If false, then both FTP and FTPS will be tried.
 		/// </summary>


### PR DESCRIPTION
I added an option to treat timeouts during the autodetection as a failed detection attempt, instead of aborting with an exception.

# Adjustments

- I added a boolean property `AbortOnTimeout` to the `FtpAutoDetectConfig` which is `true` by default.
- I adjusted the `ConnectModule` to honor the flag and treat TimeoutExceptions accordingly.

# Background

I use FluentFTP in a .NET 4.6.2 project and I had an issue connecting to a FileZilla server with FTPS enabled.
While my code works in .NET 5 and higher, I get a Timeout error with 4.6.2.
Investigating this, I determined that the Socket internally is getting the error 997 (IO PENDING), which should not necessarily be an aborting error, but is not handled my the .NET Framework. 

FluentFTP is throwing a `TimeoutException` whenever the Socket is not connected after calling .Connect(), no matter what the real cause was.

# Alternative Ideas
I do not understand why `TimeoutExceptions` should ever be treated as aborting errors during AutoDetect. In my understanding a timeout means that the configuration which has been tried did not work, but not that no configuration can work.

So I think a better solution would be to just remove the TimeoutException from the permanent errors, but I did not want to change the current behavior so drastically without knowing enough.