### PR TITLE
Fix "DisableUTF8()" sync and async(bug)

### DIFF
--- a/FluentFTP/Client/AsyncClient/DisableUTF8.cs
+++ b/FluentFTP/Client/AsyncClient/DisableUTF8.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.IO;
+﻿using FluentFTP.Exceptions;
+
 using System.Text;
-using System.Collections.Generic;
-using FluentFTP.Exceptions;
-using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using FluentFTP.Client.Modules;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
@@ -17,17 +12,18 @@ namespace FluentFTP {
 		/// back to ASCII. If the server returns an error when trying
 		/// to turn UTF8 off a FtpCommandException will be thrown.
 		/// </summary>
-		public void DisableUTF8() {
+		public async Task DisableUTF8(CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 
-			lock (m_lock) {
-				if (!(reply = ((IInternalFtpClient)this).ExecuteInternal("OPTS UTF8 OFF")).Success) {
-					throw new FtpCommandException(reply);
-				}
 
-				m_textEncoding = Encoding.ASCII;
-				m_textEncodingAutoUTF = false;
+			reply = await Execute("OPTS UTF8 OFF", token);
+
+			if (!reply.Success) {
+				throw new FtpCommandException(reply);
 			}
+
+			m_textEncoding = Encoding.ASCII;
+			m_textEncodingAutoUTF = false;
 
 		}
 	}

--- a/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
@@ -20,7 +20,7 @@ namespace FluentFTP {
 		// METHODS
 
 		bool HasFeature(FtpCapability cap);
-		void DisableUTF8();
+		Task DisableUTF8(CancellationToken token = default(CancellationToken));
 
 		Task<FtpProfile> AutoConnect(CancellationToken token = default(CancellationToken));
 		Task<List<FtpProfile>> AutoDetect(FtpAutoDetectConfig config, CancellationToken token = default(CancellationToken));

--- a/FluentFTP/Client/SyncClient/DisableUTF8.cs
+++ b/FluentFTP/Client/SyncClient/DisableUTF8.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.IO;
+﻿using FluentFTP.Exceptions;
+
+
+
 using System.Text;
-using System.Collections.Generic;
-using FluentFTP.Exceptions;
-using FluentFTP.Helpers;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using FluentFTP.Client.Modules;
 
 namespace FluentFTP {
 	public partial class FtpClient {
@@ -21,7 +16,9 @@ namespace FluentFTP {
 			FtpReply reply;
 
 			lock (m_lock) {
-				if (!(reply = Execute("OPTS UTF8 OFF")).Success) {
+				reply = Execute("OPTS UTF8 OFF");
+
+				if (!reply.Success) {
 					throw new FtpCommandException(reply);
 				}
 


### PR DESCRIPTION
The async version of DisableUTF8, which invokes Execute(....) NEEDS to be coded for async operation which was not the case.