### PR TITLE
Updated the Progress of downloading files.

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFile.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFile.cs
@@ -66,7 +66,6 @@ namespace FluentFTP {
 
 			LogFunction(nameof(DownloadFile), new object[] { localPath, remotePath, existsMode, verifyOptions });
 
-			DateTime functionStarted = DateTime.Now;	
 			bool isAppend = false;
 
 			// skip downloading if the local file exists

--- a/FluentFTP/Client/SyncClient/DownloadFile.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFile.cs
@@ -75,6 +75,12 @@ namespace FluentFTP {
 				restartPos = FtpFileStream.GetFileSize(localPath, false);
 				if (knownFileSize.Equals(restartPos)) {
 					LogWithPrefix(FtpTraceLevel.Info, "Skipping file because Resume is enabled and file is fully downloaded (Remote: " + remotePath + ", Local: " + localPath + ")");
+
+					// Also updating progress in sync operations. 
+					if (progress != null) {
+						ReportProgress(progress, 0, 0, 0, TimeSpan.Zero, localPath, remotePath, metaProgress);
+					}
+
 					return FtpStatus.Skipped;
 				}
 				else {
@@ -83,6 +89,12 @@ namespace FluentFTP {
 			}
 			else if (existsMode == FtpLocalExists.Skip && File.Exists(localPath)) {
 				LogWithPrefix(FtpTraceLevel.Info, "Skipping file because Skip is enabled and file already exists locally (Remote: " + remotePath + ", Local: " + localPath + ")");
+
+				// Also updating progress in sync operations. 
+				if (progress != null) {
+					ReportProgress(progress, 0, 0, 0, TimeSpan.Zero, localPath, remotePath, metaProgress);
+				}
+
 				return FtpStatus.Skipped;
 			}
 


### PR DESCRIPTION
Fixed issue in: #1452

In this PR I updated the progress updating of downloading files both in Sync Client and Async Client. 
I did not update the Upload Files, since I think that updating progress in there will be the same, and when you download files, there is a case where you have some files and you simply want to skip them. 
Problem of current progress is that, when you are downloading, it did not showed progress on "skipped" file, it just ignore it, and didn't fire any progress update.  

Now with this PR, it increases the count of files checked / need to download. 

Reason behind of this modification was, that when you want to show download progress to user, user can think that program doesn't do anything, when on background it does things. It is just a nice little thing to keep user notified in progress that something is happening with file. 

Current progress with PR: https://youtu.be/V-f3sCHDpjU
Video of previous bug without PR: https://youtu.be/1JpgldcjjEA