### PR TITLE
Move BaseClient Connect / Disconnect to .cs files

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -30,7 +30,6 @@ namespace FluentFTP {
 			await Connect(false, token);
 		}
 
-		// TODO: add example
 		/// <summary>
 		/// Connect to the server
 		/// </summary>

--- a/FluentFTP/Client/BaseClient/Connect.cs
+++ b/FluentFTP/Client/BaseClient/Connect.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace FluentFTP.Client.BaseClient {
+
+	public partial class BaseFtpClient {
+
+		/// <summary>
+		/// Connect to the server
+		/// </summary>
+		/// <param name="reConnect"> true indicates that we want a reconnect to take place.</param>
+		void IInternalFtpClient.ConnectInternal(bool reConnect) {
+			((IFtpClient)this).Connect(reConnect);
+		}
+
+		/// <summary>
+		/// Connect to the server
+		/// </summary>
+		/// <param name="reConnect"> true indicates that we want a reconnect to take place.</param>
+		/// <param name="token">The token that can be used to cancel the entire process</param>
+		async Task IInternalFtpClient.ConnectInternal(bool reConnect, CancellationToken token) {
+			await ((IAsyncFtpClient)this).Connect(reConnect, token);
+		}
+
+	}
+}

--- a/FluentFTP/Client/BaseClient/Disconnect.cs
+++ b/FluentFTP/Client/BaseClient/Disconnect.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace FluentFTP.Client.BaseClient {
+
+	public partial class BaseFtpClient {
+
+		/// <summary>
+		/// Disconnects from the server
+		/// </summary>
+		void IInternalFtpClient.DisconnectInternal() {
+			((IFtpClient)this).Disconnect();
+		}
+
+		/// <summary>
+		/// Disconnects from the server asynchronously
+		/// </summary>
+		async Task IInternalFtpClient.DisconnectInternal(CancellationToken token) {
+			await ((IAsyncFtpClient)this).Disconnect(token);
+		}
+
+	}
+}

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -156,19 +156,6 @@ namespace FluentFTP.Client.BaseClient {
 
 		#endregion
 
-		void IInternalFtpClient.ConnectInternal(bool reConnect) {
-			((IFtpClient)this).Connect(reConnect);
-		}
-		async Task IInternalFtpClient.ConnectInternal(bool reConnect, CancellationToken token) {
-			await ((IAsyncFtpClient)this).Connect(reConnect, token);
-		}
-		void IInternalFtpClient.DisconnectInternal() {
-			((IFtpClient)this).Disconnect();
-		}
-		async Task IInternalFtpClient.DisconnectInternal(CancellationToken token) {
-			await ((IAsyncFtpClient)this).Disconnect(token);
-		}
-
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 	}

--- a/FluentFTP/Client/Interfaces/IBaseFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IBaseFtpClient.cs
@@ -51,7 +51,6 @@ namespace FluentFTP {
 		IPEndPoint SocketLocalEndPoint { get; }
 		IPEndPoint SocketRemoteEndPoint { get; }
 
-
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 	}


### PR DESCRIPTION
Final clean up for the BaseClient Connect() / Disconnect() legacy

Move Connect() and Disconnect() statements to their own (albeit) small .cs files in the BaseClient folder.