### PR TITLE
Single Enum, alternative way to handle verification options vs. methods

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadDirectory.cs
@@ -21,16 +21,14 @@ namespace FluentFTP {
 		/// <param name="remoteFolder">The full path of the remote FTP folder that you want to download. If it does not exist, an empty result list is returned.</param>
 		/// <param name="mode">Mirror or Update mode, as explained above</param>
 		/// <param name="existsMode">If the file exists on disk, should we skip it, resume the download or restart the download?</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful download and what to do if it fails verification (See Remarks)</param>
+		/// <param name="verifyOptions">Sets verification behaviour and what to do if verification fails (See Remarks)</param>
 		/// <param name="rules">Only files and folders that pass all these rules are downloaded, and the files that don't pass are skipped. In the Mirror mode, the files that fail the rules are also deleted from the local folder.</param>
 		/// <param name="progress">Provide an implementation of IProgress to track upload progress.</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
-		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
-		/// to propagate from this method.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file will be verified against the source using the verification methods specified in <paramref name="verifyOptions"/>.
+		/// Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
+		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception to propagate from this method.
 		/// </remarks>
 		/// <returns>
 		/// Returns a listing of all the remote files, indicating if they were downloaded, skipped or overwritten.

--- a/FluentFTP/Client/AsyncClient/DownloadFile.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFile.cs
@@ -21,14 +21,14 @@ namespace FluentFTP {
 		/// <param name="localPath">The full or relative path to the file on the local file system</param>
 		/// <param name="remotePath">The full or relative path to the file on the server</param>
 		/// <param name="existsMode">Overwrite if you want the local file to be overwritten if it already exists. Append will also create a new file if it doesn't exists</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful download and what to do if it fails verification (See Remarks)</param>
+		/// <param name="verifyOptions">Sets verification behaviour and what to do if verification fails (See Remarks)</param>
 		/// <param name="progress">Provide an implementation of IProgress to track download progress.</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <returns>FtpStatus flag indicating if the file was downloaded, skipped or failed to transfer.</returns>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically be set to true for subsequent attempts.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file will be verified against the source using the verification methods specified in <paramref name="verifyOptions"/>.
+		/// Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
+		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception to propagate from this method.
 		/// </remarks>
 		public async Task<FtpStatus> DownloadFile(string localPath, string remotePath, FtpLocalExists existsMode = FtpLocalExists.Resume, FtpVerify verifyOptions = FtpVerify.None, IProgress<FtpProgress> progress = null, CancellationToken token = default(CancellationToken)) {
 			// verify args
@@ -146,7 +146,7 @@ namespace FluentFTP {
 
 				// if verification is needed
 				if (downloadSuccess && verifyOptions != FtpVerify.None) {
-					verified = await VerifyTransferAsync(localPath, remotePath, token);
+					verified = await VerifyTransferAsync(localPath, remotePath, verifyOptions, token);
 					LogWithPrefix(FtpTraceLevel.Info, "File Verification: " + (verified ? "PASS" : "FAIL"));
 					if (!verified && attemptsLeft > 0) {
 						LogWithPrefix(FtpTraceLevel.Verbose, "Retrying due to failed verification." + (existsMode == FtpLocalExists.Resume ? "  Overwrite will occur." : "") + "  " + attemptsLeft + " attempts remaining");

--- a/FluentFTP/Client/AsyncClient/DownloadFiles.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFiles.cs
@@ -24,7 +24,7 @@ namespace FluentFTP {
 		/// <param name="localDir">The full or relative path to the directory that files will be downloaded into.</param>
 		/// <param name="remotePaths">The full or relative paths to the files on the server</param>
 		/// <param name="existsMode">If the file exists on disk, should we skip it, resume the download or restart the download?</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful download and what to do if it fails verification (See Remarks)</param>
+		/// <param name="verifyOptions">Sets verification behaviour and what to do if verification fails (See Remarks)</param>
 		/// <param name="errorHandling">Used to determine how errors are handled</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <param name="progress">Provide an implementation of IProgress to track upload progress.</param>
@@ -34,11 +34,9 @@ namespace FluentFTP {
 		/// Returns a blank list if nothing was transferred. Never returns null.
 		/// </returns>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically be set to true for subsequent attempts.
-		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
-		/// to propagate from this method.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file will be verified against the source using the verification methods specified in <paramref name="verifyOptions"/>.
+		/// Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
+		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception to propagate from this method.
 		/// </remarks>
 		public async Task<List<FtpResult>> DownloadFiles(string localDir, IEnumerable<string> remotePaths, FtpLocalExists existsMode = FtpLocalExists.Overwrite,
 			FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None, CancellationToken token = default(CancellationToken),

--- a/FluentFTP/Client/AsyncClient/TransferDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/TransferDirectory.cs
@@ -22,16 +22,14 @@ namespace FluentFTP {
 		/// <param name="remoteFolder">The full or relative path to destination folder on the remote FTP Server</param>
 		/// <param name="mode">Only Update mode is currently implemented</param>
 		/// <param name="existsMode">If the file exists on disk, should we skip it, resume the download or restart the download?</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful download and what to do if it fails verification (See Remarks)</param>
+		/// <param name="verifyOptions">Sets verification behaviour and what to do if verification fails (See Remarks)</param>
 		/// <param name="rules">Only files and folders that pass all these rules are downloaded, and the files that don't pass are skipped. In the Mirror mode, the files that fail the rules are also deleted from the local folder.</param>
 		/// <param name="progress">Provide a callback to track download progress.</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
-		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
-		/// to propagate from this method.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file will be verified against the source server using the verification methods specified in <paramref name="verifyOptions"/>.
+		/// Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
+		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception to propagate from this method.
 		/// </remarks>
 		/// <returns>
 		/// Returns a listing of all the remote files, indicating if they were downloaded, skipped or overwritten.

--- a/FluentFTP/Client/AsyncClient/UploadDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/UploadDirectory.cs
@@ -20,16 +20,14 @@ namespace FluentFTP {
 		/// <param name="remoteFolder">The full path of the remote FTP folder to upload into. It is created if it does not exist.</param>
 		/// <param name="mode">Mirror or Update mode, as explained above</param>
 		/// <param name="existsMode">If the file exists on disk, should we skip it, resume the upload or restart the upload?</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful upload and what to do if it fails verification (See Remarks)</param>
+		/// <param name="verifyOptions">Sets verification behaviour and what to do if verification fails (See Remarks)</param>
 		/// <param name="rules">Only files and folders that pass all these rules are uploaded, and the files that don't pass are skipped. In the Mirror mode, the files that fail the rules are also deleted from the local folder.</param>
 		/// <param name="progress">Provide an implementation of IProgress to track upload progress.</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
-		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
-		/// to propagate from this method.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file will be verified against the source using the verification methods specified in <paramref name="verifyOptions"/>.
+		/// Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
+		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception to propagate from this method.
 		/// </remarks>
 		/// <returns>
 		/// Returns a listing of all the local files, indicating if they were uploaded, skipped or overwritten.

--- a/FluentFTP/Client/AsyncClient/UploadFiles.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFiles.cs
@@ -26,7 +26,7 @@ namespace FluentFTP {
 		/// <param name="existsMode">What to do if the file already exists? Skip, overwrite or append? Set this to <see cref="FtpRemoteExists.NoCheck"/> for fastest performance,
 		///  but only if you are SURE that the files do not exist on the server.</param>
 		/// <param name="createRemoteDir">Create the remote directory if it does not exist.</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful upload and what to do if it fails verification (See Remarks)</param>
+		/// <param name="verifyOptions">Sets verification behaviour and what to do if verification fails (See Remarks)</param>
 		/// <param name="errorHandling">Used to determine how errors are handled</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <param name="progress">Provide an implementation of IProgress to track upload progress.</param>
@@ -36,11 +36,9 @@ namespace FluentFTP {
 		/// Returns a blank list if nothing was transferred. Never returns null.
 		/// </returns>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
-		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
-		/// to propagate from this method.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file will be verified against the source using the verification methods specified in <paramref name="verifyOptions"/>.
+		/// Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
+		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception to propagate from this method.
 		/// </remarks>
 		public async Task<List<FtpResult>> UploadFiles(IEnumerable<string> localPaths, string remoteDir, FtpRemoteExists existsMode = FtpRemoteExists.Overwrite, bool createRemoteDir = true,
 			FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None, CancellationToken token = default(CancellationToken),
@@ -180,7 +178,8 @@ namespace FluentFTP {
 		/// <param name="existsMode">What to do if the file already exists? Skip, overwrite or append? Set this to <see cref="FtpRemoteExists.NoCheck"/> for fastest performance,
 		///  but only if you are SURE that the files do not exist on the server.</param>
 		/// <param name="createRemoteDir">Create the remote directory if it does not exist.</param>
-		/// <param name="verifyOptions">Sets if checksum verification is required for a successful upload and what to do if it fails verification (See Remarks)</param>
+		/// <param name="verifyOptions">Sets verification behaviour and what to do if verification fails (See Remarks)</param>
+		/// <param name="verifyMethods">Which verification methods to use. (See Remarks)</param>
 		/// <param name="errorHandling">Used to determine how errors are handled</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <param name="progress">Provide an implementation of IProgress to track upload progress.</param>
@@ -190,11 +189,11 @@ namespace FluentFTP {
 		/// Returns a blank list if nothing was transferred. Never returns null.
 		/// </returns>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
-		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
-		/// to propagate from this method.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file will be verified against the source using the verification methods specified in <paramref name="verifyMethods"/>.
+		/// If only <see cref="FtpVerifyMethod.Checksum"/> is set, but the server does not support any hash algorithm, verification will fall back to file size comparison.
+		/// If <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful upload &amp; verification.
+		/// Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
+		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception to propagate from this method.
 		/// </remarks>
 		public async Task<List<FtpResult>> UploadFiles(IEnumerable<FileInfo> localFiles, string remoteDir, FtpRemoteExists existsMode = FtpRemoteExists.Overwrite, bool createRemoteDir = true,
 			FtpVerify verifyOptions = FtpVerify.None, FtpError errorHandling = FtpError.None, CancellationToken token = default(CancellationToken),

--- a/FluentFTP/Client/AsyncClient/VerifyTransfer.cs
+++ b/FluentFTP/Client/AsyncClient/VerifyTransfer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using FluentFTP.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentFTP.Streams;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
@@ -12,10 +13,11 @@ namespace FluentFTP {
 		/// </summary>
 		/// <param name="localPath"></param>
 		/// <param name="remotePath"></param>
+		/// <param name="verify"></param>
 		/// <param name="token"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentException"></exception>
-		protected async Task<bool> VerifyTransferAsync(string localPath, string remotePath, CancellationToken token = default(CancellationToken)) {
+		protected async Task<bool> VerifyTransferAsync(string localPath, string remotePath, FtpVerify verify,  CancellationToken token = default(CancellationToken)) {
 
 			// verify args
 			if (localPath.IsBlank()) {
@@ -25,8 +27,37 @@ namespace FluentFTP {
 				throw new ArgumentException("Required parameter is null or blank.", nameof(remotePath));
 			}
 
+			// Isolate verify methods, which are the top byte of 16.
+			FtpVerify verifyMethod = (FtpVerify)((ushort)verify & 0xFF00);
+
 			try {
-				if (SupportsChecksum()) {
+				//fallback to size if only checksum is set and the server does not support hashing.
+				if (verifyMethod == FtpVerify.Checksum && !SupportsChecksum()) {
+					Log(FtpTraceLevel.Verbose, "Source server does not support any common hashing algorithm");
+					Log(FtpTraceLevel.Verbose, "Falling back to file size comparison");
+					verifyMethod = FtpVerify.Size;
+				}
+
+				//compare size
+				if (verifyMethod.HasFlag(FtpVerify.Size)) {
+					var localSize = await FtpFileStream.GetFileSizeAsync(localPath, false, token);
+					var remoteSize = await GetFileSize(remotePath, -1, token);
+					if (localSize != remoteSize) {
+						return false;
+					}
+				}
+
+				//compare date modified
+				if (verifyMethod.HasFlag(FtpVerify.Date)) {
+					var localDate = await FtpFileStream.GetFileDateModifiedUtcAsync(localPath, token);
+					var remoteDate = await GetModifiedTime(remotePath, token);
+					if (!localDate.Equals(remoteDate)) {
+						return false;
+					}
+				}
+
+				//compare hash
+				if (verifyMethod.HasFlag(FtpVerify.Checksum) && SupportsChecksum()) {
 					FtpHash hash = await GetChecksum(remotePath, FtpHashAlgorithm.NONE, token);
 					if (!hash.IsValid) {
 						return false;
@@ -35,7 +66,7 @@ namespace FluentFTP {
 					return hash.Verify(localPath);
 				}
 
-				// not supported, so return true to ignore validation
+				// check was successful
 				return true;
 			}
 			catch (IOException ex) {

--- a/FluentFTP/Client/SyncClient/DownloadDirectory.cs
+++ b/FluentFTP/Client/SyncClient/DownloadDirectory.cs
@@ -25,9 +25,9 @@ namespace FluentFTP {
 		/// <param name="rules">Only files and folders that pass all these rules are downloaded, and the files that don't pass are skipped. In the Mirror mode, the files that fail the rules are also deleted from the local folder.</param>
 		/// <param name="progress">Provide a callback to track download progress.</param>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file size and hash will be verified against the server. If the server does not support
+		/// any hash algorithm, the checksum verification is skipped. If only <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful
+		/// download &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
 		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
 		/// to propagate from this method.
 		/// </remarks>

--- a/FluentFTP/Client/SyncClient/DownloadFile.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFile.cs
@@ -25,9 +25,9 @@ namespace FluentFTP {
 		/// <param name="progress">Provide a callback to track download progress.</param>
 		/// <returns>FtpStatus flag indicating if the file was downloaded, skipped or failed to transfer.</returns>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically be set to true for subsequent attempts.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file size and hash will be verified against the server. If the server does not support
+		/// any hash algorithm, the checksum verification is skipped. If only <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful
+		/// download &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically be set to true for subsequent attempts.
 		/// </remarks>
 		public FtpStatus DownloadFile(string localPath, string remotePath, FtpLocalExists existsMode = FtpLocalExists.Overwrite, FtpVerify verifyOptions = FtpVerify.None, Action<FtpProgress> progress = null) {
 
@@ -129,7 +129,7 @@ namespace FluentFTP {
 
 				// if verification is needed
 				if (downloadSuccess && verifyOptions != FtpVerify.None) {
-					verified = VerifyTransfer(localPath, remotePath);
+					verified = VerifyTransfer(localPath, remotePath, verifyOptions);
 					Log(FtpTraceLevel.Info, "File Verification: " + (verified ? "PASS" : "FAIL"));
 					if (!verified && attemptsLeft > 0) {
 						LogWithPrefix(FtpTraceLevel.Verbose, "Retrying due to failed verification." + (existsMode == FtpLocalExists.Overwrite ? "  Overwrite will occur." : "") + "  " + attemptsLeft + " attempts remaining");

--- a/FluentFTP/Client/SyncClient/DownloadFiles.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFiles.cs
@@ -33,9 +33,9 @@ namespace FluentFTP {
 		/// Returns a blank list if nothing was transferred. Never returns null.
 		/// </returns>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file size and hash will be verified against the server. If the server does not support
+		/// any hash algorithm, the checksum verification is skipped. If only <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful
+		/// download &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
 		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
 		/// to propagate from this method.
 		/// </remarks>

--- a/FluentFTP/Client/SyncClient/TransferDirectory.cs
+++ b/FluentFTP/Client/SyncClient/TransferDirectory.cs
@@ -27,9 +27,9 @@ namespace FluentFTP {
 		/// <param name="rules">Only files and folders that pass all these rules are downloaded, and the files that don't pass are skipped. In the Mirror mode, the files that fail the rules are also deleted from the local folder.</param>
 		/// <param name="progress">Provide a callback to track download progress.</param>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file size and hash will be verified against the target servers. If a server does not support
+		/// any hash algorithm, the checksum verification is skipped. If only <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful
+		/// transfer &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
 		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
 		/// to propagate from this method.
 		/// </remarks>

--- a/FluentFTP/Client/SyncClient/TransferFile.cs
+++ b/FluentFTP/Client/SyncClient/TransferFile.cs
@@ -22,9 +22,9 @@ namespace FluentFTP {
 		/// <param name="metaProgress"></param>
 		/// Returns a FtpStatus indicating if the file was transferred.
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically be set to true for subsequent attempts.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file size and hash will be verified against the target servers. If a server does not support
+		/// any hash algorithm, the checksum verification is skipped. If only <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful
+		/// transfer &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
 		/// </remarks>
 		public FtpStatus TransferFile(string sourcePath, FtpClient remoteClient, string remotePath,
 			bool createRemoteDir = false, FtpRemoteExists existsMode = FtpRemoteExists.Resume, FtpVerify verifyOptions = FtpVerify.None, Action<FtpProgress> progress = null, FtpProgress metaProgress = null) {
@@ -52,7 +52,7 @@ namespace FluentFTP {
 
 				// if verification is needed
 				if (fxpSuccess && verifyOptions != FtpVerify.None) {
-					verified = VerifyFXPTransfer(sourcePath, remoteClient, remotePath);
+					verified = VerifyFXPTransfer(sourcePath, remoteClient, remotePath, verifyOptions);
 					LogWithPrefix(FtpTraceLevel.Info, "File Verification: " + (verified ? "PASS" : "FAIL"));
 					if (!verified && attemptsLeft > 0) {
 						LogWithPrefix(FtpTraceLevel.Verbose, "Retrying due to failed verification." + (existsMode == FtpRemoteExists.Resume ? "  Overwrite will occur." : "") + "  " + attemptsLeft + " attempts remaining");

--- a/FluentFTP/Client/SyncClient/UploadDirectory.cs
+++ b/FluentFTP/Client/SyncClient/UploadDirectory.cs
@@ -24,9 +24,9 @@ namespace FluentFTP {
 		/// <param name="rules">Only files and folders that pass all these rules are downloaded, and the files that don't pass are skipped. In the Mirror mode, the files that fail the rules are also deleted from the local folder.</param>
 		/// <param name="progress">Provide a callback to track upload progress.</param>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
-		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file size and hash will be verified against the server. If the server does not support
+		/// any hash algorithm, the checksum verification is skipped. If only <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful
+		/// upload &amp; verification. Additionally, if any verify option is set and a retry is attempted then overwrite will automatically switch to true for subsequent attempts.
 		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
 		/// to propagate from this method.
 		/// </remarks>

--- a/FluentFTP/Client/SyncClient/UploadFile.cs
+++ b/FluentFTP/Client/SyncClient/UploadFile.cs
@@ -26,8 +26,8 @@ namespace FluentFTP {
 		/// <param name="progress">Provide a callback to track download progress.</param>
 		/// <returns>FtpStatus flag indicating if the file was uploaded, skipped or failed to transfer.</returns>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file size and hash will be verified against the server. If the server does not support
+		/// any hash algorithm, the checksum verification is skipped. If only <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful
 		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
 		/// </remarks>
 		public FtpStatus UploadFile(string localPath, string remotePath, FtpRemoteExists existsMode = FtpRemoteExists.Overwrite, bool createRemoteDir = false,
@@ -95,7 +95,7 @@ namespace FluentFTP {
 
 					// If verification is needed, update the validated flag
 					if (uploadSuccess && verifyOptions != FtpVerify.None) {
-						verified = VerifyTransfer(localPath, remotePath);
+						verified = VerifyTransfer(localPath, remotePath, verifyOptions);
 						LogWithPrefix(FtpTraceLevel.Info, "File Verification: " + (verified ? "PASS" : "FAIL"));
 						if (!verified && attemptsLeft > 0) {
 							LogWithPrefix(FtpTraceLevel.Verbose, "Retrying due to failed verification." + (existsMode != FtpRemoteExists.Overwrite ? "  Switching to FtpExists.Overwrite mode.  " : "  ") + attemptsLeft + " attempts remaining");

--- a/FluentFTP/Client/SyncClient/UploadFiles.cs
+++ b/FluentFTP/Client/SyncClient/UploadFiles.cs
@@ -35,8 +35,8 @@ namespace FluentFTP {
 		/// Returns a blank list if nothing was transferred. Never returns null.
 		/// </returns>
 		/// <remarks>
-		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
+		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the file size and hash will be verified against the server. If the server does not support
+		/// any hash algorithm, the checksum verification is skipped. If only <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful
 		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
 		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
 		/// to propagate from this method.
@@ -177,7 +177,7 @@ namespace FluentFTP {
 		/// </returns>
 		/// <remarks>
 		/// If verification is enabled (All options other than <see cref="FtpVerify.None"/>) the hash will be checked against the server.  If the server does not support
-		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyChecksum"/> is set then the return of this method depends on both a successful 
+		/// any hash algorithm, then verification is ignored.  If only <see cref="FtpVerify.OnlyVerify"/> is set then the return of this method depends on both a successful 
 		/// upload &amp; verification.  Additionally, if any verify option is set and a retry is attempted the existsMode will automatically be set to <see cref="FtpRemoteExists.Overwrite"/>.
 		/// If <see cref="FtpVerify.Throw"/> is set and <see cref="FtpError.Throw"/> is <i>not set</i>, then individual verification errors will not cause an exception
 		/// to propagate from this method.

--- a/FluentFTP/Client/SyncClient/VerifyFXPTransfer.cs
+++ b/FluentFTP/Client/SyncClient/VerifyFXPTransfer.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using FluentFTP.Helpers;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace FluentFTP {
 	public partial class FtpClient {
@@ -15,7 +13,7 @@ namespace FluentFTP {
 		/// <returns></returns>
 		/// <exception cref="ArgumentException"></exception>
 		/// <exception cref="ArgumentNullException"></exception>
-		protected bool VerifyFXPTransfer(string sourcePath, FtpClient fxpDestinationClient, string remotePath) {
+		protected bool VerifyFXPTransfer(string sourcePath, FtpClient fxpDestinationClient, string remotePath, FtpVerify verify) {
 
 			// verify args
 			if (sourcePath.IsBlank()) {
@@ -30,12 +28,40 @@ namespace FluentFTP {
 				throw new ArgumentNullException(nameof(fxpDestinationClient), "Destination FXP FtpClient cannot be null!");
 			}
 
+			// Isolate verify methods, which are the top byte of 16.
+			FtpVerify verifyMethod = (FtpVerify)((ushort)verify & 0xFF00);
+
 			// check if any algorithm is supported by both servers
 			var algorithm = GetFirstMutualChecksum(fxpDestinationClient);
-			if (algorithm != FtpHashAlgorithm.NONE) {
 
+			//fallback to size if only checksum is set and the server does not support hashing.
+			if (verifyMethod == FtpVerify.Checksum && algorithm == FtpHashAlgorithm.NONE) {
+				Log(FtpTraceLevel.Info, "Source and Destination servers do not support any common hashing algorithm");
+				Log(FtpTraceLevel.Info, "Falling back to file size comparison");
+				verifyMethod = FtpVerify.Size;
+			}
+
+			//compare size
+			if (verifyMethod.HasFlag(FtpVerify.Size)) {
+				var sourceSize = GetFileSize(sourcePath, -1);
+				var remoteSize = GetFileSize(remotePath, -1);
+				if (sourceSize != remoteSize) {
+					return false;
+				}
+			}
+
+			//compare date modified
+			if (verifyMethod.HasFlag(FtpVerify.Date)) {
+				var sourceDate = GetFileSize(sourcePath);
+				var remoteDate = GetModifiedTime(remotePath);
+				if (!sourceDate.Equals(remoteDate)) {
+					return false;
+				}
+			}
+
+			//compare hash
+			if (verifyMethod.HasFlag(FtpVerify.Checksum) && algorithm != FtpHashAlgorithm.NONE) {
 				// get the hashes of both files using the same mutual algorithm
-
 				FtpHash sourceHash = GetChecksum(sourcePath, algorithm);
 				if (!sourceHash.IsValid) {
 					return false;
@@ -48,11 +74,8 @@ namespace FluentFTP {
 
 				return sourceHash.Value == destinationHash.Value;
 			}
-			else {
-				Log(FtpTraceLevel.Info, "Source and Destination servers do not support any common hashing algorithm");
-			}
 
-			// since not supported return true to ignore validation
+			// check was successful
 			return true;
 		}
 

--- a/FluentFTP/Enums/FtpVerify.cs
+++ b/FluentFTP/Enums/FtpVerify.cs
@@ -7,11 +7,14 @@ namespace FluentFTP {
 	/// FTP server does not support any hashing algorithms.
 	/// </summary>
 	[Flags]
-	public enum FtpVerify {
+	public enum FtpVerify :ushort {
 		/// <summary>
 		/// No verification of the file is performed
 		/// </summary>
 		None = 0,
+
+		// Section Options
+		// 0x0001 -> 0x0080
 
 		/// <summary>
 		/// The checksum of the file is verified, if supported by the server.
@@ -37,10 +40,31 @@ namespace FluentFTP {
 		/// </summary>
 		Throw = 4,
 
+		// Section Methods
+		// 0x0100 -> 0x8000
+
+		/// <summary>
+		/// Compares the file size.
+		/// Both file sizes should exactly match for the file to be considered equal.
+		/// </summary>
+		Size = 256,
+
+		/// <summary>
+		/// Compares the date modified of the file.
+		/// Both dates should exactly match for the file to be considered equal.
+		/// </summary>
+		Date = 1024,
+
+		/// <summary>
+		/// Compares the checksum or hash of the file using the first supported hash algorithm.
+		/// Both checksums should exactly match for the file to be considered equal.
+		/// </summary>
+		Checksum = 2048,
+
 		/// <summary>
 		/// The checksum of the file is verified, if supported by the server.
 		/// If the checksum comparison fails then the method returns false and no other action is taken.
 		/// </summary>
-		OnlyChecksum = 8,
+		OnlyChecksum = 4096,
 	}
 }


### PR DESCRIPTION
I wanted to add this possible way to go on this:

I think the main idea is to use 

```
			// Isolate verify methods, which are the top byte of 16.
			FtpVerify verifyMethod = (FtpVerify)((ushort)verify & 0xFF00);
```

and one enum:

```
﻿using System;

namespace FluentFTP {
	/// <summary>
	/// Defines if additional verification and actions upon failure that 
	/// should be performed when uploading/downloading files using the high-level APIs.  Ignored if the 
	/// FTP server does not support any hashing algorithms.
	/// </summary>
	[Flags]
	public enum FtpVerify :ushort {
		/// <summary>
		/// No verification of the file is performed
		/// </summary>
		None = 0,

		// Section Options
		// 0x0001 -> 0x0080

		/// <summary>
		/// The checksum of the file is verified, if supported by the server.
		/// If the checksum comparison fails then we retry the download/upload
		/// a specified amount of times before giving up. (See <see cref="FtpConfig.RetryAttempts"/>)
		/// </summary>
		Retry = 1,

		/// <summary>
		/// The checksum of the file is verified, if supported by the server.
		/// If the checksum comparison fails then the failed file will be deleted.
		/// If combined with <see cref="FtpVerify.Retry"/>, then
		/// the deletion will occur if it fails upon the final retry.
		/// </summary>
		Delete = 2,

		/// <summary>
		/// The checksum of the file is verified, if supported by the server.
		/// If the checksum comparison fails then an exception will be thrown.
		/// If combined with <see cref="FtpVerify.Retry"/>, then the throw will
		/// occur upon the failure of the final retry, and/or if combined with <see cref="FtpVerify.Delete"/>
		/// the method will throw after the deletion is processed.
		/// </summary>
		Throw = 4,

		// Section Methods
		// 0x0100 -> 0x8000

		/// <summary>
		/// Compares the file size.
		/// Both file sizes should exactly match for the file to be considered equal.
		/// </summary>
		Size = 256,

		/// <summary>
		/// Compares the date modified of the file.
		/// Both dates should exactly match for the file to be considered equal.
		/// </summary>
		Date = 1024,

		/// <summary>
		/// Compares the checksum or hash of the file using the first supported hash algorithm.
		/// Both checksums should exactly match for the file to be considered equal.
		/// </summary>
		Checksum = 2048,

		/// <summary>
		/// The checksum of the file is verified, if supported by the server.
		/// If the checksum comparison fails then the method returns false and no other action is taken.
		/// </summary>
		OnlyChecksum = 4096,
	}
}
```
