### PR TITLE
Rename Daemon->NoopDaemon in preparation for "PollDaemon" coming soon

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -239,8 +239,8 @@ namespace FluentFTP {
 
 			Status.InCriticalSequence = false;
 
-			if (Config.Noop && !Status.DaemonRunning) { 
-				m_task = Task.Run(() => { Daemon(); });
+			if (Config.Noop && !Status.NoopDaemonRunning) { 
+				m_task = Task.Run(() => { NoopDaemon(); });
 			}
 		}
 

--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -91,7 +91,7 @@ namespace FluentFTP {
 
 				var earlySuccess = false;
 
-				Status.DaemonAnyNoops = false;
+				Status.NoopDaemonAnyNoops = false;
 
 				// Fix #554: ability to download zero-byte files
 				if (Config.DownloadZeroByteFiles && outStream == null && localPath != null) {
@@ -158,7 +158,7 @@ namespace FluentFTP {
 					catch (IOException ex) {
 						LogWithPrefix(FtpTraceLevel.Verbose, "IOException in DownloadFileInternal", ex);
 
-						FtpReply exStatus = await ((IInternalFtpClient)this).GetReplyInternal(token, LastCommandExecuted + ", after IOException", Status.DaemonAnyNoops, 10000);
+						FtpReply exStatus = await ((IInternalFtpClient)this).GetReplyInternal(token, LastCommandExecuted + ", after IOException", Status.NoopDaemonAnyNoops, 10000);
 						if (exStatus.Code == "226") {
 							earlySuccess = true;
 							sw.Stop();
@@ -214,7 +214,7 @@ namespace FluentFTP {
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
-				FtpReply status = await ((IInternalFtpClient)this).GetReplyInternal(token, LastCommandExecuted, Status.DaemonAnyNoops);
+				FtpReply status = await ((IInternalFtpClient)this).GetReplyInternal(token, LastCommandExecuted, Status.NoopDaemonAnyNoops);
 
 				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
 				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -20,8 +20,8 @@ namespace FluentFTP {
 			bool reconnect = false;
 			string reconnectReason = string.Empty;
 
-			m_sema.Wait();
-			m_sema.Release();
+			m_NoopSema.Wait();
+			m_NoopSema.Release();
 
 			// Automatic reconnect because we lost the control channel?
 
@@ -29,7 +29,7 @@ namespace FluentFTP {
 				(Config.NoopTestConnectivity
 				 && command != "QUIT"
 		 		 && IsAuthenticated
-				 && Status.DaemonRunning
+				 && Status.NoopDaemonRunning
 				 && !await IsStillConnected())) {
 				if (command == "QUIT") {
 					LogWithPrefix(FtpTraceLevel.Info, "Not sending QUIT because the connection has already been closed.");
@@ -101,7 +101,7 @@ namespace FluentFTP {
 			Log(FtpTraceLevel.Info, "Command:  " + cleanedCommand);
 
 			// send command to FTP server
-			await m_sema.WaitAsync();
+			await m_NoopSema.WaitAsync();
 			try {
 				await m_stream.WriteLineAsync(m_textEncoding, command, token);
 				LastCommandExecuted = command;
@@ -111,7 +111,7 @@ namespace FluentFTP {
 				reply = await ((IInternalFtpClient)this).GetReplyInternal(token, command, false, 0, false);
 			}
 			finally {
-				m_sema.Release();
+				m_NoopSema.Release();
 			}
 			if (reply.Success) {
 				await OnPostExecute(command, token);

--- a/FluentFTP/Client/AsyncClient/Noop.cs
+++ b/FluentFTP/Client/AsyncClient/Noop.cs
@@ -22,7 +22,7 @@ namespace FluentFTP {
 		protected async Task<bool> Noop(bool ignoreNoopInterval = false, CancellationToken token = default(CancellationToken)) {
 			if (ignoreNoopInterval || (Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval)) {
 
-				await m_sema.WaitAsync();
+				await m_NoopSema.WaitAsync();
 				try {
 					if (IsConnected) {
 						Log(FtpTraceLevel.Verbose, "Command:  NOOP (<-Noop)");
@@ -34,7 +34,7 @@ namespace FluentFTP {
 					}
 				}
 				finally {
-					m_sema.Release();
+					m_NoopSema.Release();
 				}
 
 			}

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -178,7 +178,7 @@ namespace FluentFTP {
 				catch {
 				}
 
-				Status.DaemonAnyNoops = false;
+				Status.NoopDaemonAnyNoops = false;
 
 				// loop till entire file uploaded
 				while (localFileLen == 0 || localPosition < localFileLen) {
@@ -278,7 +278,7 @@ namespace FluentFTP {
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
-				FtpReply status = await ((IInternalFtpClient)this).GetReplyInternal(token, LastCommandExecuted, Status.DaemonAnyNoops);
+				FtpReply status = await ((IInternalFtpClient)this).GetReplyInternal(token, LastCommandExecuted, Status.NoopDaemonAnyNoops);
 
 				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
 				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -18,15 +18,15 @@ namespace FluentFTP.Client.BaseClient {
 			bool reconnect = false;
 			string reconnectReason = string.Empty;
 
-			m_sema.Wait();
-			m_sema.Release();
+			m_NoopSema.Wait();
+			m_NoopSema.Release();
 
 			// Automatic reconnect because we lost the control channel?
 			if (!IsConnected ||
 				(Config.NoopTestConnectivity
 				 && command != "QUIT"
 				 && IsAuthenticated
-				 && Status.DaemonRunning
+				 && Status.NoopDaemonRunning
 				 && !((IInternalFtpClient)this).IsStillConnectedInternal())) {
 				if (command == "QUIT") {
 					LogWithPrefix(FtpTraceLevel.Info, "Not sending QUIT because the connection has already been closed.");
@@ -94,7 +94,7 @@ namespace FluentFTP.Client.BaseClient {
 			Log(FtpTraceLevel.Info, "Command:  " + cleanedCommand);
 
 			// send command to FTP server and get the reply
-			m_sema.Wait();
+			m_NoopSema.Wait();
 			try {
 				m_stream.WriteLine(m_textEncoding, command);
 				LastCommandExecuted = command;
@@ -104,7 +104,7 @@ namespace FluentFTP.Client.BaseClient {
 				reply = ((IInternalFtpClient)this).GetReplyInternal(command, false, 0, false);
 			}
 			finally {
-				m_sema.Release();
+				m_NoopSema.Release();
 			}
 			if (reply.Success) {
 				OnPostExecute(command);

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -100,13 +100,13 @@ namespace FluentFTP.Client.BaseClient {
 			long previousElapsedTime = 0;
 
 			if (useSema) {
-				m_sema.Wait();
+				m_NoopSema.Wait();
 			}
 
 			try {
 
 				if (exhaustNoop) {
-					Status.DaemonEnable = false;
+					Status.NoopDaemonEnable = false;
 
 					// tickle the server
 					m_stream.WriteLine(Encoding, "NOOP");
@@ -214,12 +214,12 @@ namespace FluentFTP.Client.BaseClient {
 					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
 
-				Status.DaemonEnable = true;
+				Status.NoopDaemonEnable = true;
 
 			}
 			finally {
 				if (useSema) {
-					m_sema.Release();
+					m_NoopSema.Release();
 				}
 			}
 
@@ -321,13 +321,13 @@ namespace FluentFTP.Client.BaseClient {
 			long previousElapsedTime = 0;
 
 			if (useSema) {
-				await m_sema.WaitAsync();
+				await m_NoopSema.WaitAsync();
 			}
 
 			try {
 
 				if (exhaustNoop) {
-					Status.DaemonEnable = false;
+					Status.NoopDaemonEnable = false;
 
 					// tickle the server
 					m_stream.WriteLine(Encoding, "NOOP");
@@ -435,12 +435,12 @@ namespace FluentFTP.Client.BaseClient {
 					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
 
-				Status.DaemonEnable = true;
+				Status.NoopDaemonEnable = true;
 
 			}
 			finally {
 				if (useSema) {
-					m_sema.Release();
+					m_NoopSema.Release();
 				}
 			}
 

--- a/FluentFTP/Client/BaseClient/Noop.cs
+++ b/FluentFTP/Client/BaseClient/Noop.cs
@@ -22,7 +22,7 @@ namespace FluentFTP.Client.BaseClient {
 		bool IInternalFtpClient.NoopInternal(bool ignoreNoopInterval = false) {
 			if (ignoreNoopInterval || (Config.NoopInterval > 0 && DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval)) {
 
-				m_sema.Wait();
+				m_NoopSema.Wait();
 				try {
 					if (IsConnected) {
 						Log(FtpTraceLevel.Verbose, "Command:  NOOP (<-Noop)");
@@ -34,7 +34,7 @@ namespace FluentFTP.Client.BaseClient {
 					}
 				}
 				finally {
-					m_sema.Release();
+					m_NoopSema.Release();
 				}
 
 			}

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -125,7 +125,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// Used for internally synchronizing access to this
 		/// object from multiple threads in SYNC code
 		/// </summary>
-		protected SemaphoreSlim m_sema = new SemaphoreSlim(1, 1);
+		protected SemaphoreSlim m_NoopSema = new SemaphoreSlim(1, 1);
 
 		/// <summary>
 		/// Control connection socket stream

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -236,8 +236,8 @@ namespace FluentFTP {
 
 			Status.InCriticalSequence = false;
 
-			if (Config.Noop && !Status.DaemonRunning) {
-				m_task = Task.Run(() => { Daemon(); });
+			if (Config.Noop && !Status.NoopDaemonRunning) {
+				m_task = Task.Run(() => { NoopDaemon(); });
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -91,7 +91,7 @@ namespace FluentFTP {
 
 				var earlySuccess = false;
 
-				Status.DaemonAnyNoops = false;
+				Status.NoopDaemonAnyNoops = false;
 
 				// Fix #554: ability to download zero-byte files
 				if (Config.DownloadZeroByteFiles && outStream == null && localPath != null) {
@@ -158,7 +158,7 @@ namespace FluentFTP {
 					catch (IOException ex) {
 						LogWithPrefix(FtpTraceLevel.Verbose, "IOException in DownloadFileInternal", ex);
 
-						FtpReply exStatus = ((IInternalFtpClient)this).GetReplyInternal(LastCommandExecuted + ", after IOException", Status.DaemonAnyNoops, 10000);
+						FtpReply exStatus = ((IInternalFtpClient)this).GetReplyInternal(LastCommandExecuted + ", after IOException", Status.NoopDaemonAnyNoops, 10000);
 						if (exStatus.Code == "226") {
 							sw.Stop();
 							earlySuccess = true;
@@ -209,7 +209,7 @@ namespace FluentFTP {
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
-				FtpReply status = ((IInternalFtpClient)this).GetReplyInternal(LastCommandExecuted, Status.DaemonAnyNoops);
+				FtpReply status = ((IInternalFtpClient)this).GetReplyInternal(LastCommandExecuted, Status.NoopDaemonAnyNoops);
 
 				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
 				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -174,7 +174,7 @@ namespace FluentFTP {
 				catch {
 				}
 
-				Status.DaemonAnyNoops = false;
+				Status.NoopDaemonAnyNoops = false;
 
 				// loop till entire file uploaded
 				while (localFileLen == 0 || localPosition < localFileLen) {
@@ -269,7 +269,7 @@ namespace FluentFTP {
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
-				FtpReply status = ((IInternalFtpClient)this).GetReplyInternal(LastCommandExecuted, Status.DaemonAnyNoops);
+				FtpReply status = ((IInternalFtpClient)this).GetReplyInternal(LastCommandExecuted, Status.NoopDaemonAnyNoops);
 
 				// Fix #353: if server sends 550 or 5xx the transfer was received but could not be confirmed by the server
 				// Fix #509: if server sends 450 or 4xx the transfer was aborted or failed midway

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -134,18 +134,18 @@ namespace FluentFTP {
 		/// <summary>
 		/// Background task status
 		/// </summary>
-		public bool DaemonRunning { get; set; }
+		public bool NoopDaemonRunning { get; set; }
 		/// <summary>
 		/// Background task should GetReply
 		/// </summary>
-		public bool DaemonCmdMode { get; set; }
+		public bool NoopDaemonCmdMode { get; set; }
 		/// <summary>
 		/// Background task enabled
 		/// </summary>
-		public bool DaemonEnable { get; set; }
+		public bool NoopDaemonEnable { get; set; }
 		/// <summary>
 		/// Background task sent noops
 		/// </summary>
-		public bool DaemonAnyNoops { get; set; }
+		public bool NoopDaemonAnyNoops { get; set; }
 	}
 }

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -108,7 +108,7 @@ namespace FluentFTP {
 		public bool StaleDataCheck { get; set; } = true;
 		
 		/// <summary>
-		/// Install the NOOP Daemon whenever an FTP connection is established, which ensures that NOOPs are sent at regular intervals.
+		/// Install the NOOP NoopDaemon whenever an FTP connection is established, which ensures that NOOPs are sent at regular intervals.
 		/// This is the master switch for all NOOP functionality.
 		/// </summary>
 		public bool Noop { get; set; } = false;

--- a/FluentFTP/Proxy/SyncProxy/FtpClientHttp11Proxy.cs
+++ b/FluentFTP/Proxy/SyncProxy/FtpClientHttp11Proxy.cs
@@ -54,7 +54,7 @@ namespace FluentFTP.Proxy.SyncProxy {
 		protected override void Connect(FtpSocketStream stream, string host, int port, FtpIpVersion ipVersions) {
 			base.Connect(stream);
 
-			m_sema.Wait();
+			m_NoopSema.Wait();
 			try {
 				var writer = new StreamWriter(stream);
 				writer.WriteLine("CONNECT {0}:{1} HTTP/1.1", host, port);
@@ -71,7 +71,7 @@ namespace FluentFTP.Proxy.SyncProxy {
 				ProxyHandshake(stream);
 			}
 			finally {
-				m_sema.Release();
+				m_NoopSema.Release();
 			}
 		}
 

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1021,7 +1021,7 @@ namespace FluentFTP {
 
 			// the NOOP daemon needs to know this
 			if (!IsControlConnection) {
-				Client.Status.DaemonCmdMode = false;
+				Client.Status.NoopDaemonCmdMode = false;
 			}
 		}
 
@@ -1164,7 +1164,7 @@ namespace FluentFTP {
 
 			// the NOOP daemon needs to know this
 			if (!IsControlConnection) {
-				Client.Status.DaemonCmdMode = false;
+				Client.Status.NoopDaemonCmdMode = false;
 			}
 		}
 
@@ -1661,8 +1661,8 @@ namespace FluentFTP {
 
 			IsDisposed = true;
 
-			if (Client.Status.DaemonRunning && !IsControlConnection) {
-				Client.Status.DaemonCmdMode = true;
+			if (Client.Status.NoopDaemonRunning && !IsControlConnection) {
+				Client.Status.NoopDaemonCmdMode = true;
 			}
 		}
 
@@ -1763,8 +1763,8 @@ namespace FluentFTP {
 
 			IsDisposed = true;
 
-			if (Client.Status.DaemonRunning && !IsControlConnection) {
-				Client.Status.DaemonCmdMode = true;
+			if (Client.Status.NoopDaemonRunning && !IsControlConnection) {
+				Client.Status.NoopDaemonCmdMode = true;
 			}
 		}
 


### PR DESCRIPTION
The current implementation of Socket.Poll inline in "IsConnected", which is a property of socketstream needs to be isolated from the getter. Firstly, it is not guaranteed to be invoked regularly, secondly it needs an async implementation as well as a sync one. And the list of problems gets even longer when trying to implement when a poll is allowed to occur and when not. See #1582.

So, in order for clean socket polling if the user desires it, a second daemon is to be implemented, to be called "PollDaemon".

The current "Daemon" shall forthwith be called "NoopDaemon", otherwise unchanged apart from renaming.