### PR TITLE
Update FtpSocketStream.cs to fix apparent typo "#if NET50_OR_LATER" to "#if NET5_0_OR_GREATER"

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1433,7 +1433,7 @@ namespace FluentFTP {
 			// So the user would like buffering. But we might need to ignore this request
 			bool useBuffering = true;
 
-#if NET50_OR_LATER
+#if NET5_0_OR_GREATER
 			// Fix: running on .NET 5.0 and later due to issues in .NET framework - See #682
 			if (bufferingConfigured /*&& NET50_OR_LATER*/) {
 				useBuffering = false;


### PR DESCRIPTION
Appears to be a typo. Updating the directive to "NET5_0_OR_GREATER", matching other examples in the same file also "unhides" the code as expected in visual studio.