### PR TITLE
Correct implementation of Buffering

### DIFF
--- a/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenActiveDataStream.cs
@@ -138,6 +138,8 @@ namespace FluentFTP {
 			stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);
 			stream.ReadTimeout = Config.DataConnectionReadTimeout;
 
+			stream.CreateBufferStream();
+
 			return stream;
 		}
 

--- a/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
@@ -148,6 +148,8 @@ namespace FluentFTP {
 					token: token);
 			}
 
+			stream.CreateBufferStream();
+
 			return stream;
 		}
 	}

--- a/FluentFTP/Client/SyncClient/OpenActiveDataStream.cs
+++ b/FluentFTP/Client/SyncClient/OpenActiveDataStream.cs
@@ -136,6 +136,8 @@ namespace FluentFTP {
 			stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);
 			stream.ReadTimeout = Config.DataConnectionReadTimeout;
 
+			stream.CreateBufferStream();
+
 			return stream;
 		}
 

--- a/FluentFTP/Client/SyncClient/OpenPassiveDataStream.cs
+++ b/FluentFTP/Client/SyncClient/OpenPassiveDataStream.cs
@@ -154,6 +154,8 @@ namespace FluentFTP {
 					Config.SslProtocols);
 			}
 
+			stream.CreateBufferStream();
+
 			return stream;
 		}
 

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1578,41 +1578,27 @@ namespace FluentFTP {
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing(sync) FtpSocketStream(" + connText + " connection of " + Client.ClientType + ")");
 			}
 
-			if (m_bufStream != null) {
-				try {
+			try {
+				if (m_bufStream != null) {
 					m_bufStream.Dispose();
 				}
-				catch {
-				}
-				m_bufStream = null;
-			}
-
-			if (m_customStream != null) {
-				try {
-					m_customStream.Dispose();
-				}
-				catch {
-				}
-				m_customStream = null;
-			}
-
-			if (m_sslStream != null) {
-				try {
+				else if (m_sslStream != null) {
 					m_sslStream.Dispose();
 				}
-				catch {
+				else if (m_customStream != null) {
+					m_customStream.Dispose();
 				}
-				m_sslStream = null;
-			}
-
-			if (m_netStream != null) {
-				try {
+				else if (m_netStream != null) {
 					m_netStream.Dispose();
 				}
-				catch {
-				}
-				m_netStream = null;
 			}
+			catch {
+			}
+
+			m_bufStream = null;
+			m_sslStream = null;
+			m_customStream = null;
+			m_netStream = null;
 
 			DisposeSocket();
 
@@ -1676,30 +1662,15 @@ namespace FluentFTP {
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing(async) FtpSocketStream(" + connText + " connection of " + Client.ClientType + ")");
 			}
 
-			if (m_bufStream != null) {
-				try {
+			try {
+				if (m_bufStream != null) {
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 					await m_bufStream.DisposeAsync();
 #else
 					m_bufStream.Dispose(); // Async dispose not supported in this .NET?
 #endif
 				}
-				catch {
-				}
-				m_bufStream = null;
-			}
-
-			if (m_customStream != null) {
-				try {
-					m_customStream.Dispose(); // Async not supported by custom stream interface
-				}
-				catch {
-				}
-				m_customStream = null;
-			}
-
-			if (m_sslStream != null) {
-				try {
+				else if (m_sslStream != null) {
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 					// Note: FtpSslStream SSL shutdown get called here ( in the Close() )
 					m_sslStream.Close();   // Async Close override not supported yet
@@ -1709,23 +1680,24 @@ namespace FluentFTP {
 					m_sslStream.Dispose(); // Async dispose not supported in this .NET?
 #endif
 				}
-				catch {
+				else if (m_customStream != null) {
+					m_customStream.Dispose(); // Async not supported by custom stream interface
 				}
-				m_sslStream = null;
-			}
-
-			if (m_netStream != null) {
-				try {
+				else if (m_netStream != null) {
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 					await m_netStream.DisposeAsync();
 #else
 					m_netStream.Dispose(); // Async dispose not supported in this .NET?
 #endif
 				}
-				catch {
-				}
-				m_netStream = null;
 			}
+			catch {
+			}
+
+			m_bufStream = null;
+			m_sslStream = null;
+			m_customStream = null;
+			m_netStream = null;
 
 			DisposeSocket();
 

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1562,7 +1562,7 @@ namespace FluentFTP {
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing(sync) " + Client.ClientType + ".FtpSocketStream(" + connText + ")");
 			}
 
-			// BufferedStream dispose WILL dispose the underlying stream.
+			// BufferedStream dispose WILL normally dispose the underlying stream.
 			// If this is a buffered SslStream (created with LeaveInnerStreamOpen), disposing it
 			// won't dispose of the underlying NetStream.
 			// In case of a buffered CustomStream or a buffered NetStream, we need not do more.
@@ -1663,7 +1663,7 @@ namespace FluentFTP {
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing(async) " + Client.ClientType + ".FtpSocketStream(" + connText + ")");
 			}
 
-			// BufferedStream dispose WILL dispose the underlying stream.
+			// BufferedStream dispose WILL normally dispose the underlying stream.
 			// If this is a buffered SslStream (created with LeaveInnerStreamOpen), disposing it
 			// won't dispose of the underlying NetStream.
 			// In case of a buffered CustomStream or a buffered NetStream, we need not do more.

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1375,24 +1375,6 @@ namespace FluentFTP {
 			}
 		}
 
-		//#if NETFRAMEWORK
-		//		/// <summary>
-		//		/// Deactivates SSL on this stream using the specified protocols and reverts back to plain-text FTP.
-		//		/// </summary>
-		//		public void DeactivateEncryption() {
-		//			if (!IsConnected) {
-		//				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
-		//			}
-
-		//			if (m_sslStream == null) {
-		//				throw new InvalidOperationException("SSL Encryption has not been enabled on this stream.");
-		//			}
-
-		//			m_sslStream.Close();
-		//			m_sslStream = null;
-		//		}
-		//#endif
-
 		/// <summary>
 		/// Instructs this stream to listen for connections on the specified address and port
 		/// </summary>


### PR DESCRIPTION
### DO NOT MERGE, EXPERIMENTAL

Up to now it was:

**Non-encrypted:**
Raw Socket/NetStream

**Encrypted:**
Raw Socket/NetStream
Wrapped by BufferedStream
Wrapped by SslStream

Which is just plain wrong. One should present buffered data to ssl for encryption to reduce overhead.

I changed the above stream configuration to be..

**Both encrypted and non-encrypted**
Raw Socket/NetStream
Wrapped by SslStream
Wrapped by BufferedStream <-- moved this

I changed the way the BufferedStream is created: Only in Open***DataStream (Async, Sync, Active, Passive) and thus the buffering is only used on data connections and not in control connections.

It works seamlessly over all .NET versions and with encryption (both SslStream and GnuTLS) or without encryption etc. but:

**I notice to my surprise on my tests that activation of buffering makes no significant difference on .NET Framework, .NET 5+, .NET Standard. It seems all of these .NET versions employ enough inner buffering already themselves. No need to double up.**

**We might as well drop this feature**, as it **was** before this PR effectively forcibly turned off in most use cases **anyway** (proxy, .NET 5+, .NET Standard, NOOP, control connection). It was really only active on .NET Framework, so I wonder who was actually using it... In the past some issues came up where users (falsely) attributed hangs after SSL authentication to be caused by Buffering, so the code was simply changed to disable it outright without real in depth testing or analysis.

So this PR is an invitation for discussion:

1. **We remove buffering**. Means we remove the config variable as well maybe, this would be (after V50) once more an API change for users (->V51).
2. **We use this new buffering code**. We can leave the config variable (Config.SslBuffering) as is, but the name is no longer really indicative of the functionality, or we change the name to Config.Buffering.
3. _And we perhaps change the default of the config variable to_ "No buffering".
4. **We keep the current logic** - and remove the fake/unneeded forcible disable logic so it is at least at the users discretion to enable it. 
5. **We don't touch the logic at all**.

### I would actually advocate removing it completely. After some testing, I find it makes no difference between active and inactive, either in the "old" variant or the "new" one.