### PR TITLE
#1444 break download loop if stopPosition reached

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -107,7 +107,7 @@ namespace FluentFTP {
 						long bytesProcessed = 0;
 
 						sw.Start();
-						while ((readBytes = await downStream.ReadAsync(buffer, 0, buffer.Length, token)) > 0) {
+						while ((readBytes = await downStream.ReadAsync(buffer, 0, buffer.Length, token)) > 0 && (offset < fileLen || readToEnd)) {
 
 							// Fix #552: only create outstream when first bytes downloaded
 							if (outStream == null && localPath != null) {
@@ -141,12 +141,15 @@ namespace FluentFTP {
 							}
 						}
 
+						if (stopPosition != 0 && offset >= fileLen && readToEnd != true) {
+							earlySuccess = true; // not sure if this is earlySuccess, but we should stop here
+							break;
+						}
 						// if we reach here means EOF encountered
 						// stop if we are in "read until EOF" mode
 						if (offset == fileLen || readToEnd) {
 							break;
 						}
-
 						// zero return value (with no Exception) indicates EOS; so we should fail here and attempt to resume
 						throw new IOException($"Unexpected EOF for remote file {remotePath} [{offset}/{fileLen} bytes read]");
 					}

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -107,7 +107,7 @@ namespace FluentFTP {
 						long bytesProcessed = 0;
 
 						sw.Start();
-						while ((readBytes = downStream.Read(buffer, 0, buffer.Length)) > 0) {
+						while ((readBytes = downStream.Read(buffer, 0, buffer.Length)) > 0 && (offset < fileLen || readToEnd)) {
 
 							// Fix #552: only create outstream when first bytes downloaded
 							if (outStream == null && localPath != null) {
@@ -140,6 +140,10 @@ namespace FluentFTP {
 							}
 						}
 
+						if (stopPosition != 0 && offset >= fileLen && readToEnd != true) {
+							earlySuccess = true; // not sure if this is earlySuccess, but we should stop here
+							break;
+						}
 						// if we reach here means EOF encountered
 						// stop if we are in "read until EOF" mode
 						if (offset == fileLen || readToEnd) {


### PR DESCRIPTION
fixes the exit on stopPosition scenario in DownloadFileInternalAsync method
not sure if this is the right fix, as i had to set earlySuccess = true; otherwise i would get 550 error