### PR TITLE
Clean up usage of Target Symbols in code and csproj

### DIFF
--- a/FluentFTP.CSharpExamples/CSharpExamples.csproj
+++ b/FluentFTP.CSharpExamples/CSharpExamples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net50</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<OutputType>Library</OutputType>
 		<LangVersion>latest</LangVersion>
 		<ApplicationIcon />

--- a/FluentFTP/Client/AsyncClient/DownloadFile.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFile.cs
@@ -72,7 +72,7 @@ namespace FluentFTP {
 			// skip downloading if the local file exists
 			long knownFileSize = 0;
 			long restartPos = 0;
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			if (existsMode == FtpLocalExists.Resume && await Task.Run(() => File.Exists(localPath), token)) {
 				knownFileSize = (await GetFileSize(remotePath, -1, token));
 				restartPos = await FtpFileStream.GetFileSizeAsync(localPath, false, token);
@@ -90,7 +90,7 @@ namespace FluentFTP {
 					isAppend = true;
 				}
 			}
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			else if (existsMode == FtpLocalExists.Skip && await Task.Run(() => File.Exists(localPath), token)) {
 #else
 			else if (existsMode == FtpLocalExists.Skip && File.Exists(localPath)) {
@@ -102,7 +102,7 @@ namespace FluentFTP {
 			try {
 				// create the folders
 				var dirPath = Path.GetDirectoryName(localPath);
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 				if (!string.IsNullOrWhiteSpace(dirPath) && !await Task.Run(() => Directory.Exists(dirPath), token)) {
 #else
 				if (!string.IsNullOrWhiteSpace(dirPath) && !Directory.Exists(dirPath)) {

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -42,7 +42,7 @@ namespace FluentFTP {
 
 			// Check for stale data on the socket?
 			else if (Config.StaleDataCheck && Status.AllowCheckStaleData) {
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 				var staleData = await ReadStaleDataAsync("prior to command execution of \"" + command.Split()[0] + "\"", token);
 #else
 				var staleData = ReadStaleData("prior to command execution of \"" + command.Split()[0] + "\"");

--- a/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
@@ -33,9 +33,10 @@ namespace FluentFTP {
 			StartListeningOnPort(stream);
 #if NETSTANDARD || NET5_0_OR_GREATER
 			var args = stream.BeginAccept();
-#endif
-#if NETFRAMEWORK
+#elif NETFRAMEWORK
 			var ar = stream.BeginAccept(null, null);
+#else
+#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 			if (type is FtpDataConnectionType.EPRT or FtpDataConnectionType.AutoActive) {
@@ -114,8 +115,7 @@ namespace FluentFTP {
 
 #if NETSTANDARD || NET5_0_OR_GREATER
 			stream.EndAccept(args, Config.DataConnectionConnectTimeout);
-#endif
-#if NETFRAMEWORK
+#elif NETFRAMEWORK
 			ar.AsyncWaitHandle.WaitOne(Config.DataConnectionConnectTimeout);
 			if (Type.GetType("Mono.Runtime") == null) {
 				ar.AsyncWaitHandle.Close();  // See issue #648 this needs to be commented out for MONO
@@ -126,6 +126,8 @@ namespace FluentFTP {
 			}
 
 			stream.EndAccept(ar);
+#else
+#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 			if (Config.DataConnectionEncryption && Config.EncryptionMode != FtpEncryptionMode.None && !Status.ConnectionFTPSFailure) {

--- a/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
@@ -33,10 +33,9 @@ namespace FluentFTP {
 			StartListeningOnPort(stream);
 #if NETSTANDARD || NET5_0_OR_GREATER
 			var args = stream.BeginAccept();
-#elif NETFRAMEWORK
+#endif
+#if NETFRAMEWORK
 			var ar = stream.BeginAccept(null, null);
-#else
-#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 			if (type is FtpDataConnectionType.EPRT or FtpDataConnectionType.AutoActive) {
@@ -115,7 +114,8 @@ namespace FluentFTP {
 
 #if NETSTANDARD || NET5_0_OR_GREATER
 			stream.EndAccept(args, Config.DataConnectionConnectTimeout);
-#elif NETFRAMEWORK
+#endif
+#if NETFRAMEWORK
 			ar.AsyncWaitHandle.WaitOne(Config.DataConnectionConnectTimeout);
 			if (Type.GetType("Mono.Runtime") == null) {
 				ar.AsyncWaitHandle.Close();  // See issue #648 this needs to be commented out for MONO
@@ -126,8 +126,6 @@ namespace FluentFTP {
 			}
 
 			stream.EndAccept(ar);
-#else
-#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 			if (Config.DataConnectionEncryption && Config.EncryptionMode != FtpEncryptionMode.None && !Status.ConnectionFTPSFailure) {

--- a/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
@@ -31,7 +31,7 @@ namespace FluentFTP {
 			}
 
 			StartListeningOnPort(stream);
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			var args = stream.BeginAccept();
 #endif
 #if NETFRAMEWORK
@@ -112,7 +112,7 @@ namespace FluentFTP {
 			// otherwise things can get out of sync.
 			stream.CommandStatus = reply;
 
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			stream.EndAccept(args, Config.DataConnectionConnectTimeout);
 #endif
 #if NETFRAMEWORK

--- a/FluentFTP/Client/AsyncClient/UploadFile.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFile.cs
@@ -52,7 +52,7 @@ namespace FluentFTP {
 
 
 			// skip uploading if the local file does not exist
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			if (!await Task.Run(() => File.Exists(localPath), token)) {
 #else
 			if (!File.Exists(localPath)) {

--- a/FluentFTP/Client/BaseClient/ConvertDate.cs
+++ b/FluentFTP/Client/BaseClient/ConvertDate.cs
@@ -26,7 +26,7 @@ namespace FluentFTP.Client.BaseClient {
 
 					// convert UTC to local time if wanted (on .NET Core this is based on the LocalTimeZone property)
 					if (Config.TimeConversion == FtpDate.LocalTime) {
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 						date = date + Config.GetLocalTimeOffset();
 #else
 						date = System.TimeZone.CurrentTimeZone.ToLocalTime(date);
@@ -40,7 +40,7 @@ namespace FluentFTP.Client.BaseClient {
 
 					// convert local to UTC if wanted (on .NET Core this is based on the LocalTimeZone property)
 					if (Config.TimeConversion == FtpDate.LocalTime) {
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 						date = date - Config.GetLocalTimeOffset();
 #else
 						date = System.TimeZone.CurrentTimeZone.ToUniversalTime(date);

--- a/FluentFTP/Client/BaseClient/Logger.cs
+++ b/FluentFTP/Client/BaseClient/Logger.cs
@@ -90,7 +90,12 @@ namespace FluentFTP.Client.BaseClient {
 #else
 				target = "Unknown";
 #endif
+
+#if NET5_0 || NET6_0 || NETSTANDARD2_0 || NETSTANDARD2_1 || NET462 || NET472
 				LogWithPrefix(FtpTraceLevel.Verbose, "FluentFTP " + applicationVersion + "(" + target + ")");
+#else
+#error .csproj: TFM must be either net5.0, net6.0, netstandard2.0, netstandard2.1, net462 or net472
+#endif
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/OpenActiveDataStream.cs
+++ b/FluentFTP/Client/SyncClient/OpenActiveDataStream.cs
@@ -30,7 +30,7 @@ namespace FluentFTP {
 			}
 
 			StartListeningOnPort(stream);
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			var args = stream.BeginAccept();
 #endif
 #if NETFRAMEWORK
@@ -111,7 +111,7 @@ namespace FluentFTP {
 			// otherwise things can get out of sync.
 			stream.CommandStatus = reply;
 
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			stream.EndAccept(args, Config.DataConnectionConnectTimeout);
 #endif
 #if NETFRAMEWORK

--- a/FluentFTP/Exceptions/IOExceptions.cs
+++ b/FluentFTP/Exceptions/IOExceptions.cs
@@ -20,8 +20,10 @@ namespace FluentFTP.Exceptions {
 				if (exception.InnerException is SocketException socketException) {
 #if NETSTANDARD || NET5_0_OR_GREATER
 					return (int)socketException.SocketErrorCode == 10054;
-#else
+#elif NETFRAMEWORK
 					return socketException.ErrorCode == 10054;
+#else
+#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 				}
 

--- a/FluentFTP/Exceptions/IOExceptions.cs
+++ b/FluentFTP/Exceptions/IOExceptions.cs
@@ -20,10 +20,8 @@ namespace FluentFTP.Exceptions {
 				if (exception.InnerException is SocketException socketException) {
 #if NETSTANDARD || NET5_0_OR_GREATER
 					return (int)socketException.SocketErrorCode == 10054;
-#elif NETFRAMEWORK
-					return socketException.ErrorCode == 10054;
 #else
-#error "Check FluentFTP.csproj - TFM not catered for"
+					return socketException.ErrorCode == 10054;
 #endif
 				}
 

--- a/FluentFTP/Exceptions/IOExceptions.cs
+++ b/FluentFTP/Exceptions/IOExceptions.cs
@@ -18,7 +18,7 @@ namespace FluentFTP.Exceptions {
 			// resume if server disconnects midway (fixes #39 and #410)
 			if (exception.InnerException != null || exception.Message.ContainsAnyCI(ServerStringModule.unexpectedEOF)) {
 				if (exception.InnerException is SocketException socketException) {
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 					return (int)socketException.SocketErrorCode == 10054;
 #else
 					return socketException.ErrorCode == 10054;

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -35,7 +35,7 @@
 -->
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;netstandard2.0;netstandard2.1;net462;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net472;net462</TargetFrameworks>
         <Platforms>AnyCPU;x64</Platforms>
         <PackageReadmeFile></PackageReadmeFile>
         <RepositoryUrl>https://github.com/robinrodricks/FluentFTP</RepositoryUrl>

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -59,7 +59,7 @@
     </PropertyGroup>
 
     <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Release' And '$(TargetFramework)'=='net45'">
-        <Exec Command="copy /Y &quot;$(ProjectDir)bin\Release\net45\FluentFTP.dll&quot; &quot;$(SolutionDir)Powershell\FluentFTP.dll&quot;" />
+        <Exec Command="copy /Y &quot;$(ProjectDir)bin\Release\net462\FluentFTP.dll&quot; &quot;$(SolutionDir)Powershell\FluentFTP.dll&quot;" />
     </Target>
 
 </Project>

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -43,16 +43,6 @@
     </PropertyGroup>
 
 
-<!-- We include symbol NETSTANDARD on NET 5 and NET 6 to simplify #IF statements in the code -->
-
-    <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
-        <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
-        <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-    </PropertyGroup>
-    
     <ItemGroup>
         <None Include="..\.github\logo-nuget.png">
             <Pack>True</Pack>

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -35,7 +35,7 @@
 -->
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;net472;net462;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;netstandard2.0;netstandard2.1;net462;net472</TargetFrameworks>
         <Platforms>AnyCPU;x64</Platforms>
         <PackageReadmeFile></PackageReadmeFile>
         <RepositoryUrl>https://github.com/robinrodricks/FluentFTP</RepositoryUrl>

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -18,14 +18,41 @@
         <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
+
+<!-- Official Target Monikers:
+ 
+.NET 8          8       net8.0
+.NET 7          7       net7.0
+.NET 6          6       net6.0
+.NET 5          5       net5.0
+.NET Standard   2.1     netstandard2.1
+.NET Standard   2.0     netstandard2.0
+.NET Core       3.1     netcoreapp3.1
+.NET Framework  4.8     net48
+.NET Framework  4.7.2   net472
+.NET Framework  4.6.2   net462
+
+-->
+
     <PropertyGroup>
-        <TargetFrameworks>net60;net50;net472;net462;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net5.0;net472;net462;netstandard2.0;netstandard2.1</TargetFrameworks>
         <Platforms>AnyCPU;x64</Platforms>
         <PackageReadmeFile></PackageReadmeFile>
         <RepositoryUrl>https://github.com/robinrodricks/FluentFTP</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
     </PropertyGroup>
 
+
+<!-- We include symbol NETSTANDARD on NET 5 and NET 6 to simplify #IF statements in the code -->
+
+    <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
+        <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
+        <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+    </PropertyGroup>
+    
     <ItemGroup>
         <None Include="..\.github\logo-nuget.png">
             <Pack>True</Pack>
@@ -36,22 +63,6 @@
             <PackagePath></PackagePath>
         </None>
     </ItemGroup>
-
-    <PropertyGroup Condition="'$(TargetFramework)'=='net462' Or '$(TargetFramework)'=='net472'">
-        <DefineConstants>$(DefineConstants);NETFRAMEWORK;</DefineConstants>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'">
-        <DefineConstants>$(DefineConstants);NETSTANDARD;</DefineConstants>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(TargetFramework)'=='net50'">
-        <DefineConstants>$(DefineConstants);NET50;NETSTANDARD;NET50_OR_LATER;</DefineConstants>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(TargetFramework)'=='net60'">
-        <DefineConstants>$(DefineConstants);NET60;NETSTANDARD;NET50_OR_LATER;</DefineConstants>
-    </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)'=='Release'">
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -363,7 +363,7 @@ namespace FluentFTP {
 		}
 
 
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 		protected double _localTimeZone = 0;
 		protected TimeSpan _localTimeOffset = new TimeSpan();
 
@@ -620,7 +620,7 @@ namespace FluentFTP {
 			write.CustomStream = read.CustomStream;
 			write.CustomStreamConfig = read.CustomStreamConfig;
 
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			write.LocalTimeZone = read.LocalTimeZone;
 #endif
 

--- a/FluentFTP/Model/FtpHash.cs
+++ b/FluentFTP/Model/FtpHash.cs
@@ -78,7 +78,7 @@ namespace FluentFTP {
 
 				switch (m_algorithm) {
 					case FtpHashAlgorithm.SHA1:
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 						hashAlg = SHA1.Create();
 #else
 						hashAlg = new SHA1CryptoServiceProvider();
@@ -86,7 +86,7 @@ namespace FluentFTP {
 						break;
 
 					case FtpHashAlgorithm.SHA256:
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 						hashAlg = SHA256.Create();
 #else
 						hashAlg = new SHA256CryptoServiceProvider();
@@ -94,7 +94,7 @@ namespace FluentFTP {
 						break;
 
 					case FtpHashAlgorithm.SHA512:
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 						hashAlg = SHA512.Create();
 #else
 						hashAlg = new SHA512CryptoServiceProvider();
@@ -102,7 +102,7 @@ namespace FluentFTP {
 						break;
 
 					case FtpHashAlgorithm.MD5:
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 						hashAlg = MD5.Create();
 #else
 						hashAlg = new MD5CryptoServiceProvider();

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -539,7 +539,7 @@ namespace FluentFTP {
 			}
 
 			m_lastActivity = DateTime.Now;
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			return BaseStream.Read(buffer, offset, count);
 #else
 			ar = BaseStream.BeginRead(buffer, offset, count, null, null);
@@ -786,7 +786,7 @@ namespace FluentFTP {
 			await WriteAsync(data, 0, data.Length, token);
 		}
 
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 		/// <summary>
 		/// Disconnects from server
 		/// </summary>
@@ -925,7 +925,7 @@ namespace FluentFTP {
 				ipads = Client.Status.CachedHostIpads[host];
 			}
 			else {
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 				ipads = Dns.GetHostAddressesAsync(host).Result;
 #else
 				ipads = Dns.GetHostAddresses(host);
@@ -1028,7 +1028,7 @@ namespace FluentFTP {
 
 			int ctmo = this.ConnectTimeout;
 
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 			var args = new SocketAsyncEventArgs {
 				RemoteEndPoint = new IPEndPoint(ipad, port)
 			};
@@ -1236,13 +1236,13 @@ namespace FluentFTP {
 					CreateSslStream();
 
 					try {
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 						m_sslStream.AuthenticateAsClientAsync(targetHost, clientCerts, sslProtocols, Client.Config.ValidateCertificateRevocation).Wait();
 #else
 						m_sslStream.AuthenticateAsClient(targetHost, clientCerts, sslProtocols, Client.Config.ValidateCertificateRevocation);
 #endif
 					}
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 					catch (AggregateException ex) {
 						if (ex.InnerException is AuthenticationException) {
 							throw ex.InnerException;
@@ -1353,7 +1353,7 @@ namespace FluentFTP {
 					await m_sslStream.AuthenticateAsClientAsync(targetHost, clientCerts, sslProtocols, Client.Config.ValidateCertificateRevocation);
 #endif
 					}
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 					catch (AggregateException ex) {
 						if (ex.InnerException is AuthenticationException) {
 							throw ex.InnerException;
@@ -1579,7 +1579,7 @@ namespace FluentFTP {
 				m_socket = await m_socket.AcceptAsync();
 #endif
 				socketSave.Close();
-#if NETSTANDARD
+#if NETSTANDARD || NET5_0_OR_GREATER
 				m_netStream = new NetworkStream(m_socket);
 				m_netStream.ReadTimeout = m_readTimeout;
 #endif

--- a/FluentFTP/Streams/FtpSslStream.cs
+++ b/FluentFTP/Streams/FtpSslStream.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Security;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Numerics;
 
 namespace FluentFTP.Streams {
 	/// <summary>
@@ -63,6 +64,8 @@ namespace FluentFTP.Streams {
 
 			base.ShutdownAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
+#else
+#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 			base.Close();
@@ -85,6 +88,9 @@ namespace FluentFTP.Streams {
 #elif NETSTANDARD2_0_OR_GREATER      // <-- 2_0 is not a typo.
 
 			return $"{SslProtocol} ({CipherAlgorithm}, {KeyExchangeAlgorithm}, {KeyExchangeStrength})";
+
+#else
+#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 		}
@@ -132,9 +138,7 @@ namespace FluentFTP.Streams {
 			credentialsHandleHandle.HandleHi = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "HandleHi");
 			credentialsHandleHandle.HandleLo = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "HandleLo");
 
-#endif
-
-#if NETSTANDARD || NET5_0_OR_GREATER
+#elif NETSTANDARD || NET5_0_OR_GREATER
 
 			// Access the "context" field directly
 			var context = ReflectUtil.GetField(sslStream, "_context");
@@ -151,6 +155,8 @@ namespace FluentFTP.Streams {
 			credentialsHandleHandle.HandleHi = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "dwLower");
 			credentialsHandleHandle.HandleLo = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "dwUpper");
 
+#else
+#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 			NativeApi.SecurityBufferDescriptor securityBufferDescriptor = new NativeApi.SecurityBufferDescriptor();
@@ -214,13 +220,13 @@ namespace FluentFTP.Streams {
 			var innerStream = (Stream)ReflectUtil.GetProperty(sslstate, "InnerStream");
 			innerStream.Write(result, 0, resultSize);
 
-#endif
-
-#if NETSTANDARD || NET5_0_OR_GREATER
+#elif NETSTANDARD || NET5_0_OR_GREATER
 
 			var innerStream = (Stream)ReflectUtil.GetProperty(sslStream, "InnerStream");
 			innerStream.Write(result, 0, resultSize);
 
+#else
+#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 		}

--- a/FluentFTP/Streams/FtpSslStream.cs
+++ b/FluentFTP/Streams/FtpSslStream.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Net.Security;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Numerics;
 
 namespace FluentFTP.Streams {
 	/// <summary>
@@ -64,8 +63,6 @@ namespace FluentFTP.Streams {
 
 			base.ShutdownAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-#else
-#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 			base.Close();
@@ -88,9 +85,6 @@ namespace FluentFTP.Streams {
 #elif NETSTANDARD2_0_OR_GREATER      // <-- 2_0 is not a typo.
 
 			return $"{SslProtocol} ({CipherAlgorithm}, {KeyExchangeAlgorithm}, {KeyExchangeStrength})";
-
-#else
-#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 		}
@@ -138,7 +132,9 @@ namespace FluentFTP.Streams {
 			credentialsHandleHandle.HandleHi = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "HandleHi");
 			credentialsHandleHandle.HandleLo = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "HandleLo");
 
-#elif NETSTANDARD || NET5_0_OR_GREATER
+#endif
+
+#if NETSTANDARD || NET5_0_OR_GREATER
 
 			// Access the "context" field directly
 			var context = ReflectUtil.GetField(sslStream, "_context");
@@ -155,8 +151,6 @@ namespace FluentFTP.Streams {
 			credentialsHandleHandle.HandleHi = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "dwLower");
 			credentialsHandleHandle.HandleLo = (IntPtr)ReflectUtil.GetField(credentialsHandleHandleOriginal, "dwUpper");
 
-#else
-#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 			NativeApi.SecurityBufferDescriptor securityBufferDescriptor = new NativeApi.SecurityBufferDescriptor();
@@ -220,13 +214,13 @@ namespace FluentFTP.Streams {
 			var innerStream = (Stream)ReflectUtil.GetProperty(sslstate, "InnerStream");
 			innerStream.Write(result, 0, resultSize);
 
-#elif NETSTANDARD || NET5_0_OR_GREATER
+#endif
+
+#if NETSTANDARD || NET5_0_OR_GREATER
 
 			var innerStream = (Stream)ReflectUtil.GetProperty(sslStream, "InnerStream");
 			innerStream.Write(result, 0, resultSize);
 
-#else
-#error "Check FluentFTP.csproj - TFM not catered for"
 #endif
 
 		}


### PR DESCRIPTION
Using these:

```
<!-- Official Target Monikers:
 
.NET 8          8       net8.0
.NET 7          7       net7.0
.NET 6          6       net6.0
.NET 5          5       net5.0
.NET Standard   2.1     netstandard2.1
.NET Standard   2.0     netstandard2.0
.NET Core       3.1     netcoreapp3.1
.NET Framework  4.8     net48
.NET Framework  4.7.2   net472
.NET Framework  4.6.2   net462
```

and changing (in the code)

`NETSTANDARD` -> `NETSTANDARD || NET5_0_OR_GREATER`
`NET50_OR_LATER` -> `NET5_0_OR_GREATER` (already done in previous PR)

we can do away with

```cs
    <PropertyGroup Condition="'$(TargetFramework)'=='net462' Or '$(TargetFramework)'=='net472'">
        <DefineConstants>$(DefineConstants);NETFRAMEWORK;</DefineConstants>
    </PropertyGroup>

    <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'">
        <DefineConstants>$(DefineConstants);NETSTANDARD;</DefineConstants>
    </PropertyGroup>

    <PropertyGroup Condition="'$(TargetFramework)'=='net50'">
        <DefineConstants>$(DefineConstants);NET50;NETSTANDARD;NET50_OR_LATER;</DefineConstants>
    </PropertyGroup>

    <PropertyGroup Condition="'$(TargetFramework)'=='net60'">
        <DefineConstants>$(DefineConstants);NET60;NETSTANDARD;NET50_OR_LATER;</DefineConstants>
    </PropertyGroup>
```
Why?
1. `NETFRAMEWORK` and `NETSTANDARD`: Redundant, defined by build process automatically
2. Due to the `NETSTANDARD` -> `NETSTANDARD || NET5_0_OR_GREATER` code change, there is no need for a bogus `NETSTANDARD` definition for `NET5.0` and `NET6.0`.
3. `NET50` and `NET60` are not used in the code and are "wrong" syntax monikers anyway.
4. `NET_50_OR_LATER` and `NET_60_OR_LATER` are not ( actually: **are no longer**, thanks to previous PR ) used in the code.

The other symbols:
`NET50`, `NET60` = superfluous and unused
`NETFRAMEWORK` = already defined per default
`NETSTANDARD` = already defined per default
`NET50_OR_LATER` = no longer needed, no more occurrences in the code

Thus, here are the defined symbols that will be in effect for each target:

```
net5.0 -> NET;NET5_0;NETCOREAPP
net6.0 -> NET;NET6_0;NETCOREAPP
net472 -> NETFRAMEWORK;NET472
net462 -> NETFRAMEWORK;NET462
netstandard2.0 -> NETSTANDARD;NETSTANDARD2_0
netstandard2.1 -> NETSTANDARD;NETSTANDARD2_1
```

The `***_OR_GREATER` symbols are generated automatically for the build process and don't need to be defined explicitly.

The previously defined `net50` and `net60` symbols and the definition of these as targets caused the respective folders to be created under `bin` and `obj`. This now changes to `net5.0` and `net6.0`. These symbols actually **did not** cause such derived symbols as `***__OR_GREATER` to be assigned - because these symbol names were not standard TFM's (Target Framework Monikers). It only worked (more or less) because of the additional `NETSTANDARD` symbol these were given.
