### PR TITLE
"new" attribute absolutely needed on FtpDataStream.Close

### DIFF
--- a/FluentFTP/Streams/FtpDataStream.cs
+++ b/FluentFTP/Streams/FtpDataStream.cs
@@ -120,7 +120,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Closes the connection and reads (and discards) the server's reply
 		/// </summary>
-		public override void Close() {
+		public new void Close() {
 			base.Close();
 
 			try {


### PR DESCRIPTION
This inadvertent change from "new" to "override" in a previous commit makes DownloadFileInternal and UploadFileInternal fail on SYNC clients. So quickly quickly change this back to "new" instead of "override".