### PR TITLE
Fixed uncatchable Exception after cancellation of read in FTPSocketStream

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -586,12 +586,15 @@ namespace FluentFTP {
 			m_lastActivity = DateTime.UtcNow;
 			using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token)) {
 				cts.CancelAfter(ReadTimeout);
-				cts.Token.Register(async () => await CloseAsync(token));
 				try {
 					var res = await BaseStream.ReadAsync(buffer, offset, count, cts.Token);
 					return res;
 				}
 				catch {
+					if (cts.IsCancellationRequested) {
+						await CloseAsync(token);
+					}
+    
 					// CTS for Cancellation triggered and caused the exception
 					if (token.IsCancellationRequested) {
 						throw new OperationCanceledException("Cancelled read from socket stream");


### PR DESCRIPTION
If you wanted to cancel a read operation, a non-catchable exception always flew here. This could not be handled due to the fact that it was registered on the cancellation token. 
The ReadTimeout still works, as the Read method throws an exception as soon as the cts expires.
In the new setup, the connection is still closed and an exception is now thrown correctly.