### PR TITLE
NET50 and NET60 not used in code and TFM moniker correction net60 -> net6.0 and net50 -> net5.0

### DIFF
--- a/FluentFTP.CSharpExamples/CSharpExamples.csproj
+++ b/FluentFTP.CSharpExamples/CSharpExamples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net50</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<OutputType>Library</OutputType>
 		<LangVersion>latest</LangVersion>
 		<ApplicationIcon />

--- a/FluentFTP.VBExamples/VBExamples.vbproj
+++ b/FluentFTP.VBExamples/VBExamples.vbproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net50</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<OutputType>Library</OutputType>
 		<LangVersion>latest</LangVersion>
 		<ApplicationIcon />

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>net60;net50;net472;net462;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net5.0;net472;net462;netstandard2.0;netstandard2.1</TargetFrameworks>
         <Platforms>AnyCPU;x64</Platforms>
         <PackageReadmeFile></PackageReadmeFile>
         <RepositoryUrl>https://github.com/robinrodricks/FluentFTP</RepositoryUrl>
@@ -46,11 +46,11 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)'=='net50'">
-        <DefineConstants>$(DefineConstants);NET50;NETSTANDARD</DefineConstants>
+        <DefineConstants>$(DefineConstants)NETSTANDARD</DefineConstants>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)'=='net60'">
-        <DefineConstants>$(DefineConstants);NET60;NETSTANDARD</DefineConstants>
+        <DefineConstants>$(DefineConstants)NETSTANDARD</DefineConstants>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
NET50 and NET60 not used in code
TFM net60 -> net6.0 and net50 -> net5.0 (adhere to MS standard)