### PR TITLE
Fix for 1371, 1358

### DIFF
--- a/FluentFTP/Client/SyncClient/FileExists.cs
+++ b/FluentFTP/Client/SyncClient/FileExists.cs
@@ -27,7 +27,7 @@ namespace FluentFTP {
 
 				// since FTP does not include a specific command to check if a file exists
 				// here we check if file exists by attempting to get its filesize (SIZE)
-				if (HasFeature(FtpCapability.SIZE) && ServerHandler != null && !ServerHandler.DontUseSizeEvenIfCapable(path)) {
+				if (HasFeature(FtpCapability.SIZE) && (ServerHandler == null || (ServerHandler != null && !ServerHandler.DontUseSizeEvenIfCapable(path)))) {
 					// Fix #328: get filesize in ASCII or Binary mode as required by server
 					var sizeReply = new FtpSizeReply();
 					GetFileSizeInternal(path, sizeReply, -1);
@@ -40,7 +40,7 @@ namespace FluentFTP {
 				}
 
 				// check if file exists by attempting to get its date modified (MDTM)
-				if (HasFeature(FtpCapability.MDTM) && ServerHandler != null && !ServerHandler.DontUseMdtmEvenIfCapable(path)) {
+				if (HasFeature(FtpCapability.MDTM) && (ServerHandler == null || (ServerHandler != null && !ServerHandler.DontUseMdtmEvenIfCapable(path)))) {
 					var reply = Execute("MDTM " + path);
 					var ch = reply.Code[0];
 					if (ch == '2') {


### PR DESCRIPTION
Finally managed to debug why in case there **is no server handler** assigned or detected, `FileExists(...)` will ignore the SIZE FEAT and use NLST instead.
