### PR TITLE
Initial fix for #1461

### DIFF
--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -1,6 +1,8 @@
 ﻿using FluentFTP.Helpers;
 
 using System;
+using System.CodeDom;
+using System.Threading;
 
 namespace FluentFTP.Client.BaseClient {
 	public partial class BaseFtpClient : IDisposable, IInternalFtpClient {
@@ -115,7 +117,13 @@ namespace FluentFTP.Client.BaseClient {
 
 			try {
 				if (IsConnected) {
-					((IInternalFtpClient)this).DisconnectInternal();
+					if (this is AsyncFtpClient) {
+						CancellationToken token = new CancellationToken();
+						((IInternalFtpClient)this).DisconnectInternal(token).GetAwaiter().GetResult();
+					}
+					else {
+						((IInternalFtpClient)this).DisconnectInternal();
+					}
 				}
 			}
 			catch {


### PR DESCRIPTION
Some of the "Internal" or "BaseClient" methods basically refer to upper level APIs - Execute being one of the most numerous ones, but others are also present.

This referral to upper level APIs is problematic in that an ASYNC upper level method can burrow down to base client functionality ("internal") and in there lose its async character - that's fine as long as no API are needed that are at home in the SYNC or ASYNC client.

Here, `client.Dispose()` is a case in point and it is useful to peruse #1461, as it makes for good reading.

There are more places that need to be investigated (see #1460) to get this cleaned up.

A general solution, to make BaseClient not only IDisposable **but also** IAsyncDisposable**, is a long term goal and also only viable for .NET 5+.