### PR TITLE
Change semaphore logic to prevent deadlocks

### DIFF
--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -103,17 +103,19 @@ namespace FluentFTP {
 				await m_stream.WriteLineAsync(m_textEncoding, command, token);
 				LastCommandExecuted = command;
 				LastCommandTimestamp = DateTime.UtcNow;
-				reply = await ((IInternalFtpClient)this).GetReplyInternal(token, command, false, 0, false);
-				if (reply.Success) {
-					await OnPostExecute(command, token);
 
-					if (Config.SslSessionLength > 0) {
-						ConnectModule.CheckCriticalSequence(this, command);
-					}
-				}
+				// get the reply
+				reply = await ((IInternalFtpClient)this).GetReplyInternal(token, command, false, 0, false);
 			}
 			finally {
 				m_sema.Release();
+			}
+			if (reply.Success) {
+				await OnPostExecute(command, token);
+
+				if (Config.SslSessionLength > 0) {
+					ConnectModule.CheckCriticalSequence(this, command);
+				}
 			}
 
 			return reply;

--- a/FluentFTP/Client/BaseClient/Daemon.cs
+++ b/FluentFTP/Client/BaseClient/Daemon.cs
@@ -49,7 +49,7 @@ namespace FluentFTP.Client.BaseClient {
 
 						// pick the command reply if this is just an idle control connection
 						if (Status.DaemonCmdMode) {
-							bool s = ((IInternalFtpClient)this).GetReplyInternal(rndCmd + " (daemon)", false, 10000).Success;
+							bool s = ((IInternalFtpClient)this).GetReplyInternal(rndCmd + " (daemon)", false, 10000, false).Success;
 
 							// in case one of these commands is issued, make sure we store that
 

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -98,16 +98,16 @@ namespace FluentFTP.Client.BaseClient {
 
 				// get the reply
 				reply = ((IInternalFtpClient)this).GetReplyInternal(command, false, 0, false);
-				if (reply.Success) {
-					OnPostExecute(command);
-
-					if (Config.SslSessionLength > 0) {
-						ConnectModule.CheckCriticalSequence(this, command);
-					}
-				}
 			}
 			finally {
 				m_sema.Release();
+			}
+			if (reply.Success) {
+				OnPostExecute(command);
+
+				if (Config.SslSessionLength > 0) {
+					ConnectModule.CheckCriticalSequence(this, command);
+				}
 			}
 
 			return reply;

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -89,7 +89,7 @@ namespace FluentFTP.Client.BaseClient {
 			long previousElapsedTime = 0;
 
 			if (useSema) {
-				m_sema.WaitAsync();
+				m_sema.Wait();
 			}
 
 			try {


### PR DESCRIPTION
1.	Windows GUI environment using FTP client
2.	Typo in Daemon.cs
3.	In some cases Execute.cs will invoke another Execute.cs via GetWorkingDIrectory.cs - produces deadlock
4.	Typo in Getreply.cs
