### PR TITLE
Improve Noop API handling of disconnections

### DIFF
--- a/FluentFTP/Client/AsyncClient/Noop.cs
+++ b/FluentFTP/Client/AsyncClient/Noop.cs
@@ -24,12 +24,14 @@ namespace FluentFTP {
 
 				await m_sema.WaitAsync();
 				try {
-					Log(FtpTraceLevel.Verbose, "Command:  NOOP");
+					if (m_stream != null && m_stream.IsConnected) {
+						Log(FtpTraceLevel.Verbose, "Command:  NOOP");
 
-					await m_stream.WriteLineAsync(m_textEncoding, "NOOP", token);
-					LastCommandTimestamp = DateTime.UtcNow;
+						await m_stream.WriteLineAsync(m_textEncoding, "NOOP", token);
+						LastCommandTimestamp = DateTime.UtcNow;
 
-					return true;
+						return true;
+					}
 				}
 				finally {
 					m_sema.Release();

--- a/FluentFTP/Client/BaseClient/Noop.cs
+++ b/FluentFTP/Client/BaseClient/Noop.cs
@@ -24,12 +24,14 @@ namespace FluentFTP.Client.BaseClient {
 
 				m_sema.Wait();
 				try {
-					Log(FtpTraceLevel.Verbose, "Command:  NOOP");
+					if (m_stream != null && m_stream.IsConnected) {
+						Log(FtpTraceLevel.Verbose, "Command:  NOOP");
 
-					m_stream.WriteLine(m_textEncoding, "NOOP");
-					LastCommandTimestamp = DateTime.UtcNow;
+						m_stream.WriteLine(m_textEncoding, "NOOP");
+						LastCommandTimestamp = DateTime.UtcNow;
 
-					return true;
+						return true;
+					}
 				}
 				finally {
 					m_sema.Release();


### PR DESCRIPTION
After gaining the Semaphore - check if the connection is still viable, avoid sending a NOOP into the TCP void...