### PR TITLE
Exclude some commands from reconnect

### DIFF
--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -43,7 +43,7 @@ namespace FluentFTP {
 				reconnectReason = "disconnected";
 			}
 			// Automatic reconnect on reaching SslSessionLength?
-			else if (m_stream.IsEncrypted && Config.SslSessionLength > 0 && !Status.InCriticalSequence && m_stream.SslSessionLength > Config.SslSessionLength) {
+			else if (m_stream.IsEncrypted && Config.SslSessionLength > 0 && !Status.InCriticalSequence && !ConnectModule.CheckCriticalSingleCommand(this, command) && m_stream.SslSessionLength > Config.SslSessionLength) {
 				reconnect = true;
 				reconnectReason = "max SslSessionLength reached on";
 			}
@@ -108,7 +108,7 @@ namespace FluentFTP {
 				await OnPostExecute(command, token);
 
 				if (Config.SslSessionLength > 0) {
-					ConnectModule.CheckCriticalSequence(this, command);
+					ConnectModule.CheckCriticalCommandSequence(this, command);
 				}
 			}
 

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
 
@@ -39,7 +40,7 @@ namespace FluentFTP.Client.BaseClient {
 				reconnectReason = "disconnected";
 			}
 			// Automatic reconnect on reaching SslSessionLength?
-			else if (m_stream is not null && m_stream.IsEncrypted && Config.SslSessionLength > 0 && !Status.InCriticalSequence && m_stream.SslSessionLength > Config.SslSessionLength) {
+			else if (m_stream is not null && m_stream.IsEncrypted && Config.SslSessionLength > 0 && !Status.InCriticalSequence && !ConnectModule.CheckCriticalSingleCommand(this, command) && m_stream.SslSessionLength > Config.SslSessionLength) {
 				reconnect = true;
 				reconnectReason = "max SslSessionLength reached on";
 			}
@@ -100,7 +101,7 @@ namespace FluentFTP.Client.BaseClient {
 				OnPostExecute(command);
 
 				if (Config.SslSessionLength > 0) {
-					ConnectModule.CheckCriticalSequence(this, command);
+					ConnectModule.CheckCriticalCommandSequence(this, command);
 				}
 			}
 

--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -506,10 +506,19 @@ namespace FluentFTP.Client.Modules {
 		}
 
 		/// <summary>
+		/// A critical command will not be preceded by an automatic reconnect.
+		/// </summary>
+		public static bool CheckCriticalSingleCommand(BaseFtpClient client, string cmd) {
+			var cmdFirstWord = cmd.Split(new char[] { ' ' })[0];
+
+			return cmdFirstWord.EqualsAny(ServerStringModule.criticalSingleCommands);
+		}
+
+		/// <summary>
 		/// Modify the `Status.InCriticalSequence` flag based on the FTP command sent, by checking against a list of known critical commands.
 		/// A critical sequence will not be interrupted by an automatic reconnect.
 		/// </summary>
-		public static void CheckCriticalSequence(BaseFtpClient client, string cmd) {
+		public static void CheckCriticalCommandSequence(BaseFtpClient client, string cmd) {
 			var cmdFirstWord = cmd.Split(new char[] { ' ' })[0];
 
 			if (cmdFirstWord.EqualsAny(ServerStringModule.criticalStartingCommands)) {

--- a/FluentFTP/Client/Modules/ServerStringModule.cs
+++ b/FluentFTP/Client/Modules/ServerStringModule.cs
@@ -105,6 +105,10 @@ namespace FluentFTP.Client.Modules {
 		#endregion
 
 		#region Critical commands
+		public static string[] criticalSingleCommands = new[] {
+			"QUIT",
+			"NOOP",
+		};
 
 		public static string[] criticalStartingCommands = new[] {
 			"EPRT",


### PR DESCRIPTION
It is senseless to reconnect on SslSessionLength reached for a QUIT and for a NOOP command it is better to defer.