### PR TITLE
Enhance log message Uploaded/Downloaded bytes

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -188,9 +188,16 @@ namespace FluentFTP {
 					}
 				}
 
-				LogWithPrefix(FtpTraceLevel.Verbose, "Downloaded " + bytesProcessed + " bytes");
-
 				sw.Stop();
+
+				string bps;
+				try {
+					bps = (bytesProcessed / sw.ElapsedMilliseconds * 1000L).FileSizeToString();
+				}
+				catch {
+					bps = "0";
+				}
+				LogWithPrefix(FtpTraceLevel.Verbose, "Downloaded " + bytesProcessed + " bytes (" + sw.Elapsed.ToShortString() + ", " + bps + "/s)");
 
 				// disconnect FTP streams before exiting
 				if (outStream != null) {

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -259,13 +259,20 @@ namespace FluentFTP {
 					}
 				}
 
-				sw.Stop();
-
 				// wait for transfer to get over
 				while (upStream.Position < upStream.Length) {
 				}
 
-				LogWithPrefix(FtpTraceLevel.Verbose, "Uploaded " + upStream.Position + " bytes");
+				sw.Stop();
+
+				string bps;
+				try {
+					bps = (upStream.Position / sw.ElapsedMilliseconds * 1000L).FileSizeToString();
+				}
+				catch {
+					bps = "0";
+				}
+				LogWithPrefix(FtpTraceLevel.Verbose, "Uploaded " + upStream.Position + " bytes (" + sw.Elapsed.ToShortString() + ", " + bps + "/s)");
 
 				// send progress reports
 				progress?.Report(new FtpProgress(100.0, upStream.Length, 0, TimeSpan.FromSeconds(0), localPath, remotePath, metaProgress));

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -185,9 +185,16 @@ namespace FluentFTP {
 					}
 				}
 
-				LogWithPrefix(FtpTraceLevel.Verbose, "Downloaded " + bytesProcessed + " bytes");
-
 				sw.Stop();
+
+				string bps;
+				try {
+					bps = (bytesProcessed / sw.ElapsedMilliseconds * 1000L).FileSizeToString();
+				}
+				catch {
+					bps = "0";
+				}
+				LogWithPrefix(FtpTraceLevel.Verbose, "Downloaded " + bytesProcessed + " bytes (" + sw.Elapsed.ToShortString() + ", " + bps + "/s)");
 
 				// disconnect FTP streams before exiting
 				outStream?.Flush();

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -250,13 +250,20 @@ namespace FluentFTP {
 					}
 				}
 
-				sw.Stop();
-
 				// wait for transfer to get over
 				while (upStream.Position < upStream.Length) {
 				}
 
-				LogWithPrefix(FtpTraceLevel.Verbose, "Uploaded " + upStream.Position + " bytes");
+				sw.Stop();
+
+				string bps;
+				try {
+					bps = (upStream.Position / sw.ElapsedMilliseconds * 1000L).FileSizeToString();
+				}
+				catch {
+					bps = "0";
+				}
+				LogWithPrefix(FtpTraceLevel.Verbose, "Uploaded " + upStream.Position + " bytes (" + sw.Elapsed.ToShortString() + ", " + bps + "/s)");
 
 				// send progress reports
 				progress?.Invoke(new FtpProgress(100.0, upStream.Length, 0, TimeSpan.FromSeconds(0), localPath, remotePath, metaProgress));


### PR DESCRIPTION
Previously, log messages for Uploaded/Downloaded bytes were in this form:

**Status:   Downloaded 1073741824 bytes**

Now, they are:

**Status:   Downloaded 1073741824 bytes (9,212s, 111,2 MB/s)**

This was useful when checking the effect of turning on/off buffering.