### PR TITLE
Clarify the call destination, similar to code in ASYNC

### DIFF
--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -191,7 +191,7 @@ namespace FluentFTP {
 
 				// disconnect FTP stream before exiting
 				outStream?.Flush();
-				downStream.Dispose();
+				((FtpDataStream)downStream).Dispose();
 
 				// Fix #552: close the filestream if it was created in this method
 				if (disposeOutStream) {
@@ -233,7 +233,9 @@ namespace FluentFTP {
 
 				// close stream before throwing error
 				try {
-					downStream?.Dispose();
+					if (downStream != null) {
+						((FtpDataStream)downStream).Dispose();
+					}
 				}
 				catch (Exception) {
 				}
@@ -272,7 +274,7 @@ namespace FluentFTP {
 				// if resume possible
 				if (ex.IsResumeAllowed()) {
 					// dispose the old bugged out stream
-					downStream.Dispose();
+					((FtpDataStream)downStream).Dispose();
 					LogWithPrefix(FtpTraceLevel.Info, "Attempting download resume from offset " + offset);
 
 					// create and return a new stream starting at the current remotePosition

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -262,7 +262,7 @@ namespace FluentFTP {
 				progress?.Invoke(new FtpProgress(100.0, upStream.Length, 0, TimeSpan.FromSeconds(0), localPath, remotePath, metaProgress));
 
 				// disconnect FTP stream before exiting
-				upStream.Dispose();
+				((FtpDataStream)upStream).Dispose();
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
@@ -293,7 +293,9 @@ namespace FluentFTP {
 			catch (Exception ex1) {
 				// close stream before throwing error
 				try {
-					upStream?.Dispose();
+					if (upStream != null) {
+						((FtpDataStream)upStream).Dispose();
+					}
 				}
 				catch (Exception) {
 				}
@@ -316,7 +318,7 @@ namespace FluentFTP {
 				// if resume possible
 				if (ex.IsResumeAllowed()) {
 					// dispose the old bugged out stream
-					upStream.Dispose();
+					((FtpDataStream)upStream).Dispose();
 					LogWithPrefix(FtpTraceLevel.Info, "Attempting upload resume at position " + remotePosition);
 
 					// create and return a new stream starting at the current remotePosition


### PR DESCRIPTION
Although in SYNC (as opposed to ASYNC) this would seem redundant, it makes the SYNC code and the ASYNC code track each other more.