### PR TITLE
Remove SockPollInterval et. al., improve Daemon, improve FTPSocketStream

### DIFF
--- a/FluentFTP/Client/AsyncClient/Disconnect.cs
+++ b/FluentFTP/Client/AsyncClient/Disconnect.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -29,6 +28,9 @@ namespace FluentFTP {
 						m_stream = null;
 					}
 				}
+			}
+			else {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Connection already closed, nothing to do.");
 			}
 		}
 

--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -197,9 +197,6 @@ namespace FluentFTP {
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// disconnect FTP streams before exiting

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -20,16 +20,15 @@ namespace FluentFTP {
 			bool reconnect = false;
 			string reconnectReason = string.Empty;
 
-			m_daemonSemaphore.Wait();
+			m_daemonSemaphore.Wait(token);
 			m_daemonSemaphore.Release();
 
 			// Automatic reconnect because we lost the control channel?
-
 			if (!IsConnected ||
 				(Config.NoopTestConnectivity
 				 && command != "QUIT"
 		 		 && IsAuthenticated
-				 && Status.NoopDaemonRunning
+				 && Status.NoopDaemonEnable
 				 && !await IsStillConnected(token: token))) {
 				if (command == "QUIT") {
 					LogWithPrefix(FtpTraceLevel.Info, "Not sending QUIT because the connection has already been closed.");

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -268,13 +268,10 @@ namespace FluentFTP {
 				long tot = upStream.Position;
 				long ems = sw.ElapsedMilliseconds;
 				string bps = ems == 0 ? "?" : (tot / ems * 1000L).FileSizeToString();
-				string successText = "Uploaded " + tot + " bytes " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
+				string successText = "Uploaded " + tot + " bytes, " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// send progress reports

--- a/FluentFTP/Client/AsyncFtpClient.cs
+++ b/FluentFTP/Client/AsyncFtpClient.cs
@@ -89,10 +89,12 @@ namespace FluentFTP {
 			Logger = logger;
 		}
 
+		protected override BaseFtpClient Create() {
+			return new AsyncFtpClient();
+		}
 		#endregion
 
 		#region Destructor
-
 		public override void Dispose() {
 			LogFunction(nameof(Dispose));
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
@@ -104,33 +106,32 @@ namespace FluentFTP {
 
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 		public async ValueTask DisposeAsync() {
-			await DisposeAsyncCore();
-			GC.SuppressFinalize(this);
-		}
 #else
 		public async Task DisposeAsync() {
+#endif
+			if (IsDisposed) {
+				return;
+			}
+
+			LogFunction(nameof(DisposeAsync));
+			LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(async) " + this.ClientType);
+
 			await DisposeAsyncCore();
+
+			await Task.Run(() => {
+				WaitForDaemonTermination();
+			});
+
+			IsDisposed = true;
+
 			GC.SuppressFinalize(this);
 		}
-#endif
 
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 		protected virtual async ValueTask DisposeAsyncCore() {
 #else
 		protected virtual async Task DisposeAsyncCore() {
 #endif
-			if (IsDisposed) {
-				return;
-			}
-
-			// Fix: Hard catch and suppress all exceptions during disposing as there are constant issues with this method
-			try {
-				LogFunction(nameof(DisposeAsync));
-				LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(async) " + this.ClientType);
-			}
-			catch {
-			}
-
 			try {
 				if (IsConnected) {
 					await Disconnect();
@@ -145,26 +146,17 @@ namespace FluentFTP {
 				}
 				catch {
 				}
-
-				m_stream = null;
+				finally {
+					m_stream = null;
+				}
 			}
 
-			try {
-				m_credentials = null;
-				m_textEncoding = null;
-				m_host = null;
-			}
-			catch {
-			}
-
-			IsDisposed = true;
+			m_credentials = null;
+			m_textEncoding = null;
+			m_host = null;
 		}
 
-#endregion
-
-		protected override BaseFtpClient Create() {
-			return new AsyncFtpClient();
-		}
+		#endregion
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 

--- a/FluentFTP/Client/BaseClient/CloseDataStream.cs
+++ b/FluentFTP/Client/BaseClient/CloseDataStream.cs
@@ -21,10 +21,6 @@ namespace FluentFTP.Client.BaseClient {
 				throw new ArgumentException("The data stream parameter was null");
 			}
 
-			// A socket poll in here would be trouble, so disable by setting to zero.
-			int saveSocketPollInterval = stream.SocketPollInterval;
-			stream.SocketPollInterval = 0;
-
 			try {
 				if (IsConnected) {
 					// Because the data connection was closed, if the command that required the data
@@ -45,8 +41,6 @@ namespace FluentFTP.Client.BaseClient {
 				}
 			}
 
-			stream.SocketPollInterval = saveSocketPollInterval;
-
 			return reply;
 		}
 
@@ -62,10 +56,6 @@ namespace FluentFTP.Client.BaseClient {
 			if (stream == null) {
 				throw new ArgumentException("The data stream parameter was null");
 			}
-
-			// A socket poll in here would be trouble, so disable by setting to zero.
-			int saveSocketPollInterval = stream.SocketPollInterval;
-			stream.SocketPollInterval = 0;
 
 			try {
 				if (IsConnected) {
@@ -86,8 +76,6 @@ namespace FluentFTP.Client.BaseClient {
 					await ((IInternalFtpClient)this).DisposeInternal(token);
 				}
 			}
-
-			stream.SocketPollInterval = saveSocketPollInterval;
 
 			return reply;
 		}

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
 
@@ -26,7 +27,7 @@ namespace FluentFTP.Client.BaseClient {
 				(Config.NoopTestConnectivity
 				 && command != "QUIT"
 				 && IsAuthenticated
-				 && Status.NoopDaemonRunning
+				 && Status.NoopDaemonEnable
 				 && !((IInternalFtpClient)this).IsStillConnectedInternal())) {
 				if (command == "QUIT") {
 					LogWithPrefix(FtpTraceLevel.Info, "Not sending QUIT because the connection has already been closed.");

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -106,8 +106,6 @@ namespace FluentFTP.Client.BaseClient {
 			try {
 
 				if (exhaustNoop) {
-					Status.NoopDaemonEnable = false;
-
 					// tickle the server
 					m_stream.WriteLine(Encoding, "NOOP");
 				}
@@ -115,7 +113,7 @@ namespace FluentFTP.Client.BaseClient {
 				sw.Start();
 
 				do {
-					if (!IsConnected) {
+					if (useSema && !IsConnected) {
 						throw new InvalidOperationException("No connection to the server exists.");
 					}
 
@@ -215,7 +213,6 @@ namespace FluentFTP.Client.BaseClient {
 					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
 
-				Status.NoopDaemonEnable = true;
 
 			}
 			finally {
@@ -328,8 +325,6 @@ namespace FluentFTP.Client.BaseClient {
 			try {
 
 				if (exhaustNoop) {
-					Status.NoopDaemonEnable = false;
-
 					// tickle the server
 					m_stream.WriteLine(Encoding, "NOOP");
 				}
@@ -337,7 +332,7 @@ namespace FluentFTP.Client.BaseClient {
 				sw.Start();
 
 				do {
-					if (!IsConnected) {
+					if (useSema && !IsConnected) {
 						throw new InvalidOperationException("No connection to the server exists.");
 					}
 
@@ -436,8 +431,6 @@ namespace FluentFTP.Client.BaseClient {
 				if (exhaustNoop) {
 					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
-
-				Status.NoopDaemonEnable = true;
 
 			}
 			finally {

--- a/FluentFTP/Client/BaseClient/NoopDaemon.cs
+++ b/FluentFTP/Client/BaseClient/NoopDaemon.cs
@@ -8,117 +8,115 @@ namespace FluentFTP.Client.BaseClient {
 		/// <summary>
 		/// NoopDaemon for NOOP handling
 		/// </summary>
-		protected void NoopDaemon() {
+		protected void NoopDaemon(CancellationToken ct) {
 
-			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon is initialized");
+			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon(" + this.ClientType + ") is initialized, NoopInterval = " + Config.NoopInterval);
 
 			Random rnd = new Random();
 
-			Status.NoopDaemonRunning = true;
-			Status.NoopDaemonCmdMode = true;
 			Status.NoopDaemonEnable = true;
 			Status.NoopDaemonAnyNoops = 0;
+			Status.NoopDaemonCmdMode = true;
 
 			bool gotEx = false;
 
 			do { // while(true)
 
-				if (!IsConnected) {
+				if (ct.IsCancellationRequested) {
 					break;
 				}
 
-				if (Status.NoopDaemonEnable &&
-					Config.NoopInterval > 0 &&
-					DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval) {
+				if (m_stream.RealConnectionState == FtpRealConnectionStates.Up &&
+					Status.NoopDaemonEnable) {
 
-					// choose one of the normal or the safe commands
-					string rndCmd = Status.NoopDaemonCmdMode ?
-						Config.NoopInactiveCommands[rnd.Next(Config.NoopInactiveCommands.Count)] :
-						Config.NoopActiveCommands[rnd.Next(Config.NoopActiveCommands.Count)];
+					m_daemonSemaphore.Wait(ct);
 
-					// only log this if we have an active data connection
-					if (Status.NoopDaemonCmdMode) {
-						Log(FtpTraceLevel.Verbose, "Command:  " + rndCmd + " (<-NoopDaemon)");
-					}
-					else {
-						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (<-NoopDaemon)");
-					}
+					if (Config.NoopInterval > 0 &&
+						DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval) {
 
-					try {
-						m_daemonSemaphore.Wait();
-
-						LastCommandTimestamp = DateTime.UtcNow;
-
-						// send the random NOOP command
 						try {
-							m_stream.WriteLine(m_textEncoding, rndCmd);
+							// choose one of the normal or the safe commands
+							string rndCmd = Status.NoopDaemonCmdMode ?
+								Config.NoopInactiveCommands[rnd.Next(Config.NoopInactiveCommands.Count)] :
+								Config.NoopActiveCommands[rnd.Next(Config.NoopActiveCommands.Count)];
+
+							// only log this if we have an active data connection
+							if (Status.NoopDaemonCmdMode) {
+								Log(FtpTraceLevel.Verbose, "Command:  " + rndCmd + " (<-NoopDaemon)");
+							}
+							else {
+								((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (<-NoopDaemon)");
+							}
+
+							LastCommandTimestamp = DateTime.UtcNow;
+
+							// send the random NOOP command
+							try {
+								m_stream.WriteLine(m_textEncoding, rndCmd);
+							}
+							catch (Exception ex) {
+								((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#1): " + ex.Message + " (NoopDaemon)");
+								gotEx = true;
+							}
+
+							if (!gotEx) {
+								// tell the outside world, NOOPs have actually been sent.
+								Status.NoopDaemonAnyNoops += 1;
+
+								// pick the command reply if this is just an idle control connection
+								if (Status.NoopDaemonCmdMode) {
+									bool success = false;
+
+									m_stream.RealConnectionState = FtpRealConnectionStates.Unknown;
+
+									try {
+										success = ((IInternalFtpClient)this).GetReplyInternal(rndCmd + " (<-NoopDaemon)", false, 10000, false).Success;
+									}
+									catch (Exception ex) {
+										((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#2): " + ex.Message + " (NoopDaemon)");
+										gotEx = true;
+									}
+									finally {
+										LastCommandTimestamp = DateTime.UtcNow;
+										m_stream.RealConnectionState = FtpRealConnectionStates.Up;
+									}
+
+									// in case one of these commands was successfully issued, make sure we store that
+									if (success) {
+										if (rndCmd.StartsWith("TYPE I")) {
+											Status.CurrentDataType = FtpDataType.Binary;
+										}
+
+										if (rndCmd.StartsWith("TYPE A")) {
+											Status.CurrentDataType = FtpDataType.ASCII;
+										}
+									}
+								}
+							}
 						}
 						catch (Exception ex) {
-							((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#1): " + ex.Message + " (NoopDaemon)");
+							((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#3): " + ex.Message + " (NoopDaemon)");
 							gotEx = true;
 						}
-
-						if (!gotEx) {
-							// tell the outside world, NOOPs have actually been sent.
-							Status.NoopDaemonAnyNoops += 1;
-
-							// pick the command reply if this is just an idle control connection
-							if (Status.NoopDaemonCmdMode) {
-								bool success = false;
-								try {
-									success = ((IInternalFtpClient)this).GetReplyInternal(rndCmd + " (<-NoopDaemon)", false, 10000, false).Success;
-								}
-								catch (Exception ex) {
-									((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#2): " + ex.Message + " (NoopDaemon)");
-									gotEx = true;
-								}
-								finally {
-									LastCommandTimestamp = DateTime.UtcNow;
-								}
-
-								// in case one of these commands was successfully issued, make sure we store that
-								if (success) {
-									if (rndCmd.StartsWith("TYPE I")) {
-										Status.CurrentDataType = FtpDataType.Binary;
-									}
-
-									if (rndCmd.StartsWith("TYPE A")) {
-										Status.CurrentDataType = FtpDataType.ASCII;
-									}
-								}
-							}
-						}
 					}
-					catch (Exception ex) {
-						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#3): " + ex.Message + " (NoopDaemon)");
-						gotEx = true;
+
+
+					if (gotEx) {
+						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Indicating connection lost (NoopDaemon)");
+						Status.NoopDaemonEnable = false;
+						m_stream.RealConnectionState = FtpRealConnectionStates.PendingDown;
+						gotEx = false;
 					}
-					finally {
-						if (gotEx) {
-							if (m_stream != null) {
-								m_stream.Close();
-								m_stream = null;
-							}
-						}
-						m_daemonSemaphore.Release();
-					}
+
+					m_daemonSemaphore.Release();
+
 				}
 
-				if (gotEx) {
-					break;
-				}
-
-				Thread.Sleep(100);
+				Thread.Sleep(250);
 
 			} while (true);
 
-			string reason = string.Empty;
-			if (gotEx) {
-				reason = " due to detected connection problem";
-			}
-
-			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon terminated" + reason);
-			Status.NoopDaemonRunning = false;
+			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon terminated");
 		}
 	}
 }

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -100,11 +100,6 @@ namespace FluentFTP.Client.BaseClient {
 
 		protected FtpListParser CurrentListParser;
 
-		/// <summary>
-		/// A thread for background tasks
-		/// </summary>
-		protected Task m_task;
-
 		// Holds the cached resolved address
 		protected string m_Address;
 
@@ -139,6 +134,7 @@ namespace FluentFTP.Client.BaseClient {
 		FtpSocketStream IInternalFtpClient.GetBaseStream() {
 			return m_stream;
 		}
+
 		void IInternalFtpClient.SetListingParser(FtpParser parser) {
 			CurrentListParser.CurrentParser = parser;
 			CurrentListParser.ParserConfirmed = false;

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -93,7 +93,7 @@ namespace FluentFTP.Client.BaseClient {
 				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for Daemon termination(" + this.ClientType + ")");
 				Status.NoopDaemonTokenSource.Cancel();
 				DateTime startTime = DateTime.UtcNow;
-				while (Config.Noop && Status.NoopDaemonTask.Status == TaskStatus.Running &&
+				while (Config.Noop && Status.NoopDaemonTask != null && Status.NoopDaemonTask.Status == TaskStatus.Running &&
 					DateTime.UtcNow.Subtract(startTime).TotalMilliseconds < 20000) {
 					Thread.Sleep(250);
 				};

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -96,7 +96,7 @@ namespace FluentFTP.Client.BaseClient {
 				while (Config.Noop && Status.NoopDaemonTask != null && Status.NoopDaemonTask.Status == TaskStatus.Running &&
 					DateTime.UtcNow.Subtract(startTime).TotalMilliseconds < 20000) {
 					Thread.Sleep(250);
-				};
+				}
 				LogWithPrefix(FtpTraceLevel.Verbose, "Daemon terminated");
 			}
 		}

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace FluentFTP.Client.BaseClient {
 	public partial class BaseFtpClient : IDisposable, IInternalFtpClient {
@@ -15,6 +16,12 @@ namespace FluentFTP.Client.BaseClient {
 			Config = config ?? new FtpConfig();
 		}
 
+		/// <summary>
+		/// Creates a new instance of this class. Useful in FTP proxy classes.
+		/// </summary>
+		protected virtual BaseFtpClient Create() {
+			return new BaseFtpClient(null);
+		}
 		#endregion
 
 		#region Clone
@@ -63,7 +70,6 @@ namespace FluentFTP.Client.BaseClient {
 
 		}
 
-
 		#endregion
 
 		#region Destructor
@@ -81,25 +87,18 @@ namespace FluentFTP.Client.BaseClient {
 				}
 			}
 		}
-		/// <summary>
-		/// Check if the host parameter is valid
-		/// </summary>
-		/// <param name="host"></param>
-		protected string ValidateHost(Uri host) {
-			if (host == null) {
-				throw new ArgumentNullException(nameof(host), "Host is required");
-			}
-			if (host.Scheme != Uri.UriSchemeFtp) {
-				throw new ArgumentException("Host is not a valid FTP path");
-			}
-			return host.Host;
-		}
 
-		/// <summary>
-		/// Creates a new instance of this class. Useful in FTP proxy classes.
-		/// </summary>
-		protected virtual BaseFtpClient Create() {
-			return new BaseFtpClient(null);
+		public void WaitForDaemonTermination() {
+			if (Config.Noop) {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for Daemon termination(" + this.ClientType + ")");
+				Status.NoopDaemonTokenSource.Cancel();
+				DateTime startTime = DateTime.UtcNow;
+				while (Config.Noop && Status.NoopDaemonTask.Status == TaskStatus.Running &&
+					DateTime.UtcNow.Subtract(startTime).TotalMilliseconds < 20000) {
+					Thread.Sleep(250);
+				};
+				LogWithPrefix(FtpTraceLevel.Verbose, "Daemon terminated");
+			}
 		}
 
 		/// <summary>
@@ -111,13 +110,8 @@ namespace FluentFTP.Client.BaseClient {
 				return;
 			}
 
-			// Fix: Hard catch and suppress all exceptions during disposing as there are constant issues with this method
-			try {
-				LogFunction(nameof(Dispose));
-				LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(sync) " + this.ClientType);
-			}
-			catch {
-			}
+			LogFunction(nameof(Dispose));
+			LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(sync) " + this.ClientType);
 
 			try {
 				if (IsConnected) {
@@ -133,19 +127,19 @@ namespace FluentFTP.Client.BaseClient {
 				}
 				catch {
 				}
-
-				m_stream = null;
+				finally {
+					m_stream = null;
+				}
 			}
 
-			try {
-				m_credentials = null;
-				m_textEncoding = null;
-				m_host = null;
-			}
-			catch {
-			}
+			m_credentials = null;
+			m_textEncoding = null;
+			m_host = null;
+
+			WaitForDaemonTermination();
 
 			IsDisposed = true;
+
 			GC.SuppressFinalize(this);
 		}
 

--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -326,7 +326,6 @@ namespace FluentFTP.Client.Modules {
 			if (knownProfile != null) {
 				client.Config.ConnectTimeout = knownProfile.Timeout;
 				client.Config.RetryAttempts = knownProfile.RetryAttempts;
-				client.Config.SocketPollInterval = knownProfile.SocketPollInterval;
 			}
 		}
 
@@ -456,9 +455,6 @@ namespace FluentFTP.Client.Modules {
 				client.Config.ReadTimeout = profile.Timeout;
 				client.Config.DataConnectionConnectTimeout = profile.Timeout;
 				client.Config.DataConnectionReadTimeout = profile.Timeout;
-			}
-			if (client.Config.SocketPollInterval != 0) {
-				client.Config.SocketPollInterval = profile.SocketPollInterval;
 			}
 			if (client.Config.RetryAttempts != 0) {
 				client.Config.RetryAttempts = profile.RetryAttempts;

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -85,7 +85,6 @@ namespace FluentFTP {
 
 			m_hashAlgorithms = FtpHashAlgorithm.NONE;
 			m_stream.ConnectTimeout = Config.ConnectTimeout;
-			m_stream.SocketPollInterval = Config.SocketPollInterval;
 			Connect(m_stream);
 
 			m_stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);
@@ -236,8 +235,12 @@ namespace FluentFTP {
 
 			Status.InCriticalSequence = false;
 
-			if (Config.Noop && !Status.NoopDaemonRunning) {
-				m_task = Task.Run(() => { NoopDaemon(); });
+			if (Config.Noop) {
+				if (Status.NoopDaemonTask == null) {
+					Status.NoopDaemonTask = Task.Factory.StartNew(() => { NoopDaemon(Status.NoopDaemonTokenSource.Token); }, Status.NoopDaemonTokenSource.Token);
+				}
+				Status.NoopDaemonEnable = true;
+				Status.NoopDaemonCmdMode = true;
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/Disconnect.cs
+++ b/FluentFTP/Client/SyncClient/Disconnect.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace FluentFTP {
 	public partial class FtpClient {
@@ -29,6 +26,9 @@ namespace FluentFTP {
 						m_stream = null;
 					}
 				}
+			}
+			else {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Connection already closed, nothing to do.");
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -194,9 +194,6 @@ namespace FluentFTP {
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// disconnect FTP streams before exiting

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -259,13 +259,10 @@ namespace FluentFTP {
 				long tot = upStream.Position;
 				long ems = sw.ElapsedMilliseconds;
 				string bps = ems == 0 ? "?" : (tot / ems * 1000L).FileSizeToString();
-				string successText = "Uploaded " + tot + " bytes " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
+				string successText = "Uploaded " + tot + " bytes, " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// send progress reports

--- a/FluentFTP/Enums/FtpRealConnectionsStates.cs
+++ b/FluentFTP/Enums/FtpRealConnectionsStates.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace FluentFTP {
+	/// <summary>
+	/// Real transitional connection states
+	/// </summary>
+	[Flags]
+	public enum FtpRealConnectionStates {
+		/// <summary>
+		/// Deamon will determine the state
+		/// </summary>
+		Unknown,
+
+		/// <summary>
+		/// Not good state and it will be brought down, closed, disposed
+		/// </summary>
+		PendingDown,
+
+		/// <summary>
+		/// Closed, disposed
+		/// </summary>
+		Down,
+
+		/// <summary>
+		/// Connected, at least the last time the NOOP daemon checked the connection, or
+		/// the POLL daemon checked the connection, it was ok.
+		/// The POLL daemon checks control and data connections, the NOOP daemon only checks
+		/// control connections.
+		/// </summary>
+		Up,
+
+	};
+
+}

--- a/FluentFTP/Enums/FtpRealConnectionsStates.cs
+++ b/FluentFTP/Enums/FtpRealConnectionsStates.cs
@@ -7,12 +7,12 @@ namespace FluentFTP {
 	[Flags]
 	public enum FtpRealConnectionStates {
 		/// <summary>
-		/// Deamon will determine the state
+		/// Deamon will determine the state in a short while
 		/// </summary>
 		Unknown,
 
 		/// <summary>
-		/// Not good state and it will be brought down, closed, disposed
+		/// Not a good state and it will be brought down, closed and disposed soon
 		/// </summary>
 		PendingDown,
 
@@ -22,10 +22,7 @@ namespace FluentFTP {
 		Down,
 
 		/// <summary>
-		/// Connected, at least the last time the NOOP daemon checked the connection, or
-		/// the POLL daemon checked the connection, it was ok.
-		/// The POLL daemon checks control and data connections, the NOOP daemon only checks
-		/// control connections.
+		/// Connected, at least the last time the NOOP daemon checked the connection
 		/// </summary>
 		Up,
 

--- a/FluentFTP/Enums/FtpRealConnectionsStates.cs
+++ b/FluentFTP/Enums/FtpRealConnectionsStates.cs
@@ -4,7 +4,6 @@ namespace FluentFTP {
 	/// <summary>
 	/// Real transitional connection states
 	/// </summary>
-	[Flags]
 	public enum FtpRealConnectionStates {
 		/// <summary>
 		/// Deamon will determine the state in a short while

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace FluentFTP {
 
@@ -132,20 +134,24 @@ namespace FluentFTP {
 		public ushort zOSListingLRECL { get; set; }
 
 		/// <summary>
-		/// Background task status
+		/// NOOP Daemon Task
 		/// </summary>
-		public bool NoopDaemonRunning { get; set; }
+		public Task NoopDaemonTask;
 		/// <summary>
-		/// Background task should GetReply
+		/// NOOP Daemon TokenSource
 		/// </summary>
-		public bool NoopDaemonCmdMode { get; set; }
+		public CancellationTokenSource NoopDaemonTokenSource = new CancellationTokenSource();
 		/// <summary>
-		/// Background task enabled
+		/// NOOP Daemon enabled
 		/// </summary>
 		public bool NoopDaemonEnable { get; set; }
 		/// <summary>
-		/// Background task sent noops
+		/// NOOP Daemon sent noops
 		/// </summary>
 		public int NoopDaemonAnyNoops { get; set; }
+		/// <summary>
+		/// NOOP Daemon should GetReply
+		/// </summary>
+		public bool NoopDaemonCmdMode { get; set; }
 	}
 }

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -136,11 +136,11 @@ namespace FluentFTP {
 		/// <summary>
 		/// NOOP Daemon Task
 		/// </summary>
-		public Task NoopDaemonTask;
+		public Task NoopDaemonTask { get; set; }
 		/// <summary>
 		/// NOOP Daemon TokenSource
 		/// </summary>
-		public CancellationTokenSource NoopDaemonTokenSource = new CancellationTokenSource();
+		public CancellationTokenSource NoopDaemonTokenSource { get; set; } = new CancellationTokenSource();
 		/// <summary>
 		/// NOOP Daemon enabled
 		/// </summary>

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -69,33 +69,6 @@ namespace FluentFTP {
 		/// </summary>
 		public FtpIpVersion InternetProtocolVersions { get; set; } = FtpIpVersion.ANY;
 
-		protected int _socketPollInterval = 15000;
-
-		/// <summary>
-		/// Gets or sets the length of time in milliseconds
-		/// that must pass since the last socket activity
-		/// before calling <see cref="System.Net.Sockets.Socket.Poll"/> 
-		/// on the socket to test for connectivity. 
-		/// Setting this interval too low will
-		/// have a negative impact on performance. Setting this
-		/// interval to 0 disables Polling all together.
-		/// The default value is 15 seconds.
-		/// </summary>
-		public int SocketPollInterval {
-			get => _socketPollInterval;
-			set {
-				_socketPollInterval = value;
-				
-				// set this value on the FtpClient's base stream
-				if (_client != null) {
-					var stream = ((IInternalFtpClient)_client).GetBaseStream();
-					if (stream != null) {
-						stream.SocketPollInterval = value;
-					}
-				}
-			}
-		}
-
 		/// <summary>
 		/// Gets or sets a value indicating whether a test should be performed to
 		/// see if there is stale (unrequested data) sitting on the socket. In some
@@ -108,7 +81,8 @@ namespace FluentFTP {
 		public bool StaleDataCheck { get; set; } = true;
 		
 		/// <summary>
-		/// Install the NOOP NoopDaemon whenever an FTP connection is established, which ensures that NOOPs are sent at regular intervals.
+		/// Install the NOOP NoopDaemon whenever an FTP connection is established,
+		/// which ensures that NOOPs are sent at regular intervals.
 		/// This is the master switch for all NOOP functionality.
 		/// </summary>
 		public bool Noop { get; set; } = false;
@@ -119,6 +93,9 @@ namespace FluentFTP {
 		/// This is called during downloading/uploading and idle times. Setting this
 		/// interval to 0 stops NOOPs from being issued.
 		/// The default value is 3 minutes, which catches the typical 5 minute timeout by FTP servers.
+		/// Note that many servers nowadays implement a "No-files-transferred" timeout. In such a case
+		/// you would need to schedule a small dummy file transfer from time to time to avoid triggering
+		/// this. Regular NOOP commands will not help in this case.
 		/// </summary>
 		public int NoopInterval { get; set; } = 180000;
 
@@ -613,7 +590,6 @@ namespace FluentFTP {
 			write.LogUserName = read.LogUserName;
 			write.LogPassword = read.LogPassword;
 			write.InternetProtocolVersions = read.InternetProtocolVersions;
-			write.SocketPollInterval = read.SocketPollInterval;
 			write.StaleDataCheck = read.StaleDataCheck;
 			write.Noop = read.Noop;
 			write.NoopInterval = read.NoopInterval;

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -108,7 +108,7 @@ namespace FluentFTP {
 		/// the control connections is inactive longer than a set time.
 		/// This is the master switch for all NOOP related functionality.
 		/// </summary>
-		public bool Noop { get; set; } = true;
+		public bool Noop { get; set; } = false;
 
 		/// <summary>
 		/// Gets or sets the length of time in milliseconds of inactivity on the control

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -79,27 +79,51 @@ namespace FluentFTP {
 		/// available on the socket before executing a command.
 		/// </summary>
 		public bool StaleDataCheck { get; set; } = true;
-		
+
+		protected int _socketPollInterval = 15000;
+
+		/// <summary>
+		/// Gets or sets the length of time in milliseconds
+		/// that must pass since the last socket activity
+		/// before calling <see cref="System.Net.Sockets.Socket.Poll"/> 
+		/// on the socket to test for connectivity. 
+		/// Setting this interval too low will
+		/// have a negative impact on performance. Setting this
+		/// interval to 0 disables Polling all together.
+		/// The default value is 15 seconds.
+		/// This has been removed and you are encouraged to use
+		/// <see cref="Noop"/> instead, if you are interested in
+		/// avoiding inactivity timeouts or in more aggressive ways
+		/// to detect connection failures.
+		/// </summary>
+		[Obsolete]
+		public int SocketPollInterval {
+			get => _socketPollInterval;
+			set => _socketPollInterval = value;
+		}
+
 		/// <summary>
 		/// Install the NOOP Daemon whenever an FTP connection is established,
 		/// which enables the capability to send NOOP commands at regular intervals when
 		/// the control connections is inactive longer than a set time.
 		/// This is the master switch for all NOOP related functionality.
 		/// </summary>
-		public bool Noop { get; set; } = false;
+		public bool Noop { get; set; } = true;
 
 		/// <summary>
 		/// Gets or sets the length of time in milliseconds of inactivity on the control
 		/// connection that must expire before a NOOP command is sent, both during downloading/uploading
 		/// and during idle times. Setting this interval to 0 stops NOOPs from being issued.
-		/// The default value is 3 minutes, which catches the typical 5 minute timeout of popular FTP
+		/// The default value is 4:30 minutes, which defeats the typical 5 minute timeout of popular FTP
 		/// servers.
+		/// If you are interested in very aggressive detection of connection failures, you may set
+		/// this value to as low as 1000ms.
 		/// Note that many servers nowadays implement a "No-files-transferred" timeout, in order to thwart
-		/// a users attempts to keep the control connection alive. In such a case you would need to
-		/// schedule a small dummy file transfer from time to time to avoid this timeout from triggering.
+		/// a users attempts to keep the control connection alive. In such a case your code would need to
+		/// schedule a small dummy file transfer from time to time to avoid such a timeout from triggering.
 		/// Regular NOOP commands will not help when your FTP server uses such a strategy.
 		/// </summary>
-		public int NoopInterval { get; set; } = 180000;
+		public int NoopInterval { get; set; } = 270000;
 
 		private List<string> _noopInactiveCmds = new List<string> { "NOOP", "PWD", "TYPE I", "TYPE A" };
 

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -54,7 +54,7 @@ namespace FluentFTP {
 		public bool LogPassword { get; set; } = false;
 
 		/// <summary>
-		/// Should the command duration be shown after each log command?
+		/// Should the command duration be shown after each logged command?
 		/// </summary>
 		public bool LogDurations { get; set; } = true;
 
@@ -81,21 +81,23 @@ namespace FluentFTP {
 		public bool StaleDataCheck { get; set; } = true;
 		
 		/// <summary>
-		/// Install the NOOP NoopDaemon whenever an FTP connection is established,
-		/// which ensures that NOOPs are sent at regular intervals.
-		/// This is the master switch for all NOOP functionality.
+		/// Install the NOOP Daemon whenever an FTP connection is established,
+		/// which enables the capability to send NOOP commands at regular intervals when
+		/// the control connections is inactive longer than a set time.
+		/// This is the master switch for all NOOP related functionality.
 		/// </summary>
 		public bool Noop { get; set; } = false;
 
 		/// <summary>
-		/// Gets or sets the length of time in milliseconds after last command
-		/// (NOOP or other) that a NOOP command is sent./>.
-		/// This is called during downloading/uploading and idle times. Setting this
-		/// interval to 0 stops NOOPs from being issued.
-		/// The default value is 3 minutes, which catches the typical 5 minute timeout by FTP servers.
-		/// Note that many servers nowadays implement a "No-files-transferred" timeout. In such a case
-		/// you would need to schedule a small dummy file transfer from time to time to avoid triggering
-		/// this. Regular NOOP commands will not help in this case.
+		/// Gets or sets the length of time in milliseconds of inactivity on the control
+		/// connection that must expire before a NOOP command is sent, both during downloading/uploading
+		/// and during idle times. Setting this interval to 0 stops NOOPs from being issued.
+		/// The default value is 3 minutes, which catches the typical 5 minute timeout of popular FTP
+		/// servers.
+		/// Note that many servers nowadays implement a "No-files-transferred" timeout, in order to thwart
+		/// a users attempts to keep the control connection alive. In such a case you would need to
+		/// schedule a small dummy file transfer from time to time to avoid this timeout from triggering.
+		/// Regular NOOP commands will not help when your FTP server uses such a strategy.
 		/// </summary>
 		public int NoopInterval { get; set; } = 180000;
 
@@ -122,7 +124,7 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
-		/// Issue a NOOP command tp precede any command issued on the control connection
+		/// Issue a NOOP command to precede any command issued on the control connection
 		/// to test connectivity in a reliable fashion. Note: This can incur some control
 		/// connection overhead and does not alleviate inactivity timeouts, it just helps
 		/// to identify connectivity issues early on.

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -393,14 +393,6 @@ namespace FluentFTP {
 		/// Flushes the stream
 		/// </summary>
 		public override void Flush() {
-			if (!IsConnected) {
-				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
-			}
-
-			if (BaseStream == null) {
-				throw new InvalidOperationException("The base stream of the FtpSocketStream object is null.");
-			}
-
 			BaseStream.Flush();
 		}
 
@@ -409,14 +401,6 @@ namespace FluentFTP {
 		/// </summary>
 		/// <param name="token">The <see cref="CancellationToken"/> for this task</param>
 		public override async Task FlushAsync(CancellationToken token) {
-			if (!IsConnected) {
-				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
-			}
-
-			if (BaseStream == null) {
-				throw new InvalidOperationException("The base stream of the FtpSocketStream object is null.");
-			}
-
 			await BaseStream.FlushAsync(token);
 		}
 

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -142,7 +142,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Used for tracking read/write activity on the socket
 		/// </summary>
-		public DateTime m_lastActivity = DateTime.UtcNow;
+		private DateTime m_lastActivity = DateTime.UtcNow;
 
 		private Socket m_socket = null;
 

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -99,7 +99,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Real transitional connection states
 		/// </summary>
-		public FtpRealConnectionStates RealConnectionState { get; set; } = FtpRealConnectionStates.Unknown;
+		public FtpRealConnectionStates RealConnectionState { get; set; } = FtpRealConnectionStates.Down;
 
 		/// <summary>
 		/// Gets a value indicating if this socket stream is connected

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1603,6 +1603,7 @@ namespace FluentFTP {
 			}
 
 			if (IsDisposed) {
+				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Caught redundant SYNC DISPOSE");
 				return;
 			}
 
@@ -1726,6 +1727,7 @@ namespace FluentFTP {
 			}
 
 			if (IsDisposed) {
+				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Caught redundant ASYNC dispose");
 				return;
 			}
 


### PR DESCRIPTION
### Daemon:
**Use** Task.Factory.StartNew
**Use** CancellationToken
**Improve** code and use intermediate connection state to indicate lost connection

### FtpSocketStream
**Improve** IsConnected - handle sync **and async** close situations, remove extranseous socket.Poll calls, use intermediate connections state to decide return valie
**Improve** Close/Dispose logic further - add detailed logging of Close/Dispose failures for future debugging in possible user logs when issues are reported

### New Enum FtpRealConnectionStates
**Allow connection failure status tracking** with the help of NoopDaemon before IsConnected decides true/false based on socket state only.

