### PR TITLE
#1446 calculate size of bytes to download into buffer, to accomodate smaller last chunk

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -105,9 +105,10 @@ namespace FluentFTP {
 						var readBytes = 1;
 						long limitCheckBytes = 0;
 						long bytesProcessed = 0;
+						int bytesToReadInBuffer = offset == 0 || (offset > 0 && fileLen - offset > buffer.Length) ? buffer.Length : (int)(fileLen - offset);
 
 						sw.Start();
-						while ((readBytes = await downStream.ReadAsync(buffer, 0, buffer.Length, token)) > 0 && (offset < fileLen || readToEnd)) {
+						while ((readBytes = await downStream.ReadAsync(buffer, 0, bytesToReadInBuffer, token)) > 0 && (offset < fileLen || readToEnd)) {
 
 							// Fix #552: only create outstream when first bytes downloaded
 							if (outStream == null && localPath != null) {
@@ -120,6 +121,7 @@ namespace FluentFTP {
 							offset += readBytes;
 							bytesProcessed += readBytes;
 							limitCheckBytes += readBytes;
+							bytesToReadInBuffer = offset == 0 || (offset > 0 && fileLen - offset > buffer.Length) ? buffer.Length : (int)(fileLen - offset);
 
 							// send progress reports
 							if (progress != null) {

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -105,9 +105,10 @@ namespace FluentFTP {
 						var readBytes = 1;
 						long limitCheckBytes = 0;
 						long bytesProcessed = 0;
+						int bytesToReadInBuffer = offset == 0 || (offset > 0 && fileLen - offset > buffer.Length) ? buffer.Length : (int)(fileLen - offset);
 
 						sw.Start();
-						while ((readBytes = downStream.Read(buffer, 0, buffer.Length)) > 0 && (offset < fileLen || readToEnd)) {
+						while ((readBytes = downStream.Read(buffer, 0, bytesToReadInBuffer)) > 0 && (offset < fileLen || readToEnd)) {
 
 							// Fix #552: only create outstream when first bytes downloaded
 							if (outStream == null && localPath != null) {
@@ -120,6 +121,7 @@ namespace FluentFTP {
 							offset += readBytes;
 							bytesProcessed += readBytes;
 							limitCheckBytes += readBytes;
+							bytesToReadInBuffer = offset == 0 || (offset > 0 && fileLen - offset > buffer.Length) ? buffer.Length : (int)(fileLen - offset);
 
 							// send progress reports
 							if (progress != null) {


### PR DESCRIPTION
This changes fixes the overshoot of 100% while downloading not entire file.
Instead of filling entire buffer, we calculate what is actually left (fileLen - offset) and if it  is bigger than buffer - means this was not one before last. if (fileLen - offset) is smaller than buffer - we are about to take last chunk and need to download only the missing bytes, not entire buffer