### PR TITLE
This is a bugfix for #1460

### DIFF
--- a/FluentFTP/Client/BaseClient/CloseDataStream.cs
+++ b/FluentFTP/Client/BaseClient/CloseDataStream.cs
@@ -1,5 +1,9 @@
 ﻿using FluentFTP.Exceptions;
+
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace FluentFTP.Client.BaseClient {
 
 	public partial class BaseFtpClient {
@@ -43,6 +47,44 @@ namespace FluentFTP.Client.BaseClient {
 			return reply;
 		}
 
+		/// <summary>
+		/// Disconnects a data stream
+		/// </summary>
+		/// <param name="stream">The data stream to close</param>
+		async Task<FtpReply> IInternalFtpClient.CloseDataStreamInternal(FtpDataStream stream, CancellationToken token) {
+			LogFunction("CloseDataStream");
+
+			var reply = new FtpReply();
+
+			if (stream == null) {
+				throw new ArgumentException("The data stream parameter was null");
+			}
+
+			try {
+				if (IsConnected) {
+					// if the command that required the data connection was
+					// not successful then there will be no reply from
+					// the server, however if the command was successful
+					// the server will send a reply when the data connection
+					// is closed.
+					if (stream.CommandStatus.Type == FtpResponseType.PositivePreliminary) {
+						if (!(reply = await ((IInternalFtpClient)this).GetReplyInternal(token, LastCommandExecuted)).Success) {
+							throw new FtpCommandException(reply);
+						}
+					}
+				}
+			}
+			finally {
+				// if this is a clone of the original control
+				// connection we should Dispose()
+				if (IsClone) {
+					await ((IInternalFtpClient)this).DisconnectInternal(token);
+					Dispose();
+				}
+			}
+
+			return reply;
+		}
 
 	}
 }

--- a/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
@@ -36,6 +36,7 @@ namespace FluentFTP {
 		string GetWorkingDirectoryInternal();
 
 		FtpReply CloseDataStreamInternal(FtpDataStream stream);
+		Task<FtpReply> CloseDataStreamInternal(FtpDataStream stream, CancellationToken token);
 
 		void LogStatus(FtpTraceLevel eventType, string message, Exception exception = null, bool exNewLine = false);
 

--- a/FluentFTP/Streams/FtpDataStream.cs
+++ b/FluentFTP/Streams/FtpDataStream.cs
@@ -125,7 +125,13 @@ namespace FluentFTP {
 
 			try {
 				if (ControlConnection != null) {
-					((IInternalFtpClient)ControlConnection).CloseDataStreamInternal(this);
+					if (ControlConnection is AsyncFtpClient) {
+						CancellationToken token = new CancellationToken();
+						((IInternalFtpClient)ControlConnection).CloseDataStreamInternal(this, token).GetAwaiter().GetResult();
+					}
+					else {
+						((IInternalFtpClient)ControlConnection).CloseDataStreamInternal(this);
+					}
 				}
 			}
 			finally {


### PR DESCRIPTION
Using the same technique as in https://github.com/robinrodricks/FluentFTP/issues/1461, I have fixed issue #1460.

Note: At some point in time, Close, Dispose and other cleanups need to be re-examined as to how well they are "fitted to async". There might still be some async operations happening somewhere that inadvertently invoke sync methods.

Note that even if a client is not *cloned*, a sync datastream close was being invoked, because as the OP mentioned, there was **no async** datastream close **ever present**.