### PR TITLE
AsyncFtpClient: Modify all "Close()" usage to "await CloseAsync()"

### DIFF
--- a/FluentFTP/Client/AsyncClient/Disconnect.cs
+++ b/FluentFTP/Client/AsyncClient/Disconnect.cs
@@ -25,7 +25,7 @@ namespace FluentFTP {
 					// When debugging, the stream might have already been taken down
 					// from the remote side, thus causing an exception here, so check for null
 					if (m_stream != null) {
-						m_stream.Close();
+						await m_stream.CloseAsync(token);
 					}
 				}
 			}

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -75,7 +75,7 @@ namespace FluentFTP {
 						await GetWorkingDirectory();
 					}
 
-					m_stream.Close();
+					await m_stream.CloseAsync(token);
 					m_stream = null;
 				}
 

--- a/FluentFTP/Client/AsyncClient/ExecuteDownloadText.cs
+++ b/FluentFTP/Client/AsyncClient/ExecuteDownloadText.cs
@@ -38,7 +38,7 @@ namespace FluentFTP {
 			try {
 				// read in raw command output from data stream
 				try {
-					using (FtpDataStream stream = await OpenDataStreamAsync(command, 0, token)) {
+					await using (FtpDataStream stream = await OpenDataStreamAsync(command, 0, token)) {
 						try {
 							if (this is AsyncFtpClientSocks4Proxy || this is AsyncFtpClientSocks4aProxy) {
 								// first 6 bytes contains 2 bytes of unknown (to me) purpose and 4 ip address bytes
@@ -72,7 +72,7 @@ namespace FluentFTP {
 							Log(FtpTraceLevel.Verbose, "-----------------------------------------");
 						}
 						finally {
-							stream.Close();
+							await stream.CloseAsync(token);
 						}
 					}
 				}

--- a/FluentFTP/Client/AsyncClient/GetListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetListing.cs
@@ -346,7 +346,7 @@ namespace FluentFTP {
 
 					// read in raw file listing from data stream
 					try {
-						using (FtpDataStream stream = await OpenDataStreamAsync(listcmd, 0, token)) {
+						await using (FtpDataStream stream = await OpenDataStreamAsync(listcmd, 0, token)) {
 							try {
 								if (this is AsyncFtpClientSocks4Proxy || this is AsyncFtpClientSocks4aProxy) {
 									// first 6 bytes contains 2 bytes of unknown (to me) purpose and 4 ip address bytes
@@ -380,7 +380,7 @@ namespace FluentFTP {
 								Log(FtpTraceLevel.Verbose, "-----------------------------------------");
 							}
 							finally {
-								stream.Close();
+								await stream.CloseAsync(token);
 							}
 						}
 					}

--- a/FluentFTP/Client/AsyncClient/GetNameListing.cs
+++ b/FluentFTP/Client/AsyncClient/GetNameListing.cs
@@ -37,7 +37,7 @@ namespace FluentFTP {
 
 			// read in raw listing
 			try {
-				using (FtpDataStream stream = await OpenDataStreamAsync("NLST " + path, 0, token)) {
+				await using (FtpDataStream stream = await OpenDataStreamAsync("NLST " + path, 0, token)) {
 					Log(FtpTraceLevel.Verbose, "+---------------------------------------+");
 					string line;
 
@@ -48,7 +48,7 @@ namespace FluentFTP {
 						}
 					}
 					finally {
-						stream.Close();
+						await stream.CloseAsync(token);
 					}
 					Log(FtpTraceLevel.Verbose, "+---------------------------------------+");
 				}

--- a/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
@@ -58,11 +58,11 @@ namespace FluentFTP {
 					// if we're connected with IPv4 and the data channel type is AutoActive then try to fall back to the PORT command
 					if (reply.Type == FtpResponseType.PermanentNegativeCompletion && type == FtpDataConnectionType.AutoActive && m_stream != null && m_stream.LocalEndPoint.AddressFamily == AddressFamily.InterNetwork) {
 						stream.ControlConnection = null; // we don't want this failed EPRT attempt to close our control connection when the stream is closed so clear out the reference.
-						stream.Close();
+						await stream.CloseAsync(token);
 						return await OpenActiveDataStreamAsync(FtpDataConnectionType.PORT, command, restart, token);
 					}
 					else {
-						stream.Close();
+						await stream.CloseAsync(token);
 						throw new FtpCommandException(reply);
 					}
 				}
@@ -76,7 +76,7 @@ namespace FluentFTP {
 												 GetLocalAddress(stream.LocalEndPoint.Address).Replace('.', ',') + "," +
 												 stream.LocalEndPoint.Port / 256 + "," +
 												 stream.LocalEndPoint.Port % 256, token)).Success) {
-					stream.Close();
+					await stream.CloseAsync(token);
 					throw new FtpCommandException(reply);
 				}
 			}
@@ -102,7 +102,7 @@ namespace FluentFTP {
 			}
 
 			if (!(reply = await Execute(command, token)).Success) {
-				stream.Close();
+				await stream.CloseAsync(token);
 				throw new FtpCommandException(reply);
 			}
 
@@ -121,7 +121,7 @@ namespace FluentFTP {
 				ar.AsyncWaitHandle.Close();  // See issue #648 this needs to be commented out for MONO
 			}
 			if (!ar.IsCompleted) {
-				stream.Close();
+				await stream.CloseAsync(token);
 				throw new TimeoutException("Timed out waiting for the server to connect to the active data socket.");
 			}
 

--- a/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
@@ -130,7 +130,7 @@ namespace FluentFTP {
 			}
 
 			if (!(reply = await Execute(command, token)).Success) {
-				stream.Close();
+				await stream.CloseAsync(token);
 				throw new FtpCommandException(reply);
 			}
 


### PR DESCRIPTION
Finally, make the AsyncFtpClient use the CloseAsync pattern instead of Close(sync) in all places where this occurred.