### PR TITLE
AutoDetect GetWorkingProfileFromHost not thread safe

### DIFF
--- a/FluentFTP.Tests/Unit/HelperTests.cs
+++ b/FluentFTP.Tests/Unit/HelperTests.cs
@@ -18,7 +18,7 @@ namespace FluentFTP.Tests.Unit {
 			var obj = new FtpAutoDetectConfig();
 			var txt = ValuePrinter.ObjectToString(obj);
 
-			Assert.Equal(txt, "CloneConnection = True, FirstOnly = True, IncludeImplicit = True, RequireEncryption = False, ProtocolPriority = [Tls11, Tls12]");
+			Assert.Equal(txt, "CloneConnection = True, FirstOnly = True, IncludeImplicit = True, AbortOnTimeout = True, RequireEncryption = False, ProtocolPriority = [Tls11, Tls12]");
 		}
 
 	}

--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -41,7 +41,7 @@ namespace FluentFTP.Client.Modules {
 				encryptionsPriority.Add(FtpEncryptionMode.None);
 			}
 
-			if (!config.IncludeImplicit) {
+			if (config.IncludeImplicit) {
 				encryptionsPriority.Add(FtpEncryptionMode.Implicit);
 			}
 
@@ -178,7 +178,7 @@ namespace FluentFTP.Client.Modules {
 				encryptionsPriority.Add(FtpEncryptionMode.None);
 			}
 
-			if (!config.IncludeImplicit) {
+			if (config.IncludeImplicit) {
 				encryptionsPriority.Add(FtpEncryptionMode.Implicit);
 			}
 

--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -17,7 +17,7 @@ namespace FluentFTP.Client.Modules {
 	/// </summary>
 	internal static class ConnectModule {
 
-		private static List<FtpEncryptionMode> DefaultEncryptionPriority = new List<FtpEncryptionMode> {
+		private static List<FtpEncryptionMode> DefaultEncryptionsPriority = new List<FtpEncryptionMode> {
 			FtpEncryptionMode.Auto,
 		};
 
@@ -35,17 +35,19 @@ namespace FluentFTP.Client.Modules {
 				config = new FtpAutoDetectConfig();
 			}
 
+			List<FtpEncryptionMode> encryptionsPriority = DefaultEncryptionsPriority.ShallowClone(); ;
+
 			if (!config.RequireEncryption) {
-				DefaultEncryptionPriority.Add(FtpEncryptionMode.None);
+				encryptionsPriority.Add(FtpEncryptionMode.None);
 			}
 
 			if (!config.IncludeImplicit) {
-				DefaultEncryptionPriority.Add(FtpEncryptionMode.Implicit);
+				encryptionsPriority.Add(FtpEncryptionMode.Implicit);
 			}
 
 			// get known working connection profile based on the host (if any)
 			List<FtpEncryptionMode> encryptionsToTry;
-			var knownProfile = GetWorkingProfileFromHost(client.Host, out encryptionsToTry);
+			var knownProfile = GetWorkingProfileFromHost(client.Host, encryptionsPriority, out encryptionsToTry);
 
 			var blacklistedEncryptions = new List<FtpEncryptionMode>();
 			bool resetPort = (client.Port == 990 || client.Port == 21);
@@ -170,17 +172,19 @@ namespace FluentFTP.Client.Modules {
 				config = new FtpAutoDetectConfig();
 			}
 
+			List<FtpEncryptionMode> encryptionsPriority = DefaultEncryptionsPriority.ShallowClone(); ;
+
 			if (!config.RequireEncryption) {
-				DefaultEncryptionPriority.Add(FtpEncryptionMode.None);
+				encryptionsPriority.Add(FtpEncryptionMode.None);
 			}
 
 			if (!config.IncludeImplicit) {
-				DefaultEncryptionPriority.Add(FtpEncryptionMode.Implicit);
+				encryptionsPriority.Add(FtpEncryptionMode.Implicit);
 			}
 
 			// get known working connection profile based on the host (if any)
 			List<FtpEncryptionMode> encryptionsToTry;
-			var knownProfile = GetWorkingProfileFromHost(client.Host, out encryptionsToTry);
+			var knownProfile = GetWorkingProfileFromHost(client.Host, encryptionsPriority, out encryptionsToTry);
 
 			var blacklistedEncryptions = new List<FtpEncryptionMode>();
 			bool resetPort = (client.Port == 990 || client.Port == 21);
@@ -481,9 +485,9 @@ namespace FluentFTP.Client.Modules {
 		/// <summary>
 		/// Return a known working connection profile from the host/port combination.
 		/// </summary>
-		public static FtpProfile GetWorkingProfileFromHost(string host, out List<FtpEncryptionMode> encryptionsToTry) {
+		public static FtpProfile GetWorkingProfileFromHost(string host, List<FtpEncryptionMode> encryptionsPriority, out List<FtpEncryptionMode> encryptionsToTry) {
 
-			encryptionsToTry = DefaultEncryptionPriority.ShallowClone();
+			encryptionsToTry = encryptionsPriority.ShallowClone();
 
 			// Azure App Services / Azure Websites
 			if (host.IndexOf("azurewebsites.windows.net", StringComparison.OrdinalIgnoreCase) > -1) {

--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -17,7 +17,7 @@ namespace FluentFTP.Client.Modules {
 	/// </summary>
 	internal static class ConnectModule {
 
-		private static List<FtpEncryptionMode> DefaultEncryptionsPriority = new List<FtpEncryptionMode> {
+		private static readonly List<FtpEncryptionMode> DefaultEncryptionsPriority = new List<FtpEncryptionMode> {
 			FtpEncryptionMode.Auto,
 		};
 


### PR DESCRIPTION
47.1.0 introduced a "Config" object for AutoDetect(...).

This uses a static list, which is then modified by the config options.

In a multi-threaded environment (multiple AutoDetects running at the same time), such a construct is not thread safe.

Fixes: #1384

Basically, create a working copy of the static list in the static method which is then used internally after it is modified.

Mark the static list as readonly

Fix a small logic error for IncludeImplicit

Update helper tests to run cleanly on current config object

Checked integration tests