### PR TITLE
Clean up IsStillConnected(), Noop() et.al.

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -126,7 +126,7 @@ namespace FluentFTP {
 							}
 
 							// Fix #387: keep alive with NOOP as configured and needed
-							anyNoop = await NoopAsync(token) || anyNoop;
+							anyNoop = await NoopAsync(false, token) || anyNoop;
 
 							// honor the rate limit
 							var swTime = sw.ElapsedMilliseconds;

--- a/FluentFTP/Client/AsyncClient/IsStillConnected.cs
+++ b/FluentFTP/Client/AsyncClient/IsStillConnected.cs
@@ -11,16 +11,14 @@ namespace FluentFTP {
 		/// <summary>
 		/// Performs a series of tests to check if we are still connected to the FTP server.
 		/// More thourough than IsConnected.
-		/// <paramref name="timeout"/>How to wait for connection confirmation
 		/// </summary>
+		/// <param name="timeout"/>How to wait for connection confirmation
+		/// <returns>bool connection status</returns>
 		public async Task<bool> IsStillConnected(int timeout = 10000, CancellationToken token = default(CancellationToken)) {
 			LogFunction(nameof(IsStillConnected), new object[] { timeout }); bool connected = false;
 
 			if (IsConnected && IsAuthenticated) {
-				int saveNoopInterval = Config.NoopInterval;
-				LastCommandTimestamp = DateTime.MinValue;
-				Config.NoopInterval = 1;
-				if (await NoopAsync(token)) {
+				if (await NoopAsync(true, token)) {
 					try {
 						if ((await GetReplyAsyncInternal(token, "NOOP", false, timeout)).Success) {
 							connected = true;
@@ -30,7 +28,6 @@ namespace FluentFTP {
 						LogWithPrefix(FtpTraceLevel.Verbose, "Exception: " + ex.Message);
 					}
 				}
-				Config.NoopInterval = saveNoopInterval;
 				if (!connected) {
 					// This will clean up the SocketStream
 					bool saveDisconnectWithQuit = Config.DisconnectWithQuit;

--- a/FluentFTP/Client/AsyncClient/Noop.cs
+++ b/FluentFTP/Client/AsyncClient/Noop.cs
@@ -16,10 +16,11 @@ namespace FluentFTP {
 		/// Please call <see cref="GetReply"/> as needed to read the "OK" command sent by the server and prevent stale data on the socket.
 		/// Note that response is not guaranteed by all FTP servers when sent during file transfers.
 		/// </summary>
+ 		/// <param name="ignoreNoopInterval"/>Send the command regardless of NoopInterval
 		/// <param name="token"></param>
 		/// <returns>true if NOOP command was sent</returns>
-		protected async Task<bool> NoopAsync(CancellationToken token) {
-			if (Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval) {
+		protected async Task<bool> NoopAsync(bool ignoreNoopInterval = false, CancellationToken token = default(CancellationToken)) {
+			if (ignoreNoopInterval || (Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval)) {
 				Log(FtpTraceLevel.Verbose, "Command:  NOOP");
 
 				await m_stream.WriteLineAsync(m_textEncoding, "NOOP", token);

--- a/FluentFTP/Client/AsyncClient/TransferFile.cs
+++ b/FluentFTP/Client/AsyncClient/TransferFile.cs
@@ -207,8 +207,8 @@ namespace FluentFTP {
 
 					LogWithPrefix(FtpTraceLevel.Info, $"FXP transfer of file {sourcePath} has completed");
 
-					await NoopAsync(token);
-					await remoteClient.NoopAsync(token);
+					await NoopAsync(true, token);
+					await remoteClient.NoopAsync(true, token);
 
 					ftpFxpSession.Dispose();
 

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -207,7 +207,7 @@ namespace FluentFTP {
 							}
 
 							// Fix #387: keep alive with NOOP as configured and needed
-							anyNoop = await NoopAsync(token) || anyNoop;
+							anyNoop = await NoopAsync(false, token) || anyNoop;
 
 							// honor the rate limit
 							var swTime = sw.ElapsedMilliseconds;

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -126,7 +126,7 @@ namespace FluentFTP {
 							}
 
 							// Fix #387: keep alive with NOOP as configured and needed
-							anyNoop = Noop() || anyNoop;
+							anyNoop = Noop(false) || anyNoop;
 
 							// honor the rate limit
 							var swTime = sw.ElapsedMilliseconds;

--- a/FluentFTP/Client/SyncClient/IsStillConnected.cs
+++ b/FluentFTP/Client/SyncClient/IsStillConnected.cs
@@ -9,17 +9,15 @@ namespace FluentFTP {
 		/// <summary>
 		/// Performs a series of tests to check if we are still connected to the FTP server.
 		/// More thourough than IsConnected.
- 		/// <paramref name="timeout"/>How to wait for connection confirmation
 		/// </summary>
+		/// <param name="timeout"/>How to wait for connection confirmation
+		/// <returns>bool connection status</returns>
 		public bool IsStillConnected(int timeout = 10000) {
 			LogFunction(nameof(IsStillConnected), new object[] { timeout });
 
 			bool connected = false;
 			if (IsConnected && IsAuthenticated) {
-				int saveNoopInterval = Config.NoopInterval;
-				LastCommandTimestamp = DateTime.MinValue;
-				Config.NoopInterval = 1;
-				if (Noop()) {
+				if (Noop(true)) {
 					try {
 						if (GetReplyInternal("NOOP", false, timeout).Success) {
 							connected = true;
@@ -29,7 +27,6 @@ namespace FluentFTP {
 						LogWithPrefix(FtpTraceLevel.Verbose, "Exception: " + ex.Message);
 					}
 				}
-				Config.NoopInterval = saveNoopInterval;
 				if (!connected) {
 					// This will clean up the SocketStream
 					bool saveDisconnectWithQuit = Config.DisconnectWithQuit;

--- a/FluentFTP/Client/SyncClient/Noop.cs
+++ b/FluentFTP/Client/SyncClient/Noop.cs
@@ -15,10 +15,11 @@ namespace FluentFTP {
 		/// Sends the NOOP command according to <see cref="FtpConfig.NoopInterval"/> (effectively a no-op if 0).
 		/// Please call <see cref="GetReply"/> as needed to read the "OK" command sent by the server and prevent stale data on the socket.
 		/// Note that response is not guaranteed by all FTP servers when sent during file transfers.
+		/// <param name="ignoreNoopInterval"/>Send the command regardless of NoopInterval
 		/// </summary>
 		/// <returns>true if NOOP command was sent</returns>
-		public bool Noop() {
-			if (Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval) {
+		public bool Noop(bool ignoreNoopInterval = false) {
+			if (ignoreNoopInterval || (Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval)) {
 				Log(FtpTraceLevel.Verbose, "Command:  NOOP");
 
 				m_stream.WriteLine(m_textEncoding, "NOOP");

--- a/FluentFTP/Client/SyncClient/TransferFile.cs
+++ b/FluentFTP/Client/SyncClient/TransferFile.cs
@@ -207,8 +207,8 @@ namespace FluentFTP {
 
 					LogWithPrefix(FtpTraceLevel.Info, $"FXP transfer of file {sourcePath} has completed");
 
-					Noop();
-					remoteClient.Noop();
+					Noop(true);
+					remoteClient.Noop(true);
 
 					ftpFxpSession.Dispose();
 

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -203,7 +203,7 @@ namespace FluentFTP {
 							}
 
 							// Fix #387: keep alive with NOOP as configured and needed
-							anyNoop = Noop() || anyNoop;
+							anyNoop = Noop(false) || anyNoop;
 
 							// honor the speed limit
 							var swTime = sw.ElapsedMilliseconds;


### PR DESCRIPTION
Gave Noop() a parm to avoid needing to manipulate NoopInterval. This made it necessary to touch all users of Noop (there are not many).

This concludes the effort to detect connection status.