### PR TITLE
Remove ***_OR_LATER

### DIFF
--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -46,11 +46,11 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)'=='net50'">
-        <DefineConstants>$(DefineConstants);NET50;NETSTANDARD;NET50_OR_LATER;</DefineConstants>
+        <DefineConstants>$(DefineConstants);NET50;NETSTANDARD</DefineConstants>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)'=='net60'">
-        <DefineConstants>$(DefineConstants);NET60;NETSTANDARD;NET50_OR_LATER;</DefineConstants>
+        <DefineConstants>$(DefineConstants);NET60;NETSTANDARD</DefineConstants>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
NET50_OR_LATER is no longer needed as a symbol: Any conditional compilation using these symbols has been removed from the code.