### PR TITLE
Fix long standing SYNC/ASYNC method interface mixup

### DIFF
--- a/FluentFTP/Client/AsyncFtpClient.cs
+++ b/FluentFTP/Client/AsyncFtpClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentFTP.Client.BaseClient;
 
 namespace FluentFTP {
@@ -93,11 +94,11 @@ namespace FluentFTP {
 
 		#endregion
 
-		void IInternalFtpClient.ConnectInternal(bool reConnect, CancellationToken token) {
-			Connect(reConnect, token).GetAwaiter().GetResult();
+		async Task IInternalFtpClient.ConnectInternal(bool reConnect, CancellationToken token) {
+			await ((IAsyncFtpClient)this).Connect(reConnect, token);
 		}
-		void IInternalFtpClient.DisconnectInternal(CancellationToken token) {
-			Disconnect(token).GetAwaiter().GetResult();
+		async Task IInternalFtpClient.DisconnectInternal(CancellationToken token) {
+			await ((IAsyncFtpClient)this).Disconnect(token);
 		}
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace FluentFTP.Client.BaseClient {
 	public partial class BaseFtpClient : IDisposable, IInternalFtpClient {
@@ -155,14 +156,17 @@ namespace FluentFTP.Client.BaseClient {
 
 		#endregion
 
-		void IInternalFtpClient.DisconnectInternal() {
-		}
-		void IInternalFtpClient.DisconnectInternal(CancellationToken token) {
-		}
-
 		void IInternalFtpClient.ConnectInternal(bool reConnect) {
+			((IFtpClient)this).Connect(reConnect);
 		}
-		void IInternalFtpClient.ConnectInternal(bool reConnect, CancellationToken token) {
+		async Task IInternalFtpClient.ConnectInternal(bool reConnect, CancellationToken token) {
+			await ((IAsyncFtpClient)this).Connect(reConnect, token);
+		}
+		void IInternalFtpClient.DisconnectInternal() {
+			((IFtpClient)this).Disconnect();
+		}
+		async Task IInternalFtpClient.DisconnectInternal(CancellationToken token) {
+			await ((IAsyncFtpClient)this).Disconnect(token);
 		}
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/FluentFTP/Client/FtpClient.cs
+++ b/FluentFTP/Client/FtpClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Threading.Tasks;
 using FluentFTP.Client.BaseClient;
 
 namespace FluentFTP {
@@ -93,10 +94,11 @@ namespace FluentFTP {
 		#endregion
 
 		void IInternalFtpClient.ConnectInternal(bool reConnect) {
-			Connect(reConnect);
+			((IFtpClient)this).Connect(reConnect);
 		}
+
 		void IInternalFtpClient.DisconnectInternal() {
-			Disconnect();
+			((IFtpClient)this).Disconnect();
 		}
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
@@ -10,10 +10,10 @@ namespace FluentFTP {
 	public interface IInternalFtpClient {
 
 		void ConnectInternal(bool reConnect);
-		void ConnectInternal(bool reConnect, CancellationToken token);
+		Task ConnectInternal(bool reConnect, CancellationToken token);
 
 		void DisconnectInternal();
-		void DisconnectInternal(CancellationToken token);
+		Task DisconnectInternal(CancellationToken token);
 
 		FtpReply ExecuteInternal(string command);
 


### PR DESCRIPTION
I finally found this while debugging something else.

It effectively prevented ASYNC connection handling to take place.