### PR TITLE
Utilize caching Regex calls

### DIFF
--- a/FluentFTP.CSharpExamples/CustomParser.cs
+++ b/FluentFTP.CSharpExamples/CustomParser.cs
@@ -30,11 +30,11 @@ namespace Examples {
 			Match m = null;
 			var regex =
 				@"(?<permissions>[\w-]{10})\s+" +
-				@"(?<objectcount>\d+)\s+" +
-				@"(?<user>[\w\d]+)\s+" +
-				@"(?<group>[\w\d]+)\s+" +
-				@"(?<size>\d+)\s+" +
-				@"(?<modify>\w+\s+\d+\s+\d+:\d+|\w+\s+\d+\s+\d+)\s+" +
+				@"(?<objectcount>[0-9]+)\s+" +
+				@"(?<user>[\w0-9]+)\s+" +
+				@"(?<group>[\w0-9]+)\s+" +
+				@"(?<size>[0-9]+)\s+" +
+				@"(?<modify>\w+\s+[0-9]+\s+[0-9]+:[0-9]+|\w+\s+[0-9]+\s+[0-9]+)\s+" +
 				@"(?<name>.*)$";
 
 			if (!(m = Regex.Match(buf, regex, RegexOptions.IgnoreCase)).Success) {
@@ -66,7 +66,7 @@ namespace Examples {
 			////
 			// Ignore the Modify times sent in LIST format for files
 			// when the server has support for the MDTM command
-			// because they will never be as accurate as what can be had 
+			// because they will never be as accurate as what can be had
 			// by using the MDTM command. MDTM does not work on directories
 			// so if a modify time was parsed from the listing we will try
 			// to convert it to a DateTime object and use it for directories.

--- a/FluentFTP/Client/AsyncClient/OpenFXPConnection.cs
+++ b/FluentFTP/Client/AsyncClient/OpenFXPConnection.cs
@@ -50,7 +50,7 @@ namespace FluentFTP {
 			}
 
 			// extract port from response
-			m = Regex.Match(reply.Message, @"(?<quad1>\d+)," + @"(?<quad2>\d+)," + @"(?<quad3>\d+)," + @"(?<quad4>\d+)," + @"(?<port1>\d+)," + @"(?<port2>\d+)");
+			m = Regex.Match(reply.Message, @"(?<quad1>[0-9]+)," + @"(?<quad2>[0-9]+)," + @"(?<quad3>[0-9]+)," + @"(?<quad4>[0-9]+)," + @"(?<port1>[0-9]+)," + @"(?<port2>[0-9]+)");
 
 			if (!m.Success || m.Groups.Count != 7) {
 				throw new FtpException("Malformed PASV response: " + reply.Message);

--- a/FluentFTP/Client/BaseClient/GetPassivePort.cs
+++ b/FluentFTP/Client/BaseClient/GetPassivePort.cs
@@ -14,7 +14,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// </summary>
 		protected void GetEnhancedPassivePort(FtpReply reply, out string derivedIpad, out int advertisedPort) {
 			// Check the format of the EPSV response, respecting the code page problems of the vertical bar | vs. !
-			var m = Regex.Match(reply.Message, @"\([!\|][!\|][!\|](?<advertisedPort>\d+)[!\|]\)");
+			var m = Regex.Match(reply.Message, @"\([!\|][!\|][!\|](?<advertisedPort>[0-9]+)[!\|]\)");
 
 			if (!m.Success) {
 				// In case EPSV responded with a regular "227 Entering Passive Mode" instead,
@@ -56,7 +56,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// </summary>
 		protected void GetPassivePort(FtpDataConnectionType type, FtpReply reply, out string host, out int port) {
 			// Check the format of the PASV response
-			var m = Regex.Match(reply.Message, @"(?<quad1>\d+)," + @"(?<quad2>\d+)," + @"(?<quad3>\d+)," + @"(?<quad4>\d+)," + @"(?<port1>\d+)," + @"(?<port2>\d+)");
+			var m = Regex.Match(reply.Message, @"(?<quad1>[0-9]+)," + @"(?<quad2>[0-9]+)," + @"(?<quad3>[0-9]+)," + @"(?<quad4>[0-9]+)," + @"(?<port1>[0-9]+)," + @"(?<port2>[0-9]+)");
 
 			if (!m.Success || m.Groups.Count != 7) {
 				throw new FtpException("Malformed PASV response: " + reply.Message);
@@ -79,7 +79,7 @@ namespace FluentFTP.Client.BaseClient {
 			var mP = Regex.Match(host, @"(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)|(^127\.0\.0\.1)|(^0\.0\.0\.0)");
 			if (!mP.Success) {
 				// Routable IPAD, simply use the IPAD advertised by the PASV response
-				return; 
+				return;
 			}
 
 			// PASVUSE mode forces the advertised IPAD to be used, even if not routable,
@@ -94,7 +94,7 @@ namespace FluentFTP.Client.BaseClient {
 			// This VERY OFTEN works (often also with the help of DNS), but not always.
 			// If you NEED to connect via the non-routable IPAD, you must use "PASVUSE" mode
 			LogWithPrefix(FtpTraceLevel.Verbose, "PASV advertised a non-routable IPAD. Using original connect dnsname/IPAD");
-			host = m_host;			
+			host = m_host;
 		}
 
 		/// <summary>

--- a/FluentFTP/Client/Modules/LogMaskModule.cs
+++ b/FluentFTP/Client/Modules/LogMaskModule.cs
@@ -67,7 +67,7 @@ namespace FluentFTP.Client.Modules {
 					if (reply.Code == "227") {
 						message = Regex.Replace(
 							message,
-							@"^(Entering Passive Mode \()(\d{1,3},\d{1,3},\d{1,3},\d{1,3}),(\d{1,3},\d{1,3}\).)$",
+							@"^(Entering Passive Mode \()([0-9]{1,3},[0-9]{1,3},[0-9]{1,3},[0-9]{1,3}),([0-9]{1,3},[0-9]{1,3}\).)$",
 							@"$1***,***,***,***,$3");
 					}
 

--- a/FluentFTP/Client/Modules/LogMaskModule.cs
+++ b/FluentFTP/Client/Modules/LogMaskModule.cs
@@ -65,8 +65,10 @@ namespace FluentFTP.Client.Modules {
 
 					// mask out IPAD
 					if (reply.Code == "227") {
-						Regex regEx = new Regex(@"^(Entering Passive Mode \()(\d{1,3},\d{1,3},\d{1,3},\d{1,3}),(\d{1,3},\d{1,3}\).)$");
-						message = regEx.Replace(message, @"$1***,***,***,***,$3");
+						message = Regex.Replace(
+							message,
+							@"^(Entering Passive Mode \()(\d{1,3},\d{1,3},\d{1,3},\d{1,3}),(\d{1,3},\d{1,3}\).)$",
+							@"$1***,***,***,***,$3");
 					}
 
 				}

--- a/FluentFTP/Client/SyncClient/OpenFXPConnection.cs
+++ b/FluentFTP/Client/SyncClient/OpenFXPConnection.cs
@@ -49,7 +49,7 @@ namespace FluentFTP {
 			}
 
 			// extract port from response
-			m = Regex.Match(reply.Message, @"(?<quad1>\d+)," + @"(?<quad2>\d+)," + @"(?<quad3>\d+)," + @"(?<quad4>\d+)," + @"(?<port1>\d+)," + @"(?<port2>\d+)");
+			m = Regex.Match(reply.Message, @"(?<quad1>[0-9]+)," + @"(?<quad2>[0-9]+)," + @"(?<quad3>[0-9]+)," + @"(?<quad4>[0-9]+)," + @"(?<port1>[0-9]+)," + @"(?<port2>[0-9]+)");
 			if (!m.Success || m.Groups.Count != 7) {
 				throw new FtpException("Malformed PASV response: " + reply.Message);
 			}

--- a/FluentFTP/Helpers/Hashing/HashParser.cs
+++ b/FluentFTP/Helpers/Hashing/HashParser.cs
@@ -27,7 +27,7 @@ namespace FluentFTP.Helpers.Hashing {
 			// Try to parse these differing formats:
 
 			Match m;
-			if (!(m = Regex.Match(reply, @"^(?<algorithm>\S+)\s(?<bytestart>\d+)-(?<byteend>\d+)\s(?<hash>\S+)\s*(?<filename>.*)$")).Success) {
+			if (!(m = Regex.Match(reply, @"^(?<algorithm>\S+)\s(?<bytestart>[0-9]+)-(?<byteend>[0-9]+)\s(?<hash>\S+)\s*(?<filename>.*)$")).Success) {
 				m = Regex.Match(reply, @"(?<algorithm>.+)\s(?<hash>.+)\s");
 			}
 

--- a/FluentFTP/Helpers/Parsers/MachineListParser.cs
+++ b/FluentFTP/Helpers/Parsers/MachineListParser.cs
@@ -107,7 +107,7 @@ namespace FluentFTP.Helpers.Parsers {
 		/// </summary>
 		private static void ParseFileSize(string record, FtpListItem item) {
 			Match m;
-			if ((m = Regex.Match(record, @"size=(?<size>\d+);", RegexOptions.IgnoreCase)).Success) {
+			if ((m = Regex.Match(record, @"size=(?<size>[0-9]+);", RegexOptions.IgnoreCase)).Success) {
 				long size;
 
 				if (long.TryParse(m.Groups["size"].Value, out size)) {
@@ -121,7 +121,7 @@ namespace FluentFTP.Helpers.Parsers {
 		/// </summary>
 		private static void ParsePermissions(string record, FtpListItem item) {
 			Match m;
-			if ((m = Regex.Match(record, @"unix.mode=(?<mode>\d+);", RegexOptions.IgnoreCase)).Success) {
+			if ((m = Regex.Match(record, @"unix.mode=(?<mode>[0-9]+);", RegexOptions.IgnoreCase)).Success) {
 				if (m.Groups["mode"].Value.Length == 4) {
 					item.SpecialPermissions = (FtpSpecialPermissions)int.Parse(m.Groups["mode"].Value[0].ToString());
 					item.OwnerPermissions = (FtpPermission)int.Parse(m.Groups["mode"].Value[1].ToString());

--- a/FluentFTP/Servers/Handlers/OpenVmsServer.cs
+++ b/FluentFTP/Servers/Handlers/OpenVmsServer.cs
@@ -70,7 +70,7 @@ namespace FluentFTP.Servers.Handlers {
 			// FIX : #402 for OpenVMS absolute paths are "SYSDEVICE:[USERS.mylogin]"
 			// FIX : #424 for OpenVMS absolute paths are "FTP_DEFAULT:[WAGN_IN]"
 			// FIX : #454 for OpenVMS absolute paths are "TOPAS$ROOT:[000000.TUIL.YR_20.SUBLIS]"
-			if (new Regex("[A-Za-z$._]*:\\[[A-Za-z0-9$_.]*\\]").Match(path).Success) {
+			if (Regex.IsMatch(path, @"[A-Za-z$._]*:\\[[A-Za-z0-9$_.]*\\]")) {
 				return true;
 			}
 


### PR DESCRIPTION
`new Regex()` doesn't cache the build, but `Regex.Match()` does

[`\d` matches much more than `[0-9]`](https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#decimal-digit-character-d)