### PR TITLE
Demonize NOOP processing for #1410

### DIFF
--- a/FluentFTP/Client/AsyncClient/Authenticate.cs
+++ b/FluentFTP/Client/AsyncClient/Authenticate.cs
@@ -1,8 +1,7 @@
-﻿using FluentFTP.Exceptions;
-using System;
-using System.IO;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Exceptions;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/Chmod.cs
+++ b/FluentFTP/Client/AsyncClient/Chmod.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
-using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/CompareFile.cs
+++ b/FluentFTP/Client/AsyncClient/CompareFile.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentFTP.Client.Modules;
+
+using FluentFTP.Streams;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Threading;
-using FluentFTP.Client.Modules;
-using System.Threading.Tasks;
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Text;
-using FluentFTP.Helpers;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentFTP.Client.Modules;
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -239,6 +239,10 @@ namespace FluentFTP {
 			Status.AllowCheckStaleData = true;
 
 			Status.InCriticalSequence = false;
+
+			if (!Status.DaemonRunning) { 
+				m_task = Task.Run(() => { Daemon(); });
+			}
 		}
 
 		/// <summary>

--- a/FluentFTP/Client/AsyncClient/CreateDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/CreateDirectory.cs
@@ -1,8 +1,9 @@
-﻿using FluentFTP.Helpers;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Client.Modules;
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/DeleteDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/DeleteDirectory.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Linq;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/DeleteFile.cs
+++ b/FluentFTP/Client/AsyncClient/DeleteFile.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using FluentFTP.Helpers;
 using System.Threading;
-using FluentFTP.Client.Modules;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/DirectoryExists.cs
+++ b/FluentFTP/Client/AsyncClient/DirectoryExists.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Linq;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/DisableUTF8.cs
+++ b/FluentFTP/Client/AsyncClient/DisableUTF8.cs
@@ -20,14 +20,12 @@ namespace FluentFTP {
 		public void DisableUTF8() {
 			FtpReply reply;
 
-			lock (m_lock) {
-				if (!(reply = ((IInternalFtpClient)this).ExecuteInternal("OPTS UTF8 OFF")).Success) {
-					throw new FtpCommandException(reply);
-				}
-
-				m_textEncoding = Encoding.ASCII;
-				m_textEncodingAutoUTF = false;
+			if (!(reply = ((IInternalFtpClient)this).ExecuteInternal("OPTS UTF8 OFF")).Success) {
+				throw new FtpCommandException(reply);
 			}
+
+			m_textEncoding = Encoding.ASCII;
+			m_textEncodingAutoUTF = false;
 
 		}
 	}

--- a/FluentFTP/Client/AsyncClient/DisableUTF8.cs
+++ b/FluentFTP/Client/AsyncClient/DisableUTF8.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.IO;
+﻿using FluentFTP.Exceptions;
+
 using System.Text;
-using System.Collections.Generic;
-using FluentFTP.Exceptions;
-using FluentFTP.Helpers;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using FluentFTP.Client.Modules;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/Disconnect.cs
+++ b/FluentFTP/Client/AsyncClient/Disconnect.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/FluentFTP/Client/AsyncClient/Disconnect.cs
+++ b/FluentFTP/Client/AsyncClient/Disconnect.cs
@@ -10,6 +10,8 @@ namespace FluentFTP {
 		/// Disconnects from the server asynchronously
 		/// </summary>
 		public async Task Disconnect(CancellationToken token = default(CancellationToken)) {
+			LogFunction(nameof(Disconnect), null);
+
 			if (m_stream != null && m_stream.IsConnected) {
 				try {
 					if (Config.DisconnectWithQuit) {

--- a/FluentFTP/Client/AsyncClient/DiscoverSslSessionLength.cs
+++ b/FluentFTP/Client/AsyncClient/DiscoverSslSessionLength.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/DownloadBytes.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadBytes.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/DownloadDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadDirectory.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.IO;
 using System.Collections.Generic;
-using FluentFTP.Rules;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
+using FluentFTP.Rules;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/DownloadFile.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFile.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
+using FluentFTP.Streams;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
-using FluentFTP.Client.Modules;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Client.Modules;
+using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 using FluentFTP.Proxy.AsyncProxy;
-using System.Security.Authentication;
+using FluentFTP.Streams;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/DownloadFiles.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFiles.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.IO;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.IO;
 using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Data;
+
+using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 using FluentFTP.Rules;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/DownloadStream.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadStream.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/EmptyDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/EmptyDirectory.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Linq;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
 

--- a/FluentFTP/Client/AsyncClient/ExecuteDownloadText.cs
+++ b/FluentFTP/Client/AsyncClient/ExecuteDownloadText.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.IO;
 using System.Collections.Generic;
-using FluentFTP.Exceptions;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using FluentFTP.Client.Modules;
 using System.Security.Authentication;
+
+using FluentFTP.Client.Modules;
+using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 using FluentFTP.Proxy.AsyncProxy;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/FileExists.cs
+++ b/FluentFTP/Client/AsyncClient/FileExists.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using FluentFTP.Helpers;
 using System.Threading;
-using FluentFTP.Client.Modules;
 using System.Threading.Tasks;
+
+using FluentFTP.Client.Modules;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/GetAbsoluteDir.cs
+++ b/FluentFTP/Client/AsyncClient/GetAbsoluteDir.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using FluentFTP.Helpers;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/GetAbsoluteFilePath.cs
+++ b/FluentFTP/Client/AsyncClient/GetAbsoluteFilePath.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using FluentFTP.Helpers;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/GetAbsolutePath.cs
+++ b/FluentFTP/Client/AsyncClient/GetAbsolutePath.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.IO;
-using FluentFTP.Helpers;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/GetChecksum.cs
+++ b/FluentFTP/Client/AsyncClient/GetChecksum.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentFTP.Exceptions;
 using FluentFTP.Helpers;
 using FluentFTP.Helpers.Hashing;
 using HashAlgos = FluentFTP.Helpers.Hashing.HashAlgorithms;
-using System.Threading;
-using System.Threading.Tasks;
-using FluentFTP.Exceptions;
-using System.IO;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/GetChmod.cs
+++ b/FluentFTP/Client/AsyncClient/GetChmod.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
-using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/GetFilePermissions.cs
+++ b/FluentFTP/Client/AsyncClient/GetFilePermissions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Helpers;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/GetFileSize.cs
+++ b/FluentFTP/Client/AsyncClient/GetFileSize.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Client.Modules;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/GetListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetListing.cs
@@ -1,14 +1,13 @@
 ﻿using System;
-using System.IO;
-using System.Text;
 using System.Collections.Generic;
-using FluentFTP.Exceptions;
-using FluentFTP.Helpers;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using FluentFTP.Client.Modules;
 using System.Security.Authentication;
+
+using FluentFTP.Client.Modules;
+using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 using FluentFTP.Proxy.AsyncProxy;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/GetListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetListing.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using System.Security.Authentication;
 
 using FluentFTP.Client.Modules;

--- a/FluentFTP/Client/AsyncClient/GetModifiedTime.cs
+++ b/FluentFTP/Client/AsyncClient/GetModifiedTime.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/GetNameListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetNameListing.cs
@@ -1,14 +1,11 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using System.Collections.Generic;
-using FluentFTP.Exceptions;
-using FluentFTP.Helpers;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using FluentFTP.Client.Modules;
-using System.Security.Authentication;
+
+using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
+++ b/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.IO;
 using System.Text;
-using System.Collections.Generic;
-using FluentFTP.Exceptions;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using FluentFTP.Client.Modules;
+
 using FluentFTP.Client.BaseClient;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 

--- a/FluentFTP/Client/AsyncClient/GetReply.cs
+++ b/FluentFTP/Client/AsyncClient/GetReply.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Diagnostics;
-using FluentFTP.Client.Modules;
+
+using FluentFTP.Client.Modules; 
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/GetReply.cs
+++ b/FluentFTP/Client/AsyncClient/GetReply.cs
@@ -76,6 +76,8 @@ namespace FluentFTP {
 			long previousElapsedTime = 0;
 
 			if (exhaustNoop) {
+				Status.DaemonEnable = false;
+
 				// tickle the server
 				m_stream.WriteLine(Encoding, "NOOP");
 			}
@@ -180,6 +182,8 @@ namespace FluentFTP {
 			if (exhaustNoop) {
 				LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 			}
+
+			Status.DaemonEnable = true;
 
 			reply = ProcessGetReply(reply, command);
 

--- a/FluentFTP/Client/AsyncClient/GetReply.cs
+++ b/FluentFTP/Client/AsyncClient/GetReply.cs
@@ -15,7 +15,18 @@ namespace FluentFTP {
 		/// <param name="token">The token that can be used to cancel the entire process.</param>
 		/// <returns>FtpReply representing the response from the server</returns>
 		public async Task<FtpReply> GetReply(CancellationToken token = default(CancellationToken)) {
-			return await GetReplyAsyncInternal(token, null, false, 0);
+			FtpReply ftpReply = new FtpReply();
+
+			m_sema.WaitAsync();
+			try {
+				ftpReply = await GetReplyAsyncInternal(token, null, false, 0);
+			}
+			finally {
+				m_sema.Release();
+			};
+
+			return ftpReply;
+
 		}
 
 		/// <summary>

--- a/FluentFTP/Client/AsyncClient/GetWorkingDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/GetWorkingDirectory.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Linq;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/GetZOSListRealm.cs
+++ b/FluentFTP/Client/AsyncClient/GetZOSListRealm.cs
@@ -1,6 +1,7 @@
-﻿using FluentFTP.Exceptions;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Exceptions;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/Handshake.cs
+++ b/FluentFTP/Client/AsyncClient/Handshake.cs
@@ -1,8 +1,8 @@
-﻿using FluentFTP.Exceptions;
-using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Exceptions;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/IsRoot.cs
+++ b/FluentFTP/Client/AsyncClient/IsRoot.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Linq;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/IsStillConnected.cs
+++ b/FluentFTP/Client/AsyncClient/IsStillConnected.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.ComponentModel.Design;
-using System.Configuration;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/MoveDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/MoveDirectory.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Linq;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/MoveFile.cs
+++ b/FluentFTP/Client/AsyncClient/MoveFile.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using FluentFTP.Helpers;
 using System.Threading;
-using FluentFTP.Client.Modules;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/Noop.cs
+++ b/FluentFTP/Client/AsyncClient/Noop.cs
@@ -16,25 +16,29 @@ namespace FluentFTP {
 		/// Please call <see cref="GetReply"/> as needed to read the "OK" command sent by the server and prevent stale data on the socket.
 		/// Note that response is not guaranteed by all FTP servers when sent during file transfers.
 		/// </summary>
- 		/// <param name="ignoreNoopInterval"/>Send the command regardless of NoopInterval
+		/// <param name="ignoreNoopInterval"/>Send the command regardless of NoopInterval
 		/// <param name="token"></param>
 		/// <returns>true if NOOP command was sent</returns>
 		protected async Task<bool> NoopAsync(bool ignoreNoopInterval = false, CancellationToken token = default(CancellationToken)) {
 			if (ignoreNoopInterval || (Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval)) {
-				Log(FtpTraceLevel.Verbose, "Command:  NOOP");
 
-				await m_stream.WriteLineAsync(m_textEncoding, "NOOP", token);
-				LastCommandTimestamp = DateTime.UtcNow;
+				await m_sema.WaitAsync();
+				try {
+					Log(FtpTraceLevel.Verbose, "Command:  NOOP");
 
-				return true;
+					await m_stream.WriteLineAsync(m_textEncoding, "NOOP", token);
+					LastCommandTimestamp = DateTime.UtcNow;
+
+					return true;
+				}
+				finally {
+					m_sema.Release();
+				};
+
 			}
 
 			return false;
 		}
-
-		// Note: Enhancement would be to send the following commands in
-		// a random sequence to foil content aware firewalls that would
-		// make this keep alive scheme fail: NOOP, TYPE A, TYPE I, PWD
 
 	}
 }

--- a/FluentFTP/Client/AsyncClient/Noop.cs
+++ b/FluentFTP/Client/AsyncClient/Noop.cs
@@ -1,10 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Net.Sockets;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Net;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.IO;
 using System.Net.Sockets;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Net;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/OpenAppend.cs
+++ b/FluentFTP/Client/AsyncClient/OpenAppend.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Net.Sockets;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Net;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/OpenDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenDataStream.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.IO;
 using System.Net.Sockets;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Net;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/FluentFTP/Client/AsyncClient/OpenFXPConnection.cs
+++ b/FluentFTP/Client/AsyncClient/OpenFXPConnection.cs
@@ -1,7 +1,8 @@
-﻿using FluentFTP.Exceptions;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Exceptions;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.IO;
 using System.Net.Sockets;
-using System.Text.RegularExpressions;
 using System.Linq;
-using System.Net;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/OpenRead.cs
+++ b/FluentFTP/Client/AsyncClient/OpenRead.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Net.Sockets;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Net;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/OpenWrite.cs
+++ b/FluentFTP/Client/AsyncClient/OpenWrite.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Net.Sockets;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Net;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/Rename.cs
+++ b/FluentFTP/Client/AsyncClient/Rename.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using FluentFTP.Helpers;
 using System.Threading;
-using FluentFTP.Client.Modules;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/SetDataType.cs
+++ b/FluentFTP/Client/AsyncClient/SetDataType.cs
@@ -1,6 +1,7 @@
-﻿using FluentFTP.Exceptions;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Exceptions;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/SetFilePermissions.cs
+++ b/FluentFTP/Client/AsyncClient/SetFilePermissions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
 using FluentFTP.Helpers;
 

--- a/FluentFTP/Client/AsyncClient/SetModifiedTime.cs
+++ b/FluentFTP/Client/AsyncClient/SetModifiedTime.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/SetWorkingDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/SetWorkingDirectory.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Linq;
-using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/TransferDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/TransferDirectory.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using FluentFTP.Rules;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
+using FluentFTP.Rules;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/TransferFile.cs
+++ b/FluentFTP/Client/AsyncClient/TransferFile.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using FluentFTP.Helpers;
-using FluentFTP.Rules;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/UploadBytes.cs
+++ b/FluentFTP/Client/AsyncClient/UploadBytes.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/UploadDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/UploadDirectory.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.IO;
 using System.Collections.Generic;
-using FluentFTP.Rules;
-using FluentFTP.Helpers;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
+using FluentFTP.Rules;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/UploadFile.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFile.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
+using FluentFTP.Streams;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -178,7 +178,7 @@ namespace FluentFTP {
 				catch {
 				}
 
-				var anyNoop = false;
+				Status.DaemonAnyNoops = false;
 
 				// loop till entire file uploaded
 				while (localFileLen == 0 || localPosition < localFileLen) {
@@ -205,9 +205,6 @@ namespace FluentFTP {
 							if (progress != null) {
 								ReportProgress(progress, localFileLen, localPosition, bytesProcessed, DateTime.Now - transferStarted, localPath, remotePath, metaProgress);
 							}
-
-							// Fix #387: keep alive with NOOP as configured and needed
-							anyNoop = await NoopAsync(false, token) || anyNoop;
 
 							// honor the rate limit
 							var swTime = sw.ElapsedMilliseconds;
@@ -278,7 +275,7 @@ namespace FluentFTP {
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
-				FtpReply status = await GetReplyAsyncInternal(token, LastCommandExecuted, anyNoop);
+				FtpReply status = await GetReplyAsyncInternal(token, LastCommandExecuted, Status.DaemonAnyNoops);
 
 				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
 				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.IO;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
+using System.IO;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Security.Authentication;
+
+using FluentFTP.Helpers;
+using FluentFTP.Exceptions;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/UploadFiles.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFiles.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.IO;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.IO;
 using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Data;
+
+using FluentFTP.Helpers;
+using FluentFTP.Exceptions;
 using FluentFTP.Rules;
 
 namespace FluentFTP {

--- a/FluentFTP/Client/AsyncClient/UploadStream.cs
+++ b/FluentFTP/Client/AsyncClient/UploadStream.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using FluentFTP.Streams;
-using FluentFTP.Helpers;
-using FluentFTP.Exceptions;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/VerifyFXPTransfer.cs
+++ b/FluentFTP/Client/AsyncClient/VerifyFXPTransfer.cs
@@ -1,7 +1,8 @@
 ﻿using System;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/AsyncClient/VerifyTransfer.cs
+++ b/FluentFTP/Client/AsyncClient/VerifyTransfer.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.IO;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {

--- a/FluentFTP/Client/BaseClient/CloseDataStream.cs
+++ b/FluentFTP/Client/BaseClient/CloseDataStream.cs
@@ -1,5 +1,7 @@
 ﻿using FluentFTP.Exceptions;
+
 using System;
+
 namespace FluentFTP.Client.BaseClient {
 
 	public partial class BaseFtpClient {

--- a/FluentFTP/Client/BaseClient/CloseDataStream.cs
+++ b/FluentFTP/Client/BaseClient/CloseDataStream.cs
@@ -17,30 +17,27 @@ namespace FluentFTP.Client.BaseClient {
 				throw new ArgumentException("The data stream parameter was null");
 			}
 
-			lock (m_lock) {
-				try {
-					if (IsConnected) {
-						// if the command that required the data connection was
-						// not successful then there will be no reply from
-						// the server, however if the command was successful
-						// the server will send a reply when the data connection
-						// is closed.
-						if (stream.CommandStatus.Type == FtpResponseType.PositivePreliminary) {
-							if (!(reply = GetReplyInternal(LastCommandExecuted)).Success) {
-								throw new FtpCommandException(reply);
-							}
+			try {
+				if (IsConnected) {
+					// if the command that required the data connection was
+					// not successful then there will be no reply from
+					// the server, however if the command was successful
+					// the server will send a reply when the data connection
+					// is closed.
+					if (stream.CommandStatus.Type == FtpResponseType.PositivePreliminary) {
+						if (!(reply = GetReplyInternal(LastCommandExecuted)).Success) {
+							throw new FtpCommandException(reply);
 						}
 					}
 				}
-				finally {
-					// if this is a clone of the original control
-					// connection we should Dispose()
-					if (IsClone) {
-						((IInternalFtpClient)this).DisconnectInternal();
-						Dispose();
-					}
+			}
+			finally {
+				// if this is a clone of the original control
+				// connection we should Dispose()
+				if (IsClone) {
+					((IInternalFtpClient)this).DisconnectInternal();
+					Dispose();
 				}
-
 			}
 
 			return reply;

--- a/FluentFTP/Client/BaseClient/Daemon.cs
+++ b/FluentFTP/Client/BaseClient/Daemon.cs
@@ -40,36 +40,38 @@ namespace FluentFTP.Client.BaseClient {
 						rndNormalCmds[rnd.Next(rndNormalCmds.Count)] :
 						rndNormalCmds[rnd.Next(rndSafeCmds.Count)];
 
-					// only log this if we have an active data connection
-					if (!Status.DaemonGetReply) {
-						LogWithPrefix(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (daemon)");
-					}
-
-					// send the random NOOP command
-					m_stream.WriteLine(m_textEncoding, rndCmd);
-
-					LastCommandTimestamp = DateTime.UtcNow;
-
-					// tell the outside world, NOOPs have actually been sent.
-					Status.DaemonAnyNoops = true;
-
-					// pick the command reply if this is just an idle control connection
-					if (Status.DaemonGetReply) {
-
-						bool s = GetReplyInternal(rndCmd + " (daemon)", false, 10000).Success;
-
-						// in case one of these commands is issued, make sure we store that
-
-						if (s) {
-							if (rndCmd.StartsWith("TYPE I")) {
-								Status.CurrentDataType = FtpDataType.Binary;
-							}
-
-							if (rndCmd.StartsWith("TYPE A")) {
-								Status.CurrentDataType = FtpDataType.ASCII;
-							}
+					lock (m_lock) {
+						// only log this if we have an active data connection
+						if (!Status.DaemonGetReply) {
+							LogWithPrefix(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (daemon)");
 						}
 
+						// send the random NOOP command
+						m_stream.WriteLine(m_textEncoding, rndCmd);
+
+						LastCommandTimestamp = DateTime.UtcNow;
+
+						// tell the outside world, NOOPs have actually been sent.
+						Status.DaemonAnyNoops = true;
+
+						// pick the command reply if this is just an idle control connection
+						if (Status.DaemonGetReply) {
+
+							bool s = GetReplyInternal(rndCmd + " (daemon)", false, 10000).Success;
+
+							// in case one of these commands is issued, make sure we store that
+
+							if (s) {
+								if (rndCmd.StartsWith("TYPE I")) {
+									Status.CurrentDataType = FtpDataType.Binary;
+								}
+
+								if (rndCmd.StartsWith("TYPE A")) {
+									Status.CurrentDataType = FtpDataType.ASCII;
+								}
+							}
+
+						}
 					}
 
 				}

--- a/FluentFTP/Client/BaseClient/Daemon.cs
+++ b/FluentFTP/Client/BaseClient/Daemon.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FluentFTP.Client.BaseClient {
+
+	public partial class BaseFtpClient {
+
+		static List<string> rndNormalCmds = new List<string> { "NOOP", "PWD", "TYPE I", "TYPE A" };
+		static List<string> rndSafeCmds = new List<string> { "NOOP" };
+
+		public void Daemon() {
+
+			LogWithPrefix(FtpTraceLevel.Verbose, "Daemon initialized");
+			Status.DaemonRunning = true;
+			Status.DaemonGetReply = true;
+			Status.DaemonEnable = true;
+			Status.DaemonAnyNoops = false;
+
+			do {
+
+				if (m_stream == null || !m_stream.IsConnected) {
+					LogWithPrefix(FtpTraceLevel.Verbose, "Daemon terminated");
+					Status.DaemonRunning = false;
+					return;
+				}
+
+				if (Status.DaemonEnable && Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval) {
+
+					Random rnd = new Random();
+
+					string rndCmd = Status.DaemonGetReply ? rndNormalCmds[rnd.Next(rndNormalCmds.Count)] : rndNormalCmds[rnd.Next(rndSafeCmds.Count)];
+
+					if (!Status.DaemonGetReply) {
+						LogWithPrefix(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (daemon)");
+					}
+
+					m_stream.WriteLine(m_textEncoding, rndCmd);
+
+					LastCommandTimestamp = DateTime.UtcNow;
+
+					Status.DaemonAnyNoops = true;
+
+					if (Status.DaemonGetReply) {
+						bool s = GetReplyInternal(rndCmd + " (daemon)", false, 10000).Success;
+
+						if (s) {
+							if (rndCmd.StartsWith("Type I")) {
+								Status.CurrentDataType = FtpDataType.Binary;
+							}
+
+							if (rndCmd.StartsWith("Type A")) {
+								Status.CurrentDataType = FtpDataType.ASCII;
+							}
+						}
+					}
+
+				}
+
+				Thread.Sleep(100);
+
+			} while (true);
+
+		}
+
+	}
+}

--- a/FluentFTP/Client/BaseClient/Daemon.cs
+++ b/FluentFTP/Client/BaseClient/Daemon.cs
@@ -61,11 +61,11 @@ namespace FluentFTP.Client.BaseClient {
 						// in case one of these commands is issued, make sure we store that
 
 						if (s) {
-							if (rndCmd.StartsWith("Type I")) {
+							if (rndCmd.StartsWith("TYPE I")) {
 								Status.CurrentDataType = FtpDataType.Binary;
 							}
 
-							if (rndCmd.StartsWith("Type A")) {
+							if (rndCmd.StartsWith("TYPE A")) {
 								Status.CurrentDataType = FtpDataType.ASCII;
 							}
 						}

--- a/FluentFTP/Client/BaseClient/Daemon.cs
+++ b/FluentFTP/Client/BaseClient/Daemon.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace FluentFTP.Client.BaseClient {
 

--- a/FluentFTP/Client/BaseClient/Daemon.cs
+++ b/FluentFTP/Client/BaseClient/Daemon.cs
@@ -37,7 +37,8 @@ namespace FluentFTP.Client.BaseClient {
 						rndNormalCmds[rnd.Next(rndNormalCmds.Count)] :
 						rndNormalCmds[rnd.Next(rndSafeCmds.Count)];
 
-					lock (m_lock) {
+					m_sema.Wait();
+					try {
 						// only log this if we have an active data connection
 						if (!Status.DaemonGetReply) {
 							LogWithPrefix(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (daemon)");
@@ -70,7 +71,10 @@ namespace FluentFTP.Client.BaseClient {
 
 						}
 					}
-
+					finally
+					{
+						m_sema.Release();
+					}
 				}
 
 				Thread.Sleep(100);

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using FluentFTP.Client.Modules;
+﻿using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
+
+using System;
 
 namespace FluentFTP.Client.BaseClient {
 

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -76,7 +76,8 @@ namespace FluentFTP.Client.BaseClient {
 			Log(FtpTraceLevel.Info, "Command:  " + cleanedCommand);
 
 			// send command to FTP server and get the reply
-			lock (m_lock) {
+			m_sema.Wait();
+			try {
 				m_stream.WriteLine(m_textEncoding, command);
 				LastCommandExecuted = command;
 				LastCommandTimestamp = DateTime.UtcNow;
@@ -90,6 +91,9 @@ namespace FluentFTP.Client.BaseClient {
 						ConnectModule.CheckCriticalSequence(this, command);
 					}
 				}
+			}
+			finally {
+				m_sema.Release();
 			}
 
 			return reply;

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Linq;
+﻿using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
+
+using System;
+using System.Linq;
 using System.Text.RegularExpressions;
-using FluentFTP.Client.Modules;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -77,6 +77,8 @@ namespace FluentFTP.Client.BaseClient {
 				long previousElapsedTime = 0;
 
 				if (exhaustNoop) {
+					Status.DaemonEnable = false;
+
 					// tickle the server
 					m_stream.WriteLine(Encoding, "NOOP");
 				}
@@ -181,6 +183,8 @@ namespace FluentFTP.Client.BaseClient {
 				if (exhaustNoop) {
 					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
+
+				Status.DaemonEnable = true;
 
 				reply = ProcessGetReply(reply, command);
 

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -56,139 +56,135 @@ namespace FluentFTP.Client.BaseClient {
 		protected FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut) {
 			var reply = new FtpReply();
 
-			lock (m_lock) {
+			if (string.IsNullOrEmpty(command)) {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for a response");
+			}
+			else {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + LogMaskModule.MaskCommand(this, command));
+			}
 
-				if (string.IsNullOrEmpty(command)) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for a response");
+			Status.IgnoreStaleData = false;
+
+			string sequence = string.Empty;
+
+			string response;
+
+			var sw = new Stopwatch();
+
+			long elapsedTime;
+			long previousElapsedTime = 0;
+
+			if (exhaustNoop) {
+				Status.DaemonEnable = false;
+
+				// tickle the server
+				m_stream.WriteLine(Encoding, "NOOP");
+			}
+
+			sw.Start();
+
+			do {
+				if (!IsConnected) {
+					throw new InvalidOperationException("No connection to the server exists.");
 				}
-				else {
-					LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for response to: " + LogMaskModule.MaskCommand(this, command));
-				}
 
-				Status.IgnoreStaleData = false;
+				elapsedTime = sw.ElapsedMilliseconds;
 
-				string sequence = string.Empty;
-
-				string response;
-
-				var sw = new Stopwatch();
-
-				long elapsedTime;
-				long previousElapsedTime = 0;
+				response = null;
 
 				if (exhaustNoop) {
-					Status.DaemonEnable = false;
 
-					// tickle the server
-					m_stream.WriteLine(Encoding, "NOOP");
-				}
+					// If we are exhausting NOOPs, use a non-blocking ReadLine(...)
+					// as we don't want a timeout exception, which would disconnect us.
 
-				sw.Start();
-
-				do {
-					if (!IsConnected) {
-						throw new InvalidOperationException("No connection to the server exists.");
+					if (elapsedTime > timeOut) {
+						break;
 					}
 
-					elapsedTime = sw.ElapsedMilliseconds;
-
-					response = null;
-
-					if (exhaustNoop) {
-
-						// If we are exhausting NOOPs, use a non-blocking ReadLine(...)
-						// as we don't want a timeout exception, which would disconnect us.
-
-						if (elapsedTime > timeOut) {
-							break;
+					if (m_stream.SocketDataAvailable > 0) {
+						response = m_stream.ReadLine(Encoding);
+					}
+					else {
+						if (elapsedTime > (previousElapsedTime + 1000)) {
+							previousElapsedTime = elapsedTime;
+							LogWithPrefix(FtpTraceLevel.Verbose, "Waiting - " + ((timeOut - elapsedTime) / 1000).ToString() + " seconds left");
+							// if we have more then 5 seconds left, tickle the server some more
+							if (timeOut - elapsedTime >= 5000) {
+								m_stream.WriteLine(Encoding, "NOOP");
+							}
 						}
+					}
 
+				}
+				else {
+
+					// If we are not exhausting NOOPs, i.e. doing a normal GetReply(...)
+
+					if (elapsedTime > Config.ReadTimeout) {
+						throw new System.TimeoutException();
+					}
+
+					// we normally need blocking reads apart from some special cases indicated
+					// by parameter timeOut having been set to -1
+
+					if (timeOut >= 0) {
+						// BLOCKING read
+						m_stream.ReadTimeout = Config.ReadTimeout;
+						response = m_stream.ReadLine(Encoding);
+					}
+					else {
+						// NON BLOCKING read
 						if (m_stream.SocketDataAvailable > 0) {
 							response = m_stream.ReadLine(Encoding);
 						}
-						else {
-							if (elapsedTime > (previousElapsedTime + 1000)) {
-								previousElapsedTime = elapsedTime;
-								LogWithPrefix(FtpTraceLevel.Verbose, "Waiting - " + ((timeOut - elapsedTime) / 1000).ToString() + " seconds left");
-								// if we have more then 5 seconds left, tickle the server some more
-								if (timeOut - elapsedTime >= 5000) {
-									m_stream.WriteLine(Encoding, "NOOP");
-								}
-							}
-						}
-
-					}
-					else {
-
-						// If we are not exhausting NOOPs, i.e. doing a normal GetReply(...)
-
-						if (elapsedTime > Config.ReadTimeout) {
-							throw new System.TimeoutException();
-						}
-
-						// we normally need blocking reads apart from some special cases indicated
-						// by parameter timeOut having been set to -1
-
-						if (timeOut >= 0) {
-							// BLOCKING read
-							m_stream.ReadTimeout = Config.ReadTimeout;
-							response = m_stream.ReadLine(Encoding);
-						}
-						else {
-							// NON BLOCKING read
-							if (m_stream.SocketDataAvailable > 0) {
-								response = m_stream.ReadLine(Encoding);
-							}
-						}
-
 					}
 
-					if (string.IsNullOrEmpty(response)) {
-						Thread.Sleep(100);
-						continue;
-					}
-
-					sequence += "," + response.Split(' ')[0];
-
-					if (exhaustNoop &&
-						((response.StartsWith("200") && (response.IndexOf("NOOP", StringComparison.InvariantCultureIgnoreCase) >= 0)) ||
-						response.StartsWith("500"))) {
-
-						Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
-
-						continue;
-					}
-
-					if (DecodeStringToReply(response, ref reply)) {
-
-						if (exhaustNoop) {
-							// We need to perhaps exhaust more NOOP responses
-							continue;
-						}
-						else {
-							// On a normal GetReply(...) we are happy to collect the
-							// first valid response
-							break;
-						}
-
-					}
-
-					// Accumulate all responses
-					reply.InfoMessages += response + "\n";
-
-				} while (true);
-
-				sw.Stop();
-
-				if (exhaustNoop) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
 
-				Status.DaemonEnable = true;
+				if (string.IsNullOrEmpty(response)) {
+					Thread.Sleep(100);
+					continue;
+				}
 
-				reply = ProcessGetReply(reply, command);
+				sequence += "," + response.Split(' ')[0];
 
-			} // lock
+				if (exhaustNoop &&
+					((response.StartsWith("200") && (response.IndexOf("NOOP", StringComparison.InvariantCultureIgnoreCase) >= 0)) ||
+					response.StartsWith("500"))) {
+
+					Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
+
+					continue;
+				}
+
+				if (DecodeStringToReply(response, ref reply)) {
+
+					if (exhaustNoop) {
+						// We need to perhaps exhaust more NOOP responses
+						continue;
+					}
+					else {
+						// On a normal GetReply(...) we are happy to collect the
+						// first valid response
+						break;
+					}
+
+				}
+
+				// Accumulate all responses
+				reply.InfoMessages += response + "\n";
+
+			} while (true);
+
+			sw.Stop();
+
+			if (exhaustNoop) {
+				LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
+			}
+
+			Status.DaemonEnable = true;
+
+			reply = ProcessGetReply(reply, command);
 
 			return reply;
 		}

--- a/FluentFTP/Client/BaseClient/GetWorkingDirectory.cs
+++ b/FluentFTP/Client/BaseClient/GetWorkingDirectory.cs
@@ -26,11 +26,9 @@ namespace FluentFTP.Client.BaseClient {
 		protected FtpReply ReadCurrentWorkingDirectory() {
 			FtpReply reply;
 
-			lock (m_lock) {
-				// read the absolute path of the current working dir
-				if (!(reply = ((IInternalFtpClient)this).ExecuteInternal("PWD")).Success) {
-					throw new FtpCommandException(reply);
-				}
+			// read the absolute path of the current working dir
+			if (!(reply = ((IInternalFtpClient)this).ExecuteInternal("PWD")).Success) {
+				throw new FtpCommandException(reply);
 			}
 
 			// cache the last working dir

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -122,12 +122,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// Used for internally synchronizing access to this
 		/// object from multiple threads in SYNC code
 		/// </summary>
-		protected readonly object m_lock = new object();
-
-		/// <summary>
-		/// For usage by FTP proxies only
-		/// </summary>
-		protected object Lock => m_lock;
+		protected SemaphoreSlim m_sema = new SemaphoreSlim(1, 1);
 
 		/// <summary>
 		/// Control connection socket stream

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -9,6 +9,7 @@ using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace FluentFTP.Client.BaseClient {
 
@@ -84,8 +85,7 @@ namespace FluentFTP.Client.BaseClient {
 		}
 
 		/// <summary>
-		/// When last command was sent (NOOP or other), for having <see cref="FtpClient.Noop"/>/<see cref="AsyncFtpClient.NoopAsync(CancellationToken)"/>.
-		/// Respects the <see cref="FtpConfig.NoopInterval"/>.
+		/// When last command was sent (NOOP or other)/>.
 		/// </summary>
 		protected DateTime LastCommandTimestamp;
 
@@ -99,6 +99,11 @@ namespace FluentFTP.Client.BaseClient {
 		protected string LastStreamPath;
 
 		protected FtpListParser CurrentListParser;
+
+		/// <summary>
+		/// A thread for background tasks
+		/// </summary>
+		protected Task m_task;
 
 		// Holds the cached resolved address
 		protected string m_Address;

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -120,7 +120,7 @@ namespace FluentFTP.Client.BaseClient {
 
 		/// <summary>
 		/// Used for internally synchronizing access to this
-		/// object from multiple threads
+		/// object from multiple threads in SYNC code
 		/// </summary>
 		protected readonly object m_lock = new object();
 

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -102,7 +102,6 @@ namespace FluentFTP.Client.BaseClient {
 		/// object.
 		/// </summary>
 		public virtual void Dispose() {
-			lock (m_lock) {
 				if (IsDisposed) {
 					return;
 				}
@@ -143,7 +142,6 @@ namespace FluentFTP.Client.BaseClient {
 
 				IsDisposed = true;
 				GC.SuppressFinalize(this);
-			}
 		}
 
 		/// <summary>

--- a/FluentFTP/Client/SyncClient/AutoDetect.cs
+++ b/FluentFTP/Client/SyncClient/AutoDetect.cs
@@ -18,17 +18,15 @@ namespace FluentFTP {
 		/// <returns></returns>
 		public List<FtpProfile> AutoDetect(FtpAutoDetectConfig config = null) {
 
-			lock (m_lock) {
-				LogFunction(nameof(AutoDetect), config);
+			LogFunction(nameof(AutoDetect), config);
 
-				if (config == null) {
-					config = new FtpAutoDetectConfig();
-				}
-
-				ValidateAutoDetect();
-
-				return ConnectModule.AutoDetect(this, config);
+			if (config == null) {
+				config = new FtpAutoDetectConfig();
 			}
+
+			ValidateAutoDetect();
+
+			return ConnectModule.AutoDetect(this, config);
 		}
 
 		/// <summary>
@@ -45,15 +43,13 @@ namespace FluentFTP {
 		/// <returns></returns>
 		public List<FtpProfile> AutoDetect(bool firstOnly = true, bool cloneConnection = true) {
 
-			lock (m_lock) {
-				LogFunction(nameof(AutoDetect), new object[] { firstOnly, cloneConnection });
-				ValidateAutoDetect();
+			LogFunction(nameof(AutoDetect), new object[] { firstOnly, cloneConnection });
+			ValidateAutoDetect();
 
-				return ConnectModule.AutoDetect(this, new FtpAutoDetectConfig() {
-					FirstOnly = firstOnly,
-					CloneConnection = cloneConnection,
-				});
-			}
+			return ConnectModule.AutoDetect(this, new FtpAutoDetectConfig() {
+				FirstOnly = firstOnly,
+				CloneConnection = cloneConnection,
+			});
 		}
 	}
 }

--- a/FluentFTP/Client/SyncClient/AutoDetect.cs
+++ b/FluentFTP/Client/SyncClient/AutoDetect.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Threading;
-using FluentFTP.Client.Modules;
-using System.Threading.Tasks;
+﻿using FluentFTP.Client.Modules;
 using FluentFTP.Model.Functions;
+
+using System.Collections.Generic;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -39,206 +39,203 @@ namespace FluentFTP {
 		public virtual void Connect(bool reConnect) {
 			FtpReply reply;
 
-			lock (m_lock) {
+			LogFunction(nameof(Connect), new object[] { reConnect });
 
-				LogFunction(nameof(Connect), new object[] { reConnect });
+			// If we have never been connected before...
+			if (reConnect && Status.ConnectCount == 0) {
+				reConnect = false;
+				LogWithPrefix(FtpTraceLevel.Warn, "Cannot reconnect, reverting to full connect");
+			}
 
-				// If we have never been connected before...
-				if (reConnect && Status.ConnectCount == 0) {
-					reConnect = false;
-					LogWithPrefix(FtpTraceLevel.Warn, "Cannot reconnect, reverting to full connect");
+			if (reConnect) {
+				LogWithPrefix(FtpTraceLevel.Warn, "Reconnect (Count: " + Status.ConnectCount + ")");
+			}
+			else {
+				Status.ConnectCount = 0;
+			}
+
+			Status.ConnectCount++;
+
+			LogVersion();
+
+			if (IsDisposed) {
+				throw new ObjectDisposedException("This FtpClient object has been disposed. It is no longer accessible.");
+			}
+
+			if (m_stream == null) {
+				m_stream = new FtpSocketStream(this);
+				m_stream.ValidateCertificate += new FtpSocketStreamSslValidation(FireValidateCertficate);
+			}
+			else {
+				if (IsConnected) {
+					((IInternalFtpClient)this).DisconnectInternal();
 				}
+			}
 
-				if (reConnect) {
-					LogWithPrefix(FtpTraceLevel.Warn, "Reconnect (Count: " + Status.ConnectCount + ")");
+			if (Host == null) {
+				throw new FtpException("No host has been specified");
+			}
+
+			if (m_capabilities == null) {
+				m_capabilities = new List<FtpCapability>();
+			}
+
+			Status.Reset(reConnect);
+			m_stream.SslSessionLength = 0;
+
+			m_hashAlgorithms = FtpHashAlgorithm.NONE;
+			m_stream.ConnectTimeout = Config.ConnectTimeout;
+			m_stream.SocketPollInterval = Config.SocketPollInterval;
+			Connect(m_stream);
+
+			m_stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);
+
+			if (Config.EncryptionMode == FtpEncryptionMode.Implicit) {
+				m_stream.ActivateEncryption(Host,
+					Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
+					Config.SslProtocols);
+			}
+
+			Handshake();
+			m_serverType = ServerModule.DetectFtpServer(this, HandshakeReply);
+
+			if (Config.SendHost) {
+				if (!(reply = Execute("HOST " + (Config.SendHostDomain ?? Host))).Success) {
+					throw new FtpException("HOST command failed.");
 				}
-				else {
-					Status.ConnectCount = 0;
-				}
+			}
 
-				Status.ConnectCount++;
-
-				LogVersion();
-
-				if (IsDisposed) {
-					throw new ObjectDisposedException("This FtpClient object has been disposed. It is no longer accessible.");
-				}
-
-				if (m_stream == null) {
-					m_stream = new FtpSocketStream(this);
-					m_stream.ValidateCertificate += new FtpSocketStreamSslValidation(FireValidateCertficate);
-				}
-				else {
-					if (IsConnected) {
-						((IInternalFtpClient)this).DisconnectInternal();
+			// try to upgrade this connection to SSL if supported by the server
+			if (Config.EncryptionMode is FtpEncryptionMode.Explicit or FtpEncryptionMode.Auto) {
+				reply = Execute("AUTH TLS");
+				if (!reply.Success) {
+					Status.ConnectionFTPSFailure = true;
+					if (Config.EncryptionMode == FtpEncryptionMode.Explicit) {
+						throw new FtpSecurityNotAvailableException("AUTH TLS command failed.");
 					}
 				}
-
-				if (Host == null) {
-					throw new FtpException("No host has been specified");
-				}
-
-				if (m_capabilities == null) {
-					m_capabilities = new List<FtpCapability>();
-				}
-
-				Status.Reset(reConnect);
-				m_stream.SslSessionLength = 0;
-
-				m_hashAlgorithms = FtpHashAlgorithm.NONE;
-				m_stream.ConnectTimeout = Config.ConnectTimeout;
-				m_stream.SocketPollInterval = Config.SocketPollInterval;
-				Connect(m_stream);
-
-				m_stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);
-
-				if (Config.EncryptionMode == FtpEncryptionMode.Implicit) {
+				else {
 					m_stream.ActivateEncryption(Host,
 						Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
 						Config.SslProtocols);
 				}
+			}
 
-				Handshake();
-				m_serverType = ServerModule.DetectFtpServer(this, HandshakeReply);
+			if (m_credentials != null) {
+				Authenticate();
+			}
 
-				if (Config.SendHost) {
-					if (!(reply = Execute("HOST " + (Config.SendHostDomain ?? Host))).Success) {
-						throw new FtpException("HOST command failed.");
-					}
+			// configure the default FTPS settings
+			if (IsEncrypted && Config.DataConnectionEncryption) {
+				if (!(reply = Execute("PBSZ 0")).Success) {
+					throw new FtpCommandException(reply);
 				}
 
-				// try to upgrade this connection to SSL if supported by the server
-				if (Config.EncryptionMode is FtpEncryptionMode.Explicit or FtpEncryptionMode.Auto) {
-					reply = Execute("AUTH TLS");
-					if (!reply.Success) {
-						Status.ConnectionFTPSFailure = true;
-						if (Config.EncryptionMode == FtpEncryptionMode.Explicit) {
-							throw new FtpSecurityNotAvailableException("AUTH TLS command failed.");
-						}
-					}
-					else {
-						m_stream.ActivateEncryption(Host,
-							Config.ClientCertificates.Count > 0 ? Config.ClientCertificates : null,
-							Config.SslProtocols);
-					}
+				if (!(reply = Execute("PROT P")).Success) {
+					throw new FtpCommandException(reply);
 				}
+			}
 
-				if (m_credentials != null) {
-					Authenticate();
-				}
-
-				// configure the default FTPS settings
-				if (IsEncrypted && Config.DataConnectionEncryption) {
-					if (!(reply = Execute("PBSZ 0")).Success) {
-						throw new FtpCommandException(reply);
-					}
-
-					if (!(reply = Execute("PROT P")).Success) {
-						throw new FtpCommandException(reply);
-					}
-				}
-
-				// if this is a clone these values should have already been loaded
-				// so save some bandwidth and CPU time and skip executing this again.
-				// otherwise clear the capabilities in case connection is reused to 
-				// a different server 
-				if (!reConnect && !m_isClone && Config.CheckCapabilities) {
-					m_capabilities.Clear();
-				}
-				bool assumeCaps = false;
-				if (m_capabilities.IsBlank() && Config.CheckCapabilities) {
-					if ((reply = Execute("FEAT")).Success && reply.InfoMessages != null) {
-						GetFeatures(reply);
-					}
-					else {
-						assumeCaps = true;
-					}
-				}
-
-				// Enable UTF8 if the encoding is ASCII and UTF8 is supported
-				if (m_textEncodingAutoUTF && m_textEncoding == Encoding.ASCII && HasFeature(FtpCapability.UTF8)) {
-					m_textEncoding = Encoding.UTF8;
-				}
-
-				LogWithPrefix(FtpTraceLevel.Info, "Text encoding: " + m_textEncoding.ToString());
-
-				if (m_textEncoding == Encoding.UTF8) {
-					// If the server supports UTF8 it should already be enabled and this
-					// command should not matter however there are conflicting drafts
-					// about this so we'll just execute it to be safe. 
-					if ((reply = Execute("OPTS UTF8 ON")).Success) {
-						Status.ConnectionUTF8Success = true;
-					}
-				}
-
-				// Get the system type - Needed to auto-detect file listing parser
-				if ((reply = Execute("SYST")).Success) {
-					m_systemType = reply.Message;
-					m_serverType = ServerModule.DetectFtpServerBySyst(this);
-					m_serverOS = ServerModule.DetectFtpOSBySyst(this);
-				}
-
-				// Set a FTP server handler if a custom handler has not already been set
-				if (ServerHandler == null) {
-					ServerHandler = ServerModule.GetServerHandler(m_serverType);
-				}
-
-				LogWithPrefix(FtpTraceLevel.Verbose, "Active ServerHandler is: " + (ServerHandler == null ? "None" : ServerHandler.ToEnum().ToString()));
-
-				// Assume the system's capabilities if FEAT command not supported by the server
-				if (assumeCaps) {
-					ServerFeatureModule.Assume(ServerHandler, m_capabilities, ref m_hashAlgorithms);
-				}
-
-				// Unless a custom list parser has been set,
-				// Detect the listing parser and prefer machine listings over any other type
-				// FIX : #739 prefer using machine listings to fix issues with GetListing and DeleteDirectory
-				if (Config.ListingParser != FtpParser.Custom) {
-					Config.ListingParser = ServerHandler != null ? ServerHandler.GetParser() : FtpParser.Auto;
-					if (HasFeature(FtpCapability.MLSD)) {
-						Config.ListingParser = FtpParser.Machine;
-					}
-				}
-
-				// Create the parser even if the auto-OS detection failed
-				CurrentListParser.Init(m_serverOS, Config.ListingParser);
-
-				// Execute server-specific post-connection event
-				ServerHandler?.AfterConnected(this);
-
-				if (reConnect) {
-					// Restore important settings from prior to reconnect
-
-					// restore Status.DataType
-					var oldDataType = Status.CurrentDataType;
-					Status.CurrentDataType = FtpDataType.Unknown;
-					SetDataTypeNoLock(oldDataType);
-
-					// restore Status.LastWorkingDir
-					if (Status.LastWorkingDir != null) {
-						SetWorkingDirectory(Status.LastWorkingDir);
-					}
+			// if this is a clone these values should have already been loaded
+			// so save some bandwidth and CPU time and skip executing this again.
+			// otherwise clear the capabilities in case connection is reused to 
+			// a different server 
+			if (!reConnect && !m_isClone && Config.CheckCapabilities) {
+				m_capabilities.Clear();
+			}
+			bool assumeCaps = false;
+			if (m_capabilities.IsBlank() && Config.CheckCapabilities) {
+				if ((reply = Execute("FEAT")).Success && reply.InfoMessages != null) {
+					GetFeatures(reply);
 				}
 				else {
-					// Set important settings
-
-					// set Status.DataType (also: FIX : #318)
-					Status.CurrentDataType = FtpDataType.Unknown;
-
-					// set Status.LastWorkingDir: no need
+					assumeCaps = true;
 				}
+			}
 
-				// Need to know where we are in case a reconnect needs to be done
-				_ = GetWorkingDirectory();
+			// Enable UTF8 if the encoding is ASCII and UTF8 is supported
+			if (m_textEncodingAutoUTF && m_textEncoding == Encoding.ASCII && HasFeature(FtpCapability.UTF8)) {
+				m_textEncoding = Encoding.UTF8;
+			}
 
-				// FIX #922: disable checking for stale data during connection
-				Status.AllowCheckStaleData = true;
+			LogWithPrefix(FtpTraceLevel.Info, "Text encoding: " + m_textEncoding.ToString());
 
-				Status.InCriticalSequence = false;
-
-				if (!Status.DaemonRunning) {
-					m_task = Task.Run(() => { Daemon(); });
+			if (m_textEncoding == Encoding.UTF8) {
+				// If the server supports UTF8 it should already be enabled and this
+				// command should not matter however there are conflicting drafts
+				// about this so we'll just execute it to be safe. 
+				if ((reply = Execute("OPTS UTF8 ON")).Success) {
+					Status.ConnectionUTF8Success = true;
 				}
+			}
+
+			// Get the system type - Needed to auto-detect file listing parser
+			if ((reply = Execute("SYST")).Success) {
+				m_systemType = reply.Message;
+				m_serverType = ServerModule.DetectFtpServerBySyst(this);
+				m_serverOS = ServerModule.DetectFtpOSBySyst(this);
+			}
+
+			// Set a FTP server handler if a custom handler has not already been set
+			if (ServerHandler == null) {
+				ServerHandler = ServerModule.GetServerHandler(m_serverType);
+			}
+
+			LogWithPrefix(FtpTraceLevel.Verbose, "Active ServerHandler is: " + (ServerHandler == null ? "None" : ServerHandler.ToEnum().ToString()));
+
+			// Assume the system's capabilities if FEAT command not supported by the server
+			if (assumeCaps) {
+				ServerFeatureModule.Assume(ServerHandler, m_capabilities, ref m_hashAlgorithms);
+			}
+
+			// Unless a custom list parser has been set,
+			// Detect the listing parser and prefer machine listings over any other type
+			// FIX : #739 prefer using machine listings to fix issues with GetListing and DeleteDirectory
+			if (Config.ListingParser != FtpParser.Custom) {
+				Config.ListingParser = ServerHandler != null ? ServerHandler.GetParser() : FtpParser.Auto;
+				if (HasFeature(FtpCapability.MLSD)) {
+					Config.ListingParser = FtpParser.Machine;
+				}
+			}
+
+			// Create the parser even if the auto-OS detection failed
+			CurrentListParser.Init(m_serverOS, Config.ListingParser);
+
+			// Execute server-specific post-connection event
+			ServerHandler?.AfterConnected(this);
+
+			if (reConnect) {
+				// Restore important settings from prior to reconnect
+
+				// restore Status.DataType
+				var oldDataType = Status.CurrentDataType;
+				Status.CurrentDataType = FtpDataType.Unknown;
+				SetDataType(oldDataType);
+
+				// restore Status.LastWorkingDir
+				if (Status.LastWorkingDir != null) {
+					SetWorkingDirectory(Status.LastWorkingDir);
+				}
+			}
+			else {
+				// Set important settings
+
+				// set Status.DataType (also: FIX : #318)
+				Status.CurrentDataType = FtpDataType.Unknown;
+
+				// set Status.LastWorkingDir: no need
+			}
+
+			// Need to know where we are in case a reconnect needs to be done
+			_ = GetWorkingDirectory();
+
+			// FIX #922: disable checking for stale data during connection
+			Status.AllowCheckStaleData = true;
+
+			Status.InCriticalSequence = false;
+
+			if (!Status.DaemonRunning) {
+				m_task = Task.Run(() => { Daemon(); });
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -1,12 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Threading;
-using FluentFTP.Client.Modules;
-using System.Threading.Tasks;
-using System;
-using System.Net.Sockets;
-using System.Text;
-using FluentFTP.Helpers;
+﻿using FluentFTP.Client.Modules;
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
+
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using System.Text;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -41,7 +41,7 @@ namespace FluentFTP {
 
 			lock (m_lock) {
 
-				LogFunction(nameof(Connect), new object[] {reConnect});
+				LogFunction(nameof(Connect), new object[] { reConnect });
 
 				// If we have never been connected before...
 				if (reConnect && Status.ConnectCount == 0) {
@@ -235,6 +235,10 @@ namespace FluentFTP {
 				Status.AllowCheckStaleData = true;
 
 				Status.InCriticalSequence = false;
+
+				if (!Status.DaemonRunning) {
+					m_task = Task.Run(() => { Daemon(); });
+				}
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/CreateDirectory.cs
+++ b/FluentFTP/Client/SyncClient/CreateDirectory.cs
@@ -38,45 +38,42 @@ namespace FluentFTP {
 				return false;
 			}
 
-			lock (m_lock) {
-
-				// server-specific directory creation
-				// ask the server handler to create a directory
-				if (ServerHandler != null) {
-					if (ServerHandler.CreateDirectory(this, path, path, force)) {
-						return true;
-					}
+			// server-specific directory creation
+			// ask the server handler to create a directory
+			if (ServerHandler != null) {
+				if (ServerHandler.CreateDirectory(this, path, path, force)) {
+					return true;
 				}
-
-				path = path.TrimEnd('/');
-
-				if (force && !DirectoryExists(path.GetFtpDirectoryName())) {
-					LogWithPrefix(FtpTraceLevel.Verbose, "Create non-existent parent directory: " + path.GetFtpDirectoryName());
-					CreateDirectory(path.GetFtpDirectoryName(), true);
-				}
-
-				// fix: improve performance by skipping the directory exists check
-				/*else if (DirectoryExists(path)) {
-					return false;
-				}*/
-
-				LogWithPrefix(FtpTraceLevel.Verbose, "CreateDirectory " + path);
-
-				if (!(reply = Execute("MKD " + path)).Success) {
-
-					// if the error indicates the directory already exists, its not an error
-					if (reply.Code == "550") {
-						return false;
-					}
-					if (reply.Code[0] == '5' && reply.Message.ContainsAnyCI(ServerStringModule.folderExists)) {
-						return false;
-					}
-
-					throw new FtpCommandException(reply);
-				}
-				return true;
-
 			}
+
+			path = path.TrimEnd('/');
+
+			if (force && !DirectoryExists(path.GetFtpDirectoryName())) {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Create non-existent parent directory: " + path.GetFtpDirectoryName());
+				CreateDirectory(path.GetFtpDirectoryName(), true);
+			}
+
+			// fix: improve performance by skipping the directory exists check
+			/*else if (DirectoryExists(path)) {
+				return false;
+			}*/
+
+			LogWithPrefix(FtpTraceLevel.Verbose, "CreateDirectory " + path);
+
+			if (!(reply = Execute("MKD " + path)).Success) {
+
+				// if the error indicates the directory already exists, its not an error
+				if (reply.Code == "550") {
+					return false;
+				}
+				if (reply.Code[0] == '5' && reply.Message.ContainsAnyCI(ServerStringModule.folderExists)) {
+					return false;
+				}
+
+				throw new FtpCommandException(reply);
+			}
+			return true;
+
 		}
 	}
 }

--- a/FluentFTP/Client/SyncClient/CreateDirectory.cs
+++ b/FluentFTP/Client/SyncClient/CreateDirectory.cs
@@ -1,8 +1,6 @@
-﻿using FluentFTP.Helpers;
-using System.Threading;
-using System.Threading.Tasks;
-using FluentFTP.Client.Modules;
+﻿using FluentFTP.Client.Modules;
 using FluentFTP.Exceptions;
+using FluentFTP.Helpers;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/DeleteDirectory.cs
+++ b/FluentFTP/Client/SyncClient/DeleteDirectory.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using FluentFTP.Exceptions;
 using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
-using System.Threading;
-using System.Threading.Tasks;
-using FluentFTP.Exceptions;
+
+using System;
+using System.Linq;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/DeleteFile.cs
+++ b/FluentFTP/Client/SyncClient/DeleteFile.cs
@@ -1,9 +1,7 @@
-﻿using System;
+﻿using FluentFTP.Exceptions;
 using FluentFTP.Helpers;
-using System.Threading;
-using FluentFTP.Client.Modules;
-using System.Threading.Tasks;
-using FluentFTP.Exceptions;
+
+using System;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/DeleteFile.cs
+++ b/FluentFTP/Client/SyncClient/DeleteFile.cs
@@ -20,14 +20,12 @@ namespace FluentFTP {
 				throw new ArgumentException("Required parameter is null or blank.", nameof(path));
 			}
 
-			lock (m_lock) {
-				path = path.GetFtpPath();
+			path = path.GetFtpPath();
 
-				LogFunction(nameof(DeleteFile), new object[] { path });
+			LogFunction(nameof(DeleteFile), new object[] { path });
 
-				if (!(reply = Execute("DELE " + path)).Success) {
-					throw new FtpCommandException(reply);
-				}
+			if (!(reply = Execute("DELE " + path)).Success) {
+				throw new FtpCommandException(reply);
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/DirectoryExists.cs
+++ b/FluentFTP/Client/SyncClient/DirectoryExists.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Linq;
+﻿using FluentFTP.Exceptions;
 using FluentFTP.Helpers;
-using FluentFTP.Client.Modules;
-using System.Threading;
-using System.Threading.Tasks;
-using FluentFTP.Exceptions;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/DirectoryExists.cs
+++ b/FluentFTP/Client/SyncClient/DirectoryExists.cs
@@ -36,20 +36,18 @@ namespace FluentFTP {
 			}
 
 			// check if a folder exists by changing the working dir to it
-			lock (m_lock) {
-				pwd = GetWorkingDirectory();
+			pwd = GetWorkingDirectory();
 
-				if (Execute("CWD " + path).Success) {
-					var reply = Execute("CWD " + pwd);
+			if (Execute("CWD " + path).Success) {
+				var reply = Execute("CWD " + pwd);
 
-					if (!reply.Success) {
-						throw new FtpException("DirectoryExists(): Failed to restore the working directory.");
-					}
-
-					return true;
+				if (!reply.Success) {
+					throw new FtpException("DirectoryExists(): Failed to restore the working directory.");
 				}
 
+				return true;
 			}
+
 
 			return false;
 		}

--- a/FluentFTP/Client/SyncClient/DisableUTF8.cs
+++ b/FluentFTP/Client/SyncClient/DisableUTF8.cs
@@ -20,14 +20,12 @@ namespace FluentFTP {
 		public void DisableUTF8() {
 			FtpReply reply;
 
-			lock (m_lock) {
-				if (!(reply = Execute("OPTS UTF8 OFF")).Success) {
-					throw new FtpCommandException(reply);
-				}
-
-				m_textEncoding = Encoding.ASCII;
-				m_textEncodingAutoUTF = false;
+			if (!(reply = Execute("OPTS UTF8 OFF")).Success) {
+				throw new FtpCommandException(reply);
 			}
+
+			m_textEncoding = Encoding.ASCII;
+			m_textEncodingAutoUTF = false;
 
 		}
 	}

--- a/FluentFTP/Client/SyncClient/DisableUTF8.cs
+++ b/FluentFTP/Client/SyncClient/DisableUTF8.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.IO;
+﻿using FluentFTP.Exceptions;
+
 using System.Text;
-using System.Collections.Generic;
-using FluentFTP.Exceptions;
-using FluentFTP.Helpers;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using FluentFTP.Client.Modules;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/Disconnect.cs
+++ b/FluentFTP/Client/SyncClient/Disconnect.cs
@@ -10,6 +10,8 @@ namespace FluentFTP {
 		/// Disconnects from the server
 		/// </summary>
 		public void Disconnect() {
+			LogFunction(nameof(Disconnect), null);
+
 			lock (m_lock) {
 				if (m_stream != null && m_stream.IsConnected) {
 					try {

--- a/FluentFTP/Client/SyncClient/Disconnect.cs
+++ b/FluentFTP/Client/SyncClient/Disconnect.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/Disconnect.cs
+++ b/FluentFTP/Client/SyncClient/Disconnect.cs
@@ -12,21 +12,18 @@ namespace FluentFTP {
 		public void Disconnect() {
 			LogFunction(nameof(Disconnect), null);
 
-			lock (m_lock) {
-				if (m_stream != null && m_stream.IsConnected) {
-					try {
-						if (Config.DisconnectWithQuit) {
-							Execute("QUIT");
-						}
-					}
-					catch (Exception ex) {
-						LogWithPrefix(FtpTraceLevel.Warn, "FtpClient.Disconnect(): Exception caught and discarded while closing control connection", ex);
-					}
-					finally {
-						m_stream.Close();
+			if (m_stream != null && m_stream.IsConnected) {
+				try {
+					if (Config.DisconnectWithQuit) {
+						Execute("QUIT");
 					}
 				}
-
+				catch (Exception ex) {
+					LogWithPrefix(FtpTraceLevel.Warn, "FtpClient.Disconnect(): Exception caught and discarded while closing control connection", ex);
+				}
+				finally {
+					m_stream.Close();
+				}
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -88,8 +88,9 @@ namespace FluentFTP {
 				var transferStarted = DateTime.Now;
 				var sw = new Stopwatch();
 
-				var anyNoop = false;
 				var earlySuccess = false;
+
+				Status.DaemonAnyNoops = false;
 
 				// Fix #554: ability to download zero-byte files
 				if (Config.DownloadZeroByteFiles && outStream == null && localPath != null) {
@@ -125,9 +126,6 @@ namespace FluentFTP {
 								ReportProgress(progress, fileLen, offset, bytesProcessed, DateTime.Now - transferStarted, localPath, remotePath, metaProgress);
 							}
 
-							// Fix #387: keep alive with NOOP as configured and needed
-							anyNoop = Noop(false) || anyNoop;
-
 							// honor the rate limit
 							var swTime = sw.ElapsedMilliseconds;
 							if (rateLimitBytes > 0) {
@@ -154,7 +152,7 @@ namespace FluentFTP {
 					catch (IOException ex) {
 						LogWithPrefix(FtpTraceLevel.Verbose, "IOException in DownloadFileInternal", ex);
 
-						FtpReply exStatus = GetReplyInternal(LastCommandExecuted + ", after IOException", anyNoop, 10000);
+						FtpReply exStatus = GetReplyInternal(LastCommandExecuted + ", after IOException", Status.DaemonAnyNoops, 10000);
 						if (exStatus.Code == "226") {
 							sw.Stop();
 							earlySuccess = true;
@@ -204,7 +202,7 @@ namespace FluentFTP {
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
-				FtpReply status = GetReplyInternal("*DOWNLOAD*", anyNoop);
+				FtpReply status = GetReplyInternal(LastCommandExecuted, Status.DaemonAnyNoops);
 
 				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
 				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
@@ -222,7 +220,7 @@ namespace FluentFTP {
 				return true;
 			}
 			catch (AuthenticationException) {
-				FtpReply reply = GetReplyInternal("*DOWNLOAD*", false, -1); // no exhaustNoop, but non-blocking
+				FtpReply reply = GetReplyInternal(LastCommandExecuted, false, -1); // no exhaustNoop, but non-blocking
 				if (!reply.Success) {
 					throw new FtpCommandException(reply);
 				}

--- a/FluentFTP/Client/SyncClient/FileExists.cs
+++ b/FluentFTP/Client/SyncClient/FileExists.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
-using System.Threading;
-using FluentFTP.Client.Modules;
-using System.Threading.Tasks;
+
+using System;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/GetChecksum.cs
+++ b/FluentFTP/Client/SyncClient/GetChecksum.cs
@@ -116,21 +116,19 @@ namespace FluentFTP {
 				return;
 			}
 
-			lock (m_lock) {
-				if ((HashAlgorithms & algorithm) != algorithm) {
-					throw new NotImplementedException("The hash algorithm " + algorithm.ToString() + " was not advertised by the server.");
-				}
-
-				string algoName = HashAlgos.PrintToString(algorithm);
-
-				if (!(reply = Execute("OPTS HASH " + algoName)).Success) {
-					throw new FtpCommandException(reply);
-				}
-
-				// save the current hash algo so no need to repeat this command
-				Status.LastHashAlgo = algorithm;
-
+			if ((HashAlgorithms & algorithm) != algorithm) {
+				throw new NotImplementedException("The hash algorithm " + algorithm.ToString() + " was not advertised by the server.");
 			}
+
+			string algoName = HashAlgos.PrintToString(algorithm);
+
+			if (!(reply = Execute("OPTS HASH " + algoName)).Success) {
+				throw new FtpCommandException(reply);
+			}
+
+			// save the current hash algo so no need to repeat this command
+			Status.LastHashAlgo = algorithm;
+
 		}
 
 		#endregion
@@ -204,11 +202,8 @@ namespace FluentFTP {
 				}
 			}
 
-			lock (m_lock) {
-				if (!(reply = Execute("HASH " + remotePath)).Success) {
-					throw new FtpCommandException(reply);
-				}
-
+			if (!(reply = Execute("HASH " + remotePath)).Success) {
+				throw new FtpCommandException(reply);
 			}
 
 			if (autoRestore) {

--- a/FluentFTP/Client/SyncClient/GetFileSize.cs
+++ b/FluentFTP/Client/SyncClient/GetFileSize.cs
@@ -33,9 +33,8 @@ namespace FluentFTP {
 			}
 
 			var sizeReply = new FtpSizeReply();
-			lock (m_lock) {
-				GetFileSizeInternal(path, sizeReply, defaultValue);
-			}
+			GetFileSizeInternal(path, sizeReply, defaultValue);
+
 			return sizeReply.FileSize;
 		}
 
@@ -49,7 +48,7 @@ namespace FluentFTP {
 
 			// Fix #137: Switch to binary mode since some servers don't support SIZE command for ASCII files.
 			if (Status.FileSizeASCIINotSupported) {
-				SetDataTypeNoLock(FtpDataType.Binary);
+				SetDataType(FtpDataType.Binary);
 			}
 
 			// execute the SIZE command

--- a/FluentFTP/Client/SyncClient/GetListing.cs
+++ b/FluentFTP/Client/SyncClient/GetListing.cs
@@ -100,22 +100,20 @@ namespace FluentFTP {
 			bool machineList;
 			CalculateGetListingCommand(path, options, out listcmd, out machineList);
 
-			lock (m_lock) {
-				if (autoNav) {
-					pwdSave = GetWorkingDirectory();
-					if (pwdSave != path) {
-						LogWithPrefix(FtpTraceLevel.Verbose, "AutoNavigate to: \"" + path + "\"");
-						SetWorkingDirectory(path);
-					}
+			if (autoNav) {
+				pwdSave = GetWorkingDirectory();
+				if (pwdSave != path) {
+					LogWithPrefix(FtpTraceLevel.Verbose, "AutoNavigate to: \"" + path + "\"");
+					SetWorkingDirectory(path);
 				}
+			}
 
-				rawlisting = GetListingInternal(listcmd, options, true);
+			rawlisting = GetListingInternal(listcmd, options, true);
 
-				if (autoRestore) {
-					if (pwdSave != GetWorkingDirectory()) {
-						LogWithPrefix(FtpTraceLevel.Verbose, "AutoNavigate-restore to: \"" + pwdSave + "\"");
-						SetWorkingDirectory(pwdSave);
-					}
+			if (autoRestore) {
+				if (pwdSave != GetWorkingDirectory()) {
+					LogWithPrefix(FtpTraceLevel.Verbose, "AutoNavigate-restore to: \"" + pwdSave + "\"");
+					SetWorkingDirectory(pwdSave);
 				}
 			}
 
@@ -197,7 +195,7 @@ namespace FluentFTP {
 			var isUseStat = options.HasFlag(FtpListOption.UseStat);
 
 			// Get the file listing in the desired format
-			SetDataTypeNoLock(Config.ListingDataType);
+			SetDataType(Config.ListingDataType);
 
 			try {
 				// read in raw file listing from control stream

--- a/FluentFTP/Client/SyncClient/GetModifiedTime.cs
+++ b/FluentFTP/Client/SyncClient/GetModifiedTime.cs
@@ -25,15 +25,12 @@ namespace FluentFTP {
 			var date = DateTime.MinValue;
 			FtpReply reply;
 
-			lock (m_lock) {
-
-				// get modified date of a file
-				if ((reply = Execute("MDTM " + path)).Success) {
-					date = reply.Message.ParseFtpDate(this);
-					date = ConvertDate(date);
-				}
-
+			// get modified date of a file
+			if ((reply = Execute("MDTM " + path)).Success) {
+				date = reply.Message.ParseFtpDate(this);
+				date = ConvertDate(date);
 			}
+
 			return date;
 		}
 

--- a/FluentFTP/Client/SyncClient/GetNameListing.cs
+++ b/FluentFTP/Client/SyncClient/GetNameListing.cs
@@ -39,54 +39,51 @@ namespace FluentFTP {
 
 			path = GetAbsolutePath(path);
 
-			lock (m_lock) {
+			// always get the file listing in binary to avoid character translation issues with ASCII.
+			SetDataType(Config.ListingDataType);
 
-				// always get the file listing in binary to avoid character translation issues with ASCII.
-				SetDataTypeNoLock(Config.ListingDataType);
+			// read in raw listing
+			try {
+				using (var stream = OpenDataStream("NLST " + path, 0)) {
+					Log(FtpTraceLevel.Verbose, "+---------------------------------------+");
+					string line;
 
-				// read in raw listing
-				try {
-					using (var stream = OpenDataStream("NLST " + path, 0)) {
-						Log(FtpTraceLevel.Verbose, "+---------------------------------------+");
-						string line;
-
-						try {
-							while ((line = stream.ReadLine(Encoding)) != null) {
-								listing.Add(line);
-								Log(FtpTraceLevel.Verbose, "Listing:  " + line);
-							}
+					try {
+						while ((line = stream.ReadLine(Encoding)) != null) {
+							listing.Add(line);
+							Log(FtpTraceLevel.Verbose, "Listing:  " + line);
 						}
-						finally {
-							// We want to close/dispose it NOW, and not when the GM
-							// gets around to it (after the "using" expires).
-							stream.Close();
-						}
-						Log(FtpTraceLevel.Verbose, "+---------------------------------------+");
 					}
-				}
-				catch (AuthenticationException) {
-					FtpReply reply = GetReplyInternal("NLST " + path, false, -1); // no exhaustNoop, but non-blocking
-					if (!reply.Success) {
-						throw new FtpCommandException(reply);
+					finally {
+						// We want to close/dispose it NOW, and not when the GM
+						// gets around to it (after the "using" expires).
+						stream.Close();
 					}
-					throw;
+					Log(FtpTraceLevel.Verbose, "+---------------------------------------+");
 				}
-				catch (FtpMissingSocketException) {
-					// Some FTP server does not send any response when listing an empty directory
-					// and the connection fails because no communication socket is provided by the server
-				}
-				catch (FtpCommandException ftpEx) {
-					// Some FTP servers throw 450 or 550 for empty folders. Absorb these.
-					if (ftpEx.CompletionCode == null ||
-						(!ftpEx.CompletionCode.StartsWith("450") && !ftpEx.CompletionCode.StartsWith("550")) ) {
-						throw ftpEx;
-					}
-				}
-				catch (IOException) {
-					// Some FTP servers forcibly close the connection, we absorb these errors
-				}
-
 			}
+			catch (AuthenticationException) {
+				FtpReply reply = GetReplyInternal("NLST " + path, false, -1); // no exhaustNoop, but non-blocking
+				if (!reply.Success) {
+					throw new FtpCommandException(reply);
+				}
+				throw;
+			}
+			catch (FtpMissingSocketException) {
+				// Some FTP server does not send any response when listing an empty directory
+				// and the connection fails because no communication socket is provided by the server
+			}
+			catch (FtpCommandException ftpEx) {
+				// Some FTP servers throw 450 or 550 for empty folders. Absorb these.
+				if (ftpEx.CompletionCode == null ||
+					(!ftpEx.CompletionCode.StartsWith("450") && !ftpEx.CompletionCode.StartsWith("550"))) {
+					throw ftpEx;
+				}
+			}
+			catch (IOException) {
+				// Some FTP servers forcibly close the connection, we absorb these errors
+			}
+
 			return listing.ToArray();
 		}
 

--- a/FluentFTP/Client/SyncClient/GetReply.cs
+++ b/FluentFTP/Client/SyncClient/GetReply.cs
@@ -18,7 +18,17 @@ namespace FluentFTP {
 		/// </summary>
 		/// <returns>FtpReply representing the response from the server</returns>
 		public FtpReply GetReply() {
-			return GetReplyInternal();
+			FtpReply ftpReply = new FtpReply();
+
+			m_sema.Wait();
+			try {
+				 ftpReply = GetReplyInternal();
+			}
+			finally {
+				m_sema.Release();
+			};
+
+			return ftpReply;
 		}
 
 	}

--- a/FluentFTP/Client/SyncClient/GetReply.cs
+++ b/FluentFTP/Client/SyncClient/GetReply.cs
@@ -1,14 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Net.Sockets;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Net;
-using FluentFTP.Helpers;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace FluentFTP {
+﻿namespace FluentFTP {
 	public partial class FtpClient {
 
 		/// <summary>

--- a/FluentFTP/Client/SyncClient/GetZOSListRealm.cs
+++ b/FluentFTP/Client/SyncClient/GetZOSListRealm.cs
@@ -31,11 +31,9 @@ namespace FluentFTP {
 			// Ok, the CWD starts with a single quote. Classic z/OS dataset realm
 			FtpReply reply;
 
-			lock (m_lock) {
-				// Fetch the current working directory. The reply will tell us what it is we are...
-				if (!(reply = Execute("CWD " + Status.LastWorkingDir)).Success) {
-					throw new FtpCommandException(reply);
-				}
+			// Fetch the current working directory. The reply will tell us what it is we are...
+			if (!(reply = Execute("CWD " + Status.LastWorkingDir)).Success) {
+				throw new FtpCommandException(reply);
 			}
 
 			// 250-The working directory may be a load library                          

--- a/FluentFTP/Client/SyncClient/Noop.cs
+++ b/FluentFTP/Client/SyncClient/Noop.cs
@@ -1,12 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Net.Sockets;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Net;
-using FluentFTP.Helpers;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace FluentFTP {
 	public partial class FtpClient {

--- a/FluentFTP/Client/SyncClient/Noop.cs
+++ b/FluentFTP/Client/SyncClient/Noop.cs
@@ -20,12 +20,14 @@ namespace FluentFTP {
 		/// <returns>true if NOOP command was sent</returns>
 		public bool Noop(bool ignoreNoopInterval = false) {
 			if (ignoreNoopInterval || (Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval)) {
-				Log(FtpTraceLevel.Verbose, "Command:  NOOP");
+				lock (m_lock) {
+					Log(FtpTraceLevel.Verbose, "Command:  NOOP");
 
-				m_stream.WriteLine(m_textEncoding, "NOOP");
-				LastCommandTimestamp = DateTime.UtcNow;
+					m_stream.WriteLine(m_textEncoding, "NOOP");
+					LastCommandTimestamp = DateTime.UtcNow;
 
-				return true;
+					return true;
+				}
 			}
 
 			return false;

--- a/FluentFTP/Client/SyncClient/Noop.cs
+++ b/FluentFTP/Client/SyncClient/Noop.cs
@@ -20,7 +20,9 @@ namespace FluentFTP {
 		/// <returns>true if NOOP command was sent</returns>
 		public bool Noop(bool ignoreNoopInterval = false) {
 			if (ignoreNoopInterval || (Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval)) {
-				lock (m_lock) {
+
+				m_sema.Wait();
+				try { 
 					Log(FtpTraceLevel.Verbose, "Command:  NOOP");
 
 					m_stream.WriteLine(m_textEncoding, "NOOP");
@@ -28,14 +30,15 @@ namespace FluentFTP {
 
 					return true;
 				}
+				finally
+				{
+					m_sema.Release();
+				};
+
 			}
 
 			return false;
 		}
-
-		// Note: Enhancement would be to send the following commands in
-		// a random sequence to foil content aware firewalls that would
-		// make this keep alive scheme fail: NOOP, TYPE A, TYPE I, PWD
 
 	}
 }

--- a/FluentFTP/Client/SyncClient/OpenAppend.cs
+++ b/FluentFTP/Client/SyncClient/OpenAppend.cs
@@ -63,18 +63,14 @@ namespace FluentFTP {
 			FtpDataStream stream = null;
 			long length = 0;
 
-			lock (m_lock) {
+			length = fileLen == 0 ? client.GetFileSize(path) : fileLen;
 
-				length = fileLen == 0 ? client.GetFileSize(path) : fileLen;
+			client.SetDataType(type);
+			stream = client.OpenDataStream("APPE " + path, 0);
 
-				client.SetDataType(type);
-				stream = client.OpenDataStream("APPE " + path, 0);
-
-				if (length > 0 && stream != null) {
-					stream.SetLength(length);
-					stream.SetPosition(length);
-				}
-
+			if (length > 0 && stream != null) {
+				stream.SetLength(length);
+				stream.SetPosition(length);
 			}
 
 			Status.IgnoreStaleData = ignoreStaleData;

--- a/FluentFTP/Client/SyncClient/OpenRead.cs
+++ b/FluentFTP/Client/SyncClient/OpenRead.cs
@@ -66,13 +66,10 @@ namespace FluentFTP {
 			FtpDataStream stream = null;
 			long length = 0;
 
-			lock (m_lock) {
+			length = fileLen == 0 ? client.GetFileSize(path) : fileLen;
 
-				length = fileLen == 0 ? client.GetFileSize(path) : fileLen;
-
-				client.SetDataType(type);
-				stream = client.OpenDataStream("RETR " + path, restart);
-			}
+			client.SetDataType(type);
+			stream = client.OpenDataStream("RETR " + path, restart);
 
 			if (stream != null) {
 				if (length > 0) {

--- a/FluentFTP/Client/SyncClient/OpenWrite.cs
+++ b/FluentFTP/Client/SyncClient/OpenWrite.cs
@@ -63,17 +63,13 @@ namespace FluentFTP {
 			FtpDataStream stream = null;
 			long length = 0;
 
-			lock (m_lock) {
+			length = fileLen == 0 ? client.GetFileSize(path) : fileLen;
 
-				length = fileLen == 0 ? client.GetFileSize(path) : fileLen;
+			client.SetDataType(type);
+			stream = client.OpenDataStream("STOR " + path, 0);
 
-				client.SetDataType(type);
-				stream = client.OpenDataStream("STOR " + path, 0);
-
-				if (length > 0 && stream != null) {
-					stream.SetLength(length);
-				}
-
+			if (length > 0 && stream != null) {
+				stream.SetLength(length);
 			}
 
 			Status.IgnoreStaleData = ignoreStaleData;

--- a/FluentFTP/Client/SyncClient/Rename.cs
+++ b/FluentFTP/Client/SyncClient/Rename.cs
@@ -27,25 +27,23 @@ namespace FluentFTP {
 				throw new ArgumentException("Required parameter is null or blank.", nameof(dest));
 			}
 
-			lock (m_lock) {
-				path = path.GetFtpPath();
-				dest = dest.GetFtpPath();
+			path = path.GetFtpPath();
+			dest = dest.GetFtpPath();
 
-				LogFunction(nameof(Rename), new object[] { path, dest });
+			LogFunction(nameof(Rename), new object[] { path, dest });
 
-				// calc the absolute filepaths
-				path = GetAbsolutePath(path);
-				dest = GetAbsolutePath(dest);
+			// calc the absolute filepaths
+			path = GetAbsolutePath(path);
+			dest = GetAbsolutePath(dest);
 
-				if (!(reply = Execute("RNFR " + path)).Success) {
-					throw new FtpCommandException(reply);
-				}
-
-				if (!(reply = Execute("RNTO " + dest)).Success) {
-					throw new FtpCommandException(reply);
-				}
-
+			if (!(reply = Execute("RNFR " + path)).Success) {
+				throw new FtpCommandException(reply);
 			}
+
+			if (!(reply = Execute("RNTO " + dest)).Success) {
+				throw new FtpCommandException(reply);
+			}
+
 		}
 
 	}

--- a/FluentFTP/Client/SyncClient/SetDataType.cs
+++ b/FluentFTP/Client/SyncClient/SetDataType.cs
@@ -5,23 +5,12 @@ using System.Threading.Tasks;
 namespace FluentFTP {
 	public partial class FtpClient {
 
-		/// <summary>
 		/// Sets the data type of information sent over the data stream
-		/// </summary>
-		/// <param name="type">ASCII/Binary</param>
-		protected void SetDataType(FtpDataType type) {
-			lock (m_lock) {
-				SetDataTypeNoLock(type);
-
-			}
-		}
-
-		/// <summary>Internal method that handles actually setting the data type.</summary>
 		/// <exception cref="FtpCommandException">Thrown when a FTP Command error condition occurs.</exception>
 		/// <exception cref="FtpException">Thrown when a FTP error condition occurs.</exception>
 		/// <param name="type">ASCII/Binary.</param>
 		/// <remarks>This method doesn't do any locking to prevent recursive lock scenarios.  Callers must do their own locking.</remarks>
-		protected void SetDataTypeNoLock(FtpDataType type) {
+		protected void SetDataType(FtpDataType type) {
 			// FIX : #291 only change the data type if different
 			if (Status.CurrentDataType != type) {
 				FtpReply reply;

--- a/FluentFTP/Client/SyncClient/SetFilePermissions.cs
+++ b/FluentFTP/Client/SyncClient/SetFilePermissions.cs
@@ -39,16 +39,14 @@ namespace FluentFTP {
 				throw new ArgumentException("Required parameter is null or blank.", nameof(path));
 			}
 
-			lock (m_lock) {
-				path = path.GetFtpPath();
+			path = path.GetFtpPath();
 
-				LogFunction(nameof(SetFilePermissions), new object[] { path, permissions });
+			LogFunction(nameof(SetFilePermissions), new object[] { path, permissions });
 
-				if (!(reply = Execute("SITE CHMOD " + permissions.ToString() + " " + path)).Success) {
-					throw new FtpCommandException(reply);
-				}
-
+			if (!(reply = Execute("SITE CHMOD " + permissions.ToString() + " " + path)).Success) {
+				throw new FtpCommandException(reply);
 			}
+
 		}
 
 	}

--- a/FluentFTP/Client/SyncClient/SetModifiedTime.cs
+++ b/FluentFTP/Client/SyncClient/SetModifiedTime.cs
@@ -25,34 +25,31 @@ namespace FluentFTP {
 
 			FtpReply reply;
 
-			lock (m_lock) {
+			// calculate the final date string with the timezone conversion
+			date = ConvertDate(date, true);
+			var timeStr = date.GenerateFtpDate();
 
-				// calculate the final date string with the timezone conversion
-				date = ConvertDate(date, true);
-				var timeStr = date.GenerateFtpDate();
-
-				// set modified date of a file
-				if (HasFeature(FtpCapability.MFMT)) {
-					if ((reply = Execute("MFMT " + timeStr + " " + path)).Success) {
-					}
+			// set modified date of a file
+			if (HasFeature(FtpCapability.MFMT)) {
+				if ((reply = Execute("MFMT " + timeStr + " " + path)).Success) {
 				}
-				else if (HasFeature(FtpCapability.MDTM)) {
-					if ((reply = Execute("MDTM " + timeStr + " " + path)).Success) {
-					}
-				}
-				else {
-					throw new FtpException("No time setting command available - see FEAT response");
-				}
-
-				// TODO: Consider also supporting SITE UTIME.
-				// Advantages:
-				//	Uses UTC, no time zone concerns
-				// Disadvantages:
-				//  Some servers do not advertise this command in FEAT response,
-				//  need to test the availability of this command
-				//  Some servers do not support it correctly or in different formats
-
 			}
+			else if (HasFeature(FtpCapability.MDTM)) {
+				if ((reply = Execute("MDTM " + timeStr + " " + path)).Success) {
+				}
+			}
+			else {
+				throw new FtpException("No time setting command available - see FEAT response");
+			}
+
+			// TODO: Consider also supporting SITE UTIME.
+			// Advantages:
+			//	Uses UTC, no time zone concerns
+			// Disadvantages:
+			//  Some servers do not advertise this command in FEAT response,
+			//  need to test the availability of this command
+			//  Some servers do not support it correctly or in different formats
+
 		}
 
 	}

--- a/FluentFTP/Client/SyncClient/SetWorkingDirectory.cs
+++ b/FluentFTP/Client/SyncClient/SetWorkingDirectory.cs
@@ -26,13 +26,11 @@ namespace FluentFTP {
 				return;
 			}
 
-			lock (m_lock) {
-				// modify working dir
-				if (!(reply = Execute("CWD " + path)).Success) {
-					throw new FtpCommandException(reply);
-				}
-
+			// modify working dir
+			if (!(reply = Execute("CWD " + path)).Success) {
+				throw new FtpCommandException(reply);
 			}
+
 		}
 
 	}

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -174,7 +174,7 @@ namespace FluentFTP {
 				catch {
 				}
 
-				var anyNoop = false;
+				Status.DaemonAnyNoops = false;
 
 				// loop till entire file uploaded
 				while (localFileLen == 0 || localPosition < localFileLen) {
@@ -201,9 +201,6 @@ namespace FluentFTP {
 							if (progress != null) {
 								ReportProgress(progress, localFileLen, localPosition, bytesProcessed, DateTime.Now - transferStarted, localPath, remotePath, metaProgress);
 							}
-
-							// Fix #387: keep alive with NOOP as configured and needed
-							anyNoop = Noop(false) || anyNoop;
 
 							// honor the speed limit
 							var swTime = sw.ElapsedMilliseconds;
@@ -269,7 +266,7 @@ namespace FluentFTP {
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
-				FtpReply status = GetReplyInternal("*UPLOAD*", anyNoop);
+				FtpReply status = GetReplyInternal(LastCommandExecuted, Status.DaemonAnyNoops);
 
 				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
 				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway
@@ -287,7 +284,7 @@ namespace FluentFTP {
 				return FtpStatus.Success;
 			}
 			catch (AuthenticationException) {
-				FtpReply reply = GetReplyInternal("*UPLOAD*", false, -1); // no exhaustNoop, but non-blocking
+				FtpReply reply = GetReplyInternal(LastCommandExecuted, false, -1); // no exhaustNoop, but non-blocking
 				if (!reply.Success) {
 					throw new FtpCommandException(reply);
 				}

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -131,5 +131,21 @@ namespace FluentFTP {
 		/// </summary>
 		public ushort zOSListingLRECL { get; set; }
 
+		/// <summary>
+		/// Background task status
+		/// </summary>
+		public bool DaemonRunning { get; set; }
+		/// <summary>
+		/// Background task should GetReply
+		/// </summary>
+		public bool DaemonGetReply { get; set; }
+		/// <summary>
+		/// Background task enabled
+		/// </summary>
+		public bool DaemonEnable { get; set; }
+		/// <summary>
+		/// Background task sent noops
+		/// </summary>
+		public bool DaemonAnyNoops { get; set; }
 	}
 }

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Net;
-using System.Text;
 
 namespace FluentFTP {
 

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -111,9 +111,9 @@ namespace FluentFTP {
 		/// (NOOP or other) that a NOOP command is sent./>.
 		/// This is called during downloading/uploading and idle times. Setting this
 		/// interval to 0 disables this all together.
-		/// The default value is 600000 (60 seconds).
+		/// The default value is 0 (disabled).
 		/// </summary>
-		public int NoopInterval { get; set; } = 60000;
+		public int NoopInterval { get; set; } = 0;
 
 		/// <summary>
 		/// When this value is set to true (default) the control connection

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -108,12 +108,12 @@ namespace FluentFTP {
 
 		/// <summary>
 		/// Gets or sets the length of time in milliseconds after last command
-		/// (NOOP or other) that a NOOP command is sent by <see cref="FtpClient.Noop"/>/<see cref="AsyncFtpClient.NoopAsync(System.Threading.CancellationToken)"/>.
-		/// This is called during downloading/uploading. Setting this
-		/// interval to 0 disables <see cref="FtpClient.Noop"/>/<see cref="AsyncFtpClient.NoopAsync(System.Threading.CancellationToken)"/> all together.
-		/// The default value is 0 (disabled).
+		/// (NOOP or other) that a NOOP command is sent./>.
+		/// This is called during downloading/uploading and idle times. Setting this
+		/// interval to 0 disables this all together.
+		/// The default value is 600000 (60 seconds).
 		/// </summary>
-		public int NoopInterval { get; set; } = 0;
+		public int NoopInterval { get; set; } = 60000;
 
 		/// <summary>
 		/// When this value is set to true (default) the control connection

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -856,6 +856,7 @@ namespace FluentFTP {
 			if (Client.Status.DaemonRunning) {
 
 				if (this.IsControlConnection) {
+					// if we are terminating the control connection, stop the NOOP daemon
 					DateTime tn = DateTime.Now;
 					do {
 						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Waiting for daemon termination");
@@ -865,6 +866,7 @@ namespace FluentFTP {
 					} while (DateTime.Compare(DateTime.Now, tn.AddMilliseconds(5000)) <= 0);
 				}
 				else {
+					// if terminating a data connection, tell the NOOP daemon to revert to GetReply usage
 					Client.Status.DaemonGetReply = true;
 				}
 			}
@@ -1035,6 +1037,7 @@ namespace FluentFTP {
 			m_netStream.ReadTimeout = m_readTimeout;
 			m_lastActivity = DateTime.Now;
 
+			// the NOOP daemon needs to know this
 			if (!IsControlConnection) {
 				Client.Status.DaemonGetReply = false;
 			}
@@ -1172,6 +1175,7 @@ namespace FluentFTP {
 			m_netStream.ReadTimeout = m_readTimeout;
 			m_lastActivity = DateTime.Now;
 
+			// the NOOP daemon needs to know this
 			if (!IsControlConnection) {
 				Client.Status.DaemonGetReply = false;
 			}

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -850,6 +850,24 @@ namespace FluentFTP {
 			}
 
 			DisposeSocket();
+
+			// needed or not? base.Dispose(disposing);
+
+			if (Client.Status.DaemonRunning) {
+
+				if (this.IsControlConnection) {
+					DateTime tn = DateTime.Now;
+					do {
+						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Waiting for daemon termination");
+						Thread.Sleep(150);
+						if (!Client.Status.DaemonRunning) break;
+						Thread.Sleep(850);
+					} while (DateTime.Compare(DateTime.Now, tn.AddMilliseconds(5000)) <= 0);
+				}
+				else {
+					Client.Status.DaemonGetReply = true;
+				}
+			}
 		}
 
 		/// <summary>
@@ -1016,6 +1034,8 @@ namespace FluentFTP {
 			m_netStream = new NetworkStream(m_socket);
 			m_netStream.ReadTimeout = m_readTimeout;
 			m_lastActivity = DateTime.Now;
+
+			Client.Status.DaemonGetReply = false;
 		}
 
 		/// <summary>
@@ -1149,6 +1169,8 @@ namespace FluentFTP {
 			m_netStream = new NetworkStream(m_socket);
 			m_netStream.ReadTimeout = m_readTimeout;
 			m_lastActivity = DateTime.Now;
+
+			Client.Status.DaemonGetReply = false;
 		}
 
 		/// <summary>

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1035,7 +1035,9 @@ namespace FluentFTP {
 			m_netStream.ReadTimeout = m_readTimeout;
 			m_lastActivity = DateTime.Now;
 
-			Client.Status.DaemonGetReply = false;
+			if (!IsControlConnection) {
+				Client.Status.DaemonGetReply = false;
+			}
 		}
 
 		/// <summary>
@@ -1170,7 +1172,9 @@ namespace FluentFTP {
 			m_netStream.ReadTimeout = m_readTimeout;
 			m_lastActivity = DateTime.Now;
 
-			Client.Status.DaemonGetReply = false;
+			if (!IsControlConnection) {
+				Client.Status.DaemonGetReply = false;
+			}
 		}
 
 		/// <summary>

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -851,8 +851,6 @@ namespace FluentFTP {
 
 			DisposeSocket();
 
-			// needed or not? base.Dispose(disposing);
-
 			if (Client.Status.DaemonRunning) {
 
 				if (this.IsControlConnection) {
@@ -861,7 +859,9 @@ namespace FluentFTP {
 					do {
 						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Waiting for daemon termination");
 						Thread.Sleep(150);
-						if (!Client.Status.DaemonRunning) break;
+						if (!Client.Status.DaemonRunning) {
+							break;
+						}
 						Thread.Sleep(850);
 					} while (DateTime.Compare(DateTime.Now, tn.AddMilliseconds(5000)) <= 0);
 				}


### PR DESCRIPTION
Send a random command from { "NOOP", "PWD", "TYPE I", "TYPE A" } when the control connection is idle and no transfer is in progres every NOOPINTERVAL seconds. Use only "NOOP" if a data transfer is running on the data connection.

Use a daemon (task) for this.

Start it on Connect/Authorization ok, stop it when control connection is disposed. Handle reconnects correctly, don't start more than one daemon.

Tell it when GetReply is beginning and when it ends.

Tell it a transfer is running by monitoring SocketStream for Connect/Disconnect of data connection.

It uses NoopInterval

ref. #1410