### PR TITLE
Update AsyncFtpClientSocks5Proxy.cs

### DIFF
--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks5Proxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks5Proxy.cs
@@ -34,5 +34,13 @@ namespace FluentFTP.Proxy.AsyncProxy {
 			await proxy.AuthenticateAsync(cancellationToken);
 			await proxy.ConnectAsync(cancellationToken);
 		}
+		/// <inheritdoc/>
+		protected override async Task ConnectAsync(FtpSocketStream stream, string host, int port, FtpIpVersion ipVersions, CancellationToken token) {
+			await base.ConnectAsync(stream, token);
+			var proxy = new SocksProxy(Host, port, stream, Proxy);
+			await proxy.NegotiateAsync(token);
+			await proxy.AuthenticateAsync(token);
+			await proxy.ConnectAsync(token);
+		}
 	}
 }


### PR DESCRIPTION
When a proxy is used and FTP is in passive mode, GetListing directly accesses the FTP service without going through the proxy, resulting in the inability to obtain data. The committed code fixes this issue.