### PR TITLE
fileLen may be negative

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -105,7 +105,7 @@ namespace FluentFTP {
 						// read a chunk of bytes from the FTP stream
 						var readBytes = 1;
 						long limitCheckBytes = 0;
-						int bytesToReadInBuffer = fileLen != 0 && buffer.Length > fileLen - offset ? (int)(fileLen - offset) : buffer.Length;
+						int bytesToReadInBuffer = fileLen > 0 && buffer.Length > fileLen - offset ? (int)(fileLen - offset) : buffer.Length;
 
 						sw.Start();
 						while ((readBytes = await downStream.ReadAsync(buffer, 0, bytesToReadInBuffer, token)) > 0 && (offset < fileLen || readToEnd)) {
@@ -121,7 +121,7 @@ namespace FluentFTP {
 							offset += readBytes;
 							bytesProcessed += readBytes;
 							limitCheckBytes += readBytes;
-							bytesToReadInBuffer = fileLen != 0 && buffer.Length > fileLen - offset ? (int)(fileLen - offset) : buffer.Length;
+							bytesToReadInBuffer = fileLen > 0 && buffer.Length > fileLen - offset ? (int)(fileLen - offset) : buffer.Length;
 
 							// send progress reports
 							if (progress != null) {


### PR DESCRIPTION
If `GetFileSize` fails to determine the size `fileLen` will be -1 here. In that case we would end up with a negative amount of bytes to write.