### PR TITLE
Remove socket.Poll et. al., improve Daemon, improve FTPSocketStream

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -241,7 +241,6 @@ namespace FluentFTP {
 				if (Status.NoopDaemonTask == null) {
 					Status.NoopDaemonTask = Task.Factory.StartNew(() => { NoopDaemon(Status.NoopDaemonTokenSource.Token); }, Status.NoopDaemonTokenSource.Token);
 				}
-				LastCommandTimestamp = DateTime.UtcNow;
 				Status.NoopDaemonEnable = true;
 				Status.NoopDaemonCmdMode = true;
 				LogWithPrefix(FtpTraceLevel.Verbose, "NoopDaemon enabled");

--- a/FluentFTP/Client/AsyncClient/Disconnect.cs
+++ b/FluentFTP/Client/AsyncClient/Disconnect.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -29,6 +28,9 @@ namespace FluentFTP {
 						m_stream = null;
 					}
 				}
+			}
+			else {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Connection already closed, nothing to do.");
 			}
 		}
 

--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.bak
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.bak
@@ -210,7 +210,7 @@ namespace FluentFTP {
 					disposeOutStream = false;
 				}
 
-				await ((FtpDataStream)downStream).DisposeAsync();
+				await ((FtpDataStream)downStream).CloseAsync();
 
 				if (earlySuccess) {
 					return true;
@@ -248,7 +248,7 @@ namespace FluentFTP {
 				// close stream before throwing error
 				try {
 					if (downStream != null) {
-						await ((FtpDataStream)downStream).DisposeAsync();
+						await ((FtpDataStream)downStream).CloseAsync();
 					}
 				}
 				catch (Exception) {
@@ -295,7 +295,7 @@ namespace FluentFTP {
 				// if resume possible
 				if (ex.IsResumeAllowed()) {
 					// dispose the old bugged out stream
-					await ((FtpDataStream)downStream).DisposeAsync();
+					await ((FtpDataStream)downStream).CloseAsync();
 					LogWithPrefix(FtpTraceLevel.Info, "Attempting download resume from offset " + offset);
 
 					// create and return a new stream starting at the current remotePosition

--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -197,9 +197,6 @@ namespace FluentFTP {
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// disconnect FTP streams before exiting

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -20,7 +20,7 @@ namespace FluentFTP {
 			bool reconnect = false;
 			string reconnectReason = string.Empty;
 
-			m_daemonSemaphore.Wait(token);
+			await m_daemonSemaphore.WaitAsync(token);
 			m_daemonSemaphore.Release();
 
 			// Automatic reconnect because we lost the control channel?

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -20,16 +20,15 @@ namespace FluentFTP {
 			bool reconnect = false;
 			string reconnectReason = string.Empty;
 
-			m_daemonSemaphore.Wait();
+			m_daemonSemaphore.Wait(token);
 			m_daemonSemaphore.Release();
 
 			// Automatic reconnect because we lost the control channel?
-
 			if (!IsConnected ||
 				(Config.NoopTestConnectivity
 				 && command != "QUIT"
 		 		 && IsAuthenticated
-				 && Status.NoopDaemonRunning
+				 && Status.NoopDaemonEnable
 				 && !await IsStillConnected(token: token))) {
 				if (command == "QUIT") {
 					LogWithPrefix(FtpTraceLevel.Info, "Not sending QUIT because the connection has already been closed.");

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.bak
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.bak
@@ -278,7 +278,7 @@ namespace FluentFTP {
 				progress?.Report(new FtpProgress(100.0, upStream.Length, 0, TimeSpan.FromSeconds(0), localPath, remotePath, metaProgress));
 
 				// disconnect FTP stream before exiting
-				await ((FtpDataStream)upStream).DisposeAsync();
+				await ((FtpDataStream)upStream).CloseAsync();
 
 				// listen for a success/failure reply or out of band data (like NOOP responses)
 				// GetReply(true) means: Exhaust any NOOP responses
@@ -312,7 +312,7 @@ namespace FluentFTP {
 				// close stream before throwing error
 				try {
 					if (upStream != null) {
-						await ((FtpDataStream)upStream).DisposeAsync();
+						await ((FtpDataStream)upStream).CloseAsync();
 					}
 				}
 				catch (Exception) {
@@ -343,7 +343,7 @@ namespace FluentFTP {
 				// if resume possible
 				if (ex.IsResumeAllowed()) {
 					// dispose the old bugged out stream
-					await ((FtpDataStream)upStream).DisposeAsync();
+					await ((FtpDataStream)upStream).CloseAsync();
 					LogWithPrefix(FtpTraceLevel.Info, "Attempting upload resume at position " + remotePosition);
 
 					// create and return a new stream starting at the current remotePosition

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -268,13 +268,10 @@ namespace FluentFTP {
 				long tot = upStream.Position;
 				long ems = sw.ElapsedMilliseconds;
 				string bps = ems == 0 ? "?" : (tot / ems * 1000L).FileSizeToString();
-				string successText = "Uploaded " + tot + " bytes " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
+				string successText = "Uploaded " + tot + " bytes, " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// send progress reports

--- a/FluentFTP/Client/AsyncFtpClient.cs
+++ b/FluentFTP/Client/AsyncFtpClient.cs
@@ -89,10 +89,12 @@ namespace FluentFTP {
 			Logger = logger;
 		}
 
+		protected override BaseFtpClient Create() {
+			return new AsyncFtpClient();
+		}
 		#endregion
 
 		#region Destructor
-
 		public override void Dispose() {
 			LogFunction(nameof(Dispose));
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
@@ -104,33 +106,32 @@ namespace FluentFTP {
 
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 		public async ValueTask DisposeAsync() {
-			await DisposeAsyncCore();
-			GC.SuppressFinalize(this);
-		}
 #else
 		public async Task DisposeAsync() {
+#endif
+			if (IsDisposed) {
+				return;
+			}
+
+			LogFunction(nameof(DisposeAsync));
+			LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(async) " + this.ClientType);
+
 			await DisposeAsyncCore();
+
+			await Task.Run(() => {
+				WaitForDaemonTermination();
+			});
+
+			IsDisposed = true;
+
 			GC.SuppressFinalize(this);
 		}
-#endif
 
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 		protected virtual async ValueTask DisposeAsyncCore() {
 #else
 		protected virtual async Task DisposeAsyncCore() {
 #endif
-			if (IsDisposed) {
-				return;
-			}
-
-			// Fix: Hard catch and suppress all exceptions during disposing as there are constant issues with this method
-			try {
-				LogFunction(nameof(DisposeAsync));
-				LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(async) " + this.ClientType);
-			}
-			catch {
-			}
-
 			try {
 				if (IsConnected) {
 					await Disconnect();
@@ -145,26 +146,17 @@ namespace FluentFTP {
 				}
 				catch {
 				}
-
-				m_stream = null;
+				finally {
+					m_stream = null;
+				}
 			}
 
-			try {
-				m_credentials = null;
-				m_textEncoding = null;
-				m_host = null;
-			}
-			catch {
-			}
-
-			IsDisposed = true;
+			m_credentials = null;
+			m_textEncoding = null;
+			m_host = null;
 		}
 
-#endregion
-
-		protected override BaseFtpClient Create() {
-			return new AsyncFtpClient();
-		}
+		#endregion
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 

--- a/FluentFTP/Client/AsyncFtpClient.cs
+++ b/FluentFTP/Client/AsyncFtpClient.cs
@@ -132,23 +132,11 @@ namespace FluentFTP {
 #else
 		protected virtual async Task DisposeAsyncCore() {
 #endif
-			try {
-				if (IsConnected) {
-					await Disconnect();
-				}
-			}
-			catch {
-			}
+			await Disconnect();
 
 			if (m_stream != null) {
-				try {
-					await m_stream.CloseAsync();
-				}
-				catch {
-				}
-				finally {
-					m_stream = null;
-				}
+				await m_stream.CloseAsync();
+				m_stream = null;
 			}
 
 			m_credentials = null;

--- a/FluentFTP/Client/BaseClient/CloseDataStream.cs
+++ b/FluentFTP/Client/BaseClient/CloseDataStream.cs
@@ -21,10 +21,6 @@ namespace FluentFTP.Client.BaseClient {
 				throw new ArgumentException("The data stream parameter was null");
 			}
 
-			// A socket poll in here would be trouble, so disable by setting to zero.
-			int saveSocketPollInterval = stream.SocketPollInterval;
-			stream.SocketPollInterval = 0;
-
 			try {
 				if (IsConnected) {
 					// Because the data connection was closed, if the command that required the data
@@ -45,8 +41,6 @@ namespace FluentFTP.Client.BaseClient {
 				}
 			}
 
-			stream.SocketPollInterval = saveSocketPollInterval;
-
 			return reply;
 		}
 
@@ -62,10 +56,6 @@ namespace FluentFTP.Client.BaseClient {
 			if (stream == null) {
 				throw new ArgumentException("The data stream parameter was null");
 			}
-
-			// A socket poll in here would be trouble, so disable by setting to zero.
-			int saveSocketPollInterval = stream.SocketPollInterval;
-			stream.SocketPollInterval = 0;
 
 			try {
 				if (IsConnected) {
@@ -86,8 +76,6 @@ namespace FluentFTP.Client.BaseClient {
 					await ((IInternalFtpClient)this).DisposeInternal(token);
 				}
 			}
-
-			stream.SocketPollInterval = saveSocketPollInterval;
 
 			return reply;
 		}

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
 
@@ -26,7 +27,7 @@ namespace FluentFTP.Client.BaseClient {
 				(Config.NoopTestConnectivity
 				 && command != "QUIT"
 				 && IsAuthenticated
-				 && Status.NoopDaemonRunning
+				 && Status.NoopDaemonEnable
 				 && !((IInternalFtpClient)this).IsStillConnectedInternal())) {
 				if (command == "QUIT") {
 					LogWithPrefix(FtpTraceLevel.Info, "Not sending QUIT because the connection has already been closed.");

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -106,8 +106,6 @@ namespace FluentFTP.Client.BaseClient {
 			try {
 
 				if (exhaustNoop) {
-					Status.NoopDaemonEnable = false;
-
 					// tickle the server
 					m_stream.WriteLine(Encoding, "NOOP");
 				}
@@ -115,7 +113,7 @@ namespace FluentFTP.Client.BaseClient {
 				sw.Start();
 
 				do {
-					if (!IsConnected) {
+					if (useSema && !IsConnected) {
 						throw new InvalidOperationException("No connection to the server exists.");
 					}
 
@@ -215,7 +213,6 @@ namespace FluentFTP.Client.BaseClient {
 					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
 
-				Status.NoopDaemonEnable = true;
 
 			}
 			finally {
@@ -328,8 +325,6 @@ namespace FluentFTP.Client.BaseClient {
 			try {
 
 				if (exhaustNoop) {
-					Status.NoopDaemonEnable = false;
-
 					// tickle the server
 					m_stream.WriteLine(Encoding, "NOOP");
 				}
@@ -337,7 +332,7 @@ namespace FluentFTP.Client.BaseClient {
 				sw.Start();
 
 				do {
-					if (!IsConnected) {
+					if (useSema && !IsConnected) {
 						throw new InvalidOperationException("No connection to the server exists.");
 					}
 
@@ -436,8 +431,6 @@ namespace FluentFTP.Client.BaseClient {
 				if (exhaustNoop) {
 					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
-
-				Status.NoopDaemonEnable = true;
 
 			}
 			finally {

--- a/FluentFTP/Client/BaseClient/NoopDaemon.cs
+++ b/FluentFTP/Client/BaseClient/NoopDaemon.cs
@@ -10,7 +10,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// </summary>
 		protected void NoopDaemon(CancellationToken ct) {
 
-			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon(" + this.ClientType + ") is initialized, NoopInterval = " + Config.NoopInterval);
+			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon(" + this.ClientType + ") is initialized, NoopInterval = " + Config.NoopInterval + "ms");
 
 			Random rnd = new Random();
 

--- a/FluentFTP/Client/BaseClient/NoopDaemon.cs
+++ b/FluentFTP/Client/BaseClient/NoopDaemon.cs
@@ -8,117 +8,115 @@ namespace FluentFTP.Client.BaseClient {
 		/// <summary>
 		/// NoopDaemon for NOOP handling
 		/// </summary>
-		protected void NoopDaemon() {
+		protected void NoopDaemon(CancellationToken ct) {
 
-			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon is initialized");
+			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon(" + this.ClientType + ") is initialized, NoopInterval = " + Config.NoopInterval);
 
 			Random rnd = new Random();
 
-			Status.NoopDaemonRunning = true;
-			Status.NoopDaemonCmdMode = true;
 			Status.NoopDaemonEnable = true;
 			Status.NoopDaemonAnyNoops = 0;
+			Status.NoopDaemonCmdMode = true;
 
 			bool gotEx = false;
 
 			do { // while(true)
 
-				if (!IsConnected) {
+				if (ct.IsCancellationRequested) {
 					break;
 				}
 
-				if (Status.NoopDaemonEnable &&
-					Config.NoopInterval > 0 &&
-					DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval) {
+				if (m_stream.RealConnectionState == FtpRealConnectionStates.Up &&
+					Status.NoopDaemonEnable) {
 
-					// choose one of the normal or the safe commands
-					string rndCmd = Status.NoopDaemonCmdMode ?
-						Config.NoopInactiveCommands[rnd.Next(Config.NoopInactiveCommands.Count)] :
-						Config.NoopActiveCommands[rnd.Next(Config.NoopActiveCommands.Count)];
+					m_daemonSemaphore.Wait(ct);
 
-					// only log this if we have an active data connection
-					if (Status.NoopDaemonCmdMode) {
-						Log(FtpTraceLevel.Verbose, "Command:  " + rndCmd + " (<-NoopDaemon)");
-					}
-					else {
-						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (<-NoopDaemon)");
-					}
+					if (Config.NoopInterval > 0 &&
+						DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval) {
 
-					try {
-						m_daemonSemaphore.Wait();
-
-						LastCommandTimestamp = DateTime.UtcNow;
-
-						// send the random NOOP command
 						try {
-							m_stream.WriteLine(m_textEncoding, rndCmd);
+							// choose one of the normal or the safe commands
+							string rndCmd = Status.NoopDaemonCmdMode ?
+								Config.NoopInactiveCommands[rnd.Next(Config.NoopInactiveCommands.Count)] :
+								Config.NoopActiveCommands[rnd.Next(Config.NoopActiveCommands.Count)];
+
+							// only log this if we have an active data connection
+							if (Status.NoopDaemonCmdMode) {
+								Log(FtpTraceLevel.Verbose, "Command:  " + rndCmd + " (<-NoopDaemon)");
+							}
+							else {
+								((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (<-NoopDaemon)");
+							}
+
+							LastCommandTimestamp = DateTime.UtcNow;
+
+							// send the random NOOP command
+							try {
+								m_stream.WriteLine(m_textEncoding, rndCmd);
+							}
+							catch (Exception ex) {
+								((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#1): " + ex.Message + " (NoopDaemon)");
+								gotEx = true;
+							}
+
+							if (!gotEx) {
+								// tell the outside world, NOOPs have actually been sent.
+								Status.NoopDaemonAnyNoops += 1;
+
+								// pick the command reply if this is just an idle control connection
+								if (Status.NoopDaemonCmdMode) {
+									bool success = false;
+
+									m_stream.RealConnectionState = FtpRealConnectionStates.Unknown;
+
+									try {
+										success = ((IInternalFtpClient)this).GetReplyInternal(rndCmd + " (<-NoopDaemon)", false, 10000, false).Success;
+									}
+									catch (Exception ex) {
+										((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#2): " + ex.Message + " (NoopDaemon)");
+										gotEx = true;
+									}
+									finally {
+										LastCommandTimestamp = DateTime.UtcNow;
+										m_stream.RealConnectionState = FtpRealConnectionStates.Up;
+									}
+
+									// in case one of these commands was successfully issued, make sure we store that
+									if (success) {
+										if (rndCmd.StartsWith("TYPE I")) {
+											Status.CurrentDataType = FtpDataType.Binary;
+										}
+
+										if (rndCmd.StartsWith("TYPE A")) {
+											Status.CurrentDataType = FtpDataType.ASCII;
+										}
+									}
+								}
+							}
 						}
 						catch (Exception ex) {
-							((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#1): " + ex.Message + " (NoopDaemon)");
+							((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#3): " + ex.Message + " (NoopDaemon)");
 							gotEx = true;
 						}
-
-						if (!gotEx) {
-							// tell the outside world, NOOPs have actually been sent.
-							Status.NoopDaemonAnyNoops += 1;
-
-							// pick the command reply if this is just an idle control connection
-							if (Status.NoopDaemonCmdMode) {
-								bool success = false;
-								try {
-									success = ((IInternalFtpClient)this).GetReplyInternal(rndCmd + " (<-NoopDaemon)", false, 10000, false).Success;
-								}
-								catch (Exception ex) {
-									((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#2): " + ex.Message + " (NoopDaemon)");
-									gotEx = true;
-								}
-								finally {
-									LastCommandTimestamp = DateTime.UtcNow;
-								}
-
-								// in case one of these commands was successfully issued, make sure we store that
-								if (success) {
-									if (rndCmd.StartsWith("TYPE I")) {
-										Status.CurrentDataType = FtpDataType.Binary;
-									}
-
-									if (rndCmd.StartsWith("TYPE A")) {
-										Status.CurrentDataType = FtpDataType.ASCII;
-									}
-								}
-							}
-						}
 					}
-					catch (Exception ex) {
-						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#3): " + ex.Message + " (NoopDaemon)");
-						gotEx = true;
+
+
+					if (gotEx) {
+						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Indicating connection lost (NoopDaemon)");
+						Status.NoopDaemonEnable = false;
+						m_stream.RealConnectionState = FtpRealConnectionStates.PendingDown;
+						gotEx = false;
 					}
-					finally {
-						if (gotEx) {
-							if (m_stream != null) {
-								m_stream.Close();
-								m_stream = null;
-							}
-						}
-						m_daemonSemaphore.Release();
-					}
+
+					m_daemonSemaphore.Release();
+
 				}
 
-				if (gotEx) {
-					break;
-				}
-
-				Thread.Sleep(100);
+				Thread.Sleep(250);
 
 			} while (true);
 
-			string reason = string.Empty;
-			if (gotEx) {
-				reason = " due to detected connection problem";
-			}
-
-			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon terminated" + reason);
-			Status.NoopDaemonRunning = false;
+			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon terminated");
 		}
 	}
 }

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -100,11 +100,6 @@ namespace FluentFTP.Client.BaseClient {
 
 		protected FtpListParser CurrentListParser;
 
-		/// <summary>
-		/// A thread for background tasks
-		/// </summary>
-		protected Task m_task;
-
 		// Holds the cached resolved address
 		protected string m_Address;
 
@@ -139,6 +134,7 @@ namespace FluentFTP.Client.BaseClient {
 		FtpSocketStream IInternalFtpClient.GetBaseStream() {
 			return m_stream;
 		}
+
 		void IInternalFtpClient.SetListingParser(FtpParser parser) {
 			CurrentListParser.CurrentParser = parser;
 			CurrentListParser.ParserConfirmed = false;

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -93,7 +93,7 @@ namespace FluentFTP.Client.BaseClient {
 				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for Daemon termination(" + this.ClientType + ")");
 				Status.NoopDaemonTokenSource.Cancel();
 				DateTime startTime = DateTime.UtcNow;
-				while (Config.Noop && Status.NoopDaemonTask != null && Status.NoopDaemonTask.Status == TaskStatus.Running &&
+				while (Status.NoopDaemonTask != null && Status.NoopDaemonTask.Status == TaskStatus.Running &&
 					DateTime.UtcNow.Subtract(startTime).TotalMilliseconds < 20000) {
 					Thread.Sleep(250);
 				}
@@ -113,23 +113,11 @@ namespace FluentFTP.Client.BaseClient {
 			LogFunction(nameof(Dispose));
 			LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(sync) " + this.ClientType);
 
-			try {
-				if (IsConnected) {
-					((IInternalFtpClient)this).DisconnectInternal();
-				}
-			}
-			catch {
-			}
+			((IInternalFtpClient)this).DisconnectInternal();
 
 			if (m_stream != null) {
-				try {
-					m_stream.Dispose();
-				}
-				catch {
-				}
-				finally {
-					m_stream = null;
-				}
+				m_stream.Dispose();
+				m_stream = null;
 			}
 
 			m_credentials = null;

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -131,13 +131,6 @@ namespace FluentFTP.Client.BaseClient {
 			GC.SuppressFinalize(this);
 		}
 
-		/// <summary>
-		/// Finalizer
-		/// </summary>
-		~BaseFtpClient() {
-			Dispose();
-		}
-
 		#endregion
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -326,7 +326,6 @@ namespace FluentFTP.Client.Modules {
 			if (knownProfile != null) {
 				client.Config.ConnectTimeout = knownProfile.Timeout;
 				client.Config.RetryAttempts = knownProfile.RetryAttempts;
-				client.Config.SocketPollInterval = knownProfile.SocketPollInterval;
 			}
 		}
 
@@ -456,9 +455,6 @@ namespace FluentFTP.Client.Modules {
 				client.Config.ReadTimeout = profile.Timeout;
 				client.Config.DataConnectionConnectTimeout = profile.Timeout;
 				client.Config.DataConnectionReadTimeout = profile.Timeout;
-			}
-			if (client.Config.SocketPollInterval != 0) {
-				client.Config.SocketPollInterval = profile.SocketPollInterval;
 			}
 			if (client.Config.RetryAttempts != 0) {
 				client.Config.RetryAttempts = profile.RetryAttempts;

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -85,7 +85,6 @@ namespace FluentFTP {
 
 			m_hashAlgorithms = FtpHashAlgorithm.NONE;
 			m_stream.ConnectTimeout = Config.ConnectTimeout;
-			m_stream.SocketPollInterval = Config.SocketPollInterval;
 			Connect(m_stream);
 
 			m_stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);
@@ -236,8 +235,12 @@ namespace FluentFTP {
 
 			Status.InCriticalSequence = false;
 
-			if (Config.Noop && !Status.NoopDaemonRunning) {
-				m_task = Task.Run(() => { NoopDaemon(); });
+			if (Config.Noop) {
+				if (Status.NoopDaemonTask == null) {
+					Status.NoopDaemonTask = Task.Factory.StartNew(() => { NoopDaemon(Status.NoopDaemonTokenSource.Token); }, Status.NoopDaemonTokenSource.Token);
+				}
+				Status.NoopDaemonEnable = true;
+				Status.NoopDaemonCmdMode = true;
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/Disconnect.cs
+++ b/FluentFTP/Client/SyncClient/Disconnect.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace FluentFTP {
 	public partial class FtpClient {
@@ -29,6 +26,9 @@ namespace FluentFTP {
 						m_stream = null;
 					}
 				}
+			}
+			else {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Connection already closed, nothing to do.");
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -194,9 +194,6 @@ namespace FluentFTP {
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// disconnect FTP streams before exiting

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -259,13 +259,10 @@ namespace FluentFTP {
 				long tot = upStream.Position;
 				long ems = sw.ElapsedMilliseconds;
 				string bps = ems == 0 ? "?" : (tot / ems * 1000L).FileSizeToString();
-				string successText = "Uploaded " + tot + " bytes " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
+				string successText = "Uploaded " + tot + " bytes, " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// send progress reports

--- a/FluentFTP/Enums/FtpRealConnectionsStates.cs
+++ b/FluentFTP/Enums/FtpRealConnectionsStates.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace FluentFTP {
+	/// <summary>
+	/// Real transitional connection states
+	/// </summary>
+	public enum FtpRealConnectionStates {
+		/// <summary>
+		/// Deamon will determine the state in a short while
+		/// </summary>
+		Unknown,
+
+		/// <summary>
+		/// Not a good state and it will be brought down, closed and disposed soon
+		/// </summary>
+		PendingDown,
+
+		/// <summary>
+		/// Closed, disposed
+		/// </summary>
+		Down,
+
+		/// <summary>
+		/// Connected, at least the last time the NOOP daemon checked the connection
+		/// </summary>
+		Up,
+
+	};
+
+}

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace FluentFTP {
 
@@ -132,20 +134,24 @@ namespace FluentFTP {
 		public ushort zOSListingLRECL { get; set; }
 
 		/// <summary>
-		/// Background task status
+		/// NOOP Daemon Task
 		/// </summary>
-		public bool NoopDaemonRunning { get; set; }
+		public Task NoopDaemonTask { get; set; }
 		/// <summary>
-		/// Background task should GetReply
+		/// NOOP Daemon TokenSource
 		/// </summary>
-		public bool NoopDaemonCmdMode { get; set; }
+		public CancellationTokenSource NoopDaemonTokenSource { get; set; } = new CancellationTokenSource();
 		/// <summary>
-		/// Background task enabled
+		/// NOOP Daemon enabled
 		/// </summary>
 		public bool NoopDaemonEnable { get; set; }
 		/// <summary>
-		/// Background task sent noops
+		/// NOOP Daemon sent noops
 		/// </summary>
 		public int NoopDaemonAnyNoops { get; set; }
+		/// <summary>
+		/// NOOP Daemon should GetReply
+		/// </summary>
+		public bool NoopDaemonCmdMode { get; set; }
 	}
 }

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -144,14 +144,14 @@ namespace FluentFTP {
 		/// <summary>
 		/// NOOP Daemon enabled
 		/// </summary>
-		public bool NoopDaemonEnable { get; set; }
+		public bool NoopDaemonEnable { get; set; } = false;
 		/// <summary>
 		/// NOOP Daemon sent noops
 		/// </summary>
-		public int NoopDaemonAnyNoops { get; set; }
+		public int NoopDaemonAnyNoops { get; set; } = 0;
 		/// <summary>
 		/// NOOP Daemon should GetReply
 		/// </summary>
-		public bool NoopDaemonCmdMode { get; set; }
+		public bool NoopDaemonCmdMode { get; set; } = true;
 	}
 }

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -54,7 +54,7 @@ namespace FluentFTP {
 		public bool LogPassword { get; set; } = false;
 
 		/// <summary>
-		/// Should the command duration be shown after each log command?
+		/// Should the command duration be shown after each logged command?
 		/// </summary>
 		public bool LogDurations { get; set; } = true;
 
@@ -69,6 +69,17 @@ namespace FluentFTP {
 		/// </summary>
 		public FtpIpVersion InternetProtocolVersions { get; set; } = FtpIpVersion.ANY;
 
+		/// <summary>
+		/// Gets or sets a value indicating whether a test should be performed to
+		/// see if there is stale (unrequested data) sitting on the socket. In some
+		/// cases the control connection may time out but before the server closes
+		/// the connection it might send a 4xx response that was unexpected and
+		/// can cause synchronization errors with transactions. To avoid this
+		/// problem the <see cref="o:Execute"/> method checks to see if there is any data
+		/// available on the socket before executing a command.
+		/// </summary>
+		public bool StaleDataCheck { get; set; } = true;
+
 		protected int _socketPollInterval = 15000;
 
 		/// <summary>
@@ -80,47 +91,39 @@ namespace FluentFTP {
 		/// have a negative impact on performance. Setting this
 		/// interval to 0 disables Polling all together.
 		/// The default value is 15 seconds.
+		/// This has been removed and you are encouraged to use
+		/// <see cref="Noop"/> instead, if you are interested in
+		/// avoiding inactivity timeouts or in more aggressive ways
+		/// to detect connection failures.
 		/// </summary>
+		[Obsolete]
 		public int SocketPollInterval {
 			get => _socketPollInterval;
-			set {
-				_socketPollInterval = value;
-				
-				// set this value on the FtpClient's base stream
-				if (_client != null) {
-					var stream = ((IInternalFtpClient)_client).GetBaseStream();
-					if (stream != null) {
-						stream.SocketPollInterval = value;
-					}
-				}
-			}
+			set => _socketPollInterval = value;
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating whether a test should be performed to
-		/// see if there is stale (unrequested data) sitting on the socket. In some
-		/// cases the control connection may time out but before the server closes
-		/// the connection it might send a 4xx response that was unexpected and
-		/// can cause synchronization errors with transactions. To avoid this
-		/// problem the <see cref="o:Execute"/> method checks to see if there is any data
-		/// available on the socket before executing a command.
-		/// </summary>
-		public bool StaleDataCheck { get; set; } = true;
-		
-		/// <summary>
-		/// Install the NOOP NoopDaemon whenever an FTP connection is established, which ensures that NOOPs are sent at regular intervals.
-		/// This is the master switch for all NOOP functionality.
+		/// Install the NOOP Daemon whenever an FTP connection is established,
+		/// which enables the capability to send NOOP commands at regular intervals when
+		/// the control connections is inactive longer than a set time.
+		/// This is the master switch for all NOOP related functionality.
 		/// </summary>
 		public bool Noop { get; set; } = false;
 
 		/// <summary>
-		/// Gets or sets the length of time in milliseconds after last command
-		/// (NOOP or other) that a NOOP command is sent./>.
-		/// This is called during downloading/uploading and idle times. Setting this
-		/// interval to 0 stops NOOPs from being issued.
-		/// The default value is 3 minutes, which catches the typical 5 minute timeout by FTP servers.
+		/// Gets or sets the length of time in milliseconds of inactivity on the control
+		/// connection that must expire before a NOOP command is sent, both during downloading/uploading
+		/// and during idle times. Setting this interval to 0 stops NOOPs from being issued.
+		/// The default value is 4:30 minutes, which defeats the typical 5 minute timeout of popular FTP
+		/// servers.
+		/// If you are interested in very aggressive detection of connection failures, you may set
+		/// this value to as low as 1000ms.
+		/// Note that many servers nowadays implement a "No-files-transferred" timeout, in order to thwart
+		/// a users attempts to keep the control connection alive. In such a case your code would need to
+		/// schedule a small dummy file transfer from time to time to avoid such a timeout from triggering.
+		/// Regular NOOP commands will not help when your FTP server uses such a strategy.
 		/// </summary>
-		public int NoopInterval { get; set; } = 180000;
+		public int NoopInterval { get; set; } = 270000;
 
 		private List<string> _noopInactiveCmds = new List<string> { "NOOP", "PWD", "TYPE I", "TYPE A" };
 
@@ -145,7 +148,7 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
-		/// Issue a NOOP command tp precede any command issued on the control connection
+		/// Issue a NOOP command to precede any command issued on the control connection
 		/// to test connectivity in a reliable fashion. Note: This can incur some control
 		/// connection overhead and does not alleviate inactivity timeouts, it just helps
 		/// to identify connectivity issues early on.
@@ -613,7 +616,6 @@ namespace FluentFTP {
 			write.LogUserName = read.LogUserName;
 			write.LogPassword = read.LogPassword;
 			write.InternetProtocolVersions = read.InternetProtocolVersions;
-			write.SocketPollInterval = read.SocketPollInterval;
 			write.StaleDataCheck = read.StaleDataCheck;
 			write.Noop = read.Noop;
 			write.NoopInterval = read.NoopInterval;

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -80,28 +80,6 @@ namespace FluentFTP {
 		/// </summary>
 		public bool StaleDataCheck { get; set; } = true;
 
-		protected int _socketPollInterval = 15000;
-
-		/// <summary>
-		/// Gets or sets the length of time in milliseconds
-		/// that must pass since the last socket activity
-		/// before calling <see cref="System.Net.Sockets.Socket.Poll"/> 
-		/// on the socket to test for connectivity. 
-		/// Setting this interval too low will
-		/// have a negative impact on performance. Setting this
-		/// interval to 0 disables Polling all together.
-		/// The default value is 15 seconds.
-		/// This has been removed and you are encouraged to use
-		/// <see cref="Noop"/> instead, if you are interested in
-		/// avoiding inactivity timeouts or in more aggressive ways
-		/// to detect connection failures.
-		/// </summary>
-		[Obsolete]
-		public int SocketPollInterval {
-			get => _socketPollInterval;
-			set => _socketPollInterval = value;
-		}
-
 		/// <summary>
 		/// Install the NOOP Daemon whenever an FTP connection is established,
 		/// which enables the capability to send NOOP commands at regular intervals when
@@ -109,6 +87,8 @@ namespace FluentFTP {
 		/// This is the master switch for all NOOP related functionality.
 		/// </summary>
 		public bool Noop { get; set; } = false;
+
+		private int _noopInterval = 270000;
 
 		/// <summary>
 		/// Gets or sets the length of time in milliseconds of inactivity on the control
@@ -123,7 +103,10 @@ namespace FluentFTP {
 		/// schedule a small dummy file transfer from time to time to avoid such a timeout from triggering.
 		/// Regular NOOP commands will not help when your FTP server uses such a strategy.
 		/// </summary>
-		public int NoopInterval { get; set; } = 270000;
+		public int NoopInterval {
+			get => _noopInterval;
+			set => _noopInterval = Math.Max(1000, value);
+		}
 
 		private List<string> _noopInactiveCmds = new List<string> { "NOOP", "PWD", "TYPE I", "TYPE A" };
 

--- a/FluentFTP/Streams/FtpDataStream.bak
+++ b/FluentFTP/Streams/FtpDataStream.bak
@@ -232,10 +232,10 @@ namespace FluentFTP {
 		~FtpDataStream() {
 			try {
 				if (Client is AsyncFtpClient) {
-					DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+					CloseAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 				}
 				else {
-					Dispose();
+					Close();
 				}
 			}
 			catch (Exception ex) {

--- a/FluentFTP/Streams/FtpDataStream.cs
+++ b/FluentFTP/Streams/FtpDataStream.cs
@@ -230,7 +230,6 @@ namespace FluentFTP {
 		/// Finalizer
 		/// </summary>
 		~FtpDataStream() {
-			// Fix: Hard catch and suppress all exceptions during disposing as there are constant issues with this method
 			try {
 				if (Client is AsyncFtpClient) {
 					CloseAsync().ConfigureAwait(false).GetAwaiter().GetResult();

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -134,7 +134,6 @@ namespace FluentFTP {
 					}
 				}
 
-				// DEBUG ((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "IsCOnnected returns: " + (RealConnectionState == FtpRealConnectionStates.Up).ToString() + " " + RealConnectionState.ToString());
 				return RealConnectionState == FtpRealConnectionStates.Up;
 			}
 		}
@@ -1731,8 +1730,6 @@ namespace FluentFTP {
 			if (Client != null) {
 				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing(async) " + Client.ClientType + ".FtpSocketStream(" + connText + ")" + reduText);
 			}
-
-			// DEBUG ((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, new System.Diagnostics.StackTrace().ToString());
 
 			// TODO: To support the CCC (Deactivate Encryption) command, some more additional logic
 			// is required and note that CustomStream GnuTLS currently does not support this at all.

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -557,13 +557,16 @@ namespace FluentFTP {
 
 			m_lastActivity = DateTime.UtcNow;
 			using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token)) {
-				cts.CancelAfter(ReadTimeout);
 				cts.Token.Register(async () => await CloseAsync(token));
 				try {
 					var res = await BaseStream.ReadAsync(buffer, cts.Token);
 					return res;
 				}
 				catch {
+					if (cts.IsCancellationRequested) {
+						await CloseAsync(token);
+					}
+
 					// CTS for Cancellation triggered and caused the exception
 					if (token.IsCancellationRequested) {
 						throw new OperationCanceledException("Cancelled read from socket stream");

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -112,17 +112,6 @@ namespace FluentFTP {
 					}
 				}
 
-				if (RealConnectionState == FtpRealConnectionStates.PendingDown) {
-					if (Client is AsyncFtpClient) {
-						CloseAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-					}
-					else {
-						Close();
-					}
-					RealConnectionState = FtpRealConnectionStates.Down;
-					return false;
-				}
-
 				if (RealConnectionState == FtpRealConnectionStates.Unknown) {
 					Thread.Sleep(500);
 					if (RealConnectionState == FtpRealConnectionStates.Unknown) {
@@ -133,6 +122,17 @@ namespace FluentFTP {
 							Thread.Sleep(1000);
 						}
 					}
+				}
+
+				if (RealConnectionState == FtpRealConnectionStates.PendingDown) {
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Connection state pending down. Closing");
+					if (Client is AsyncFtpClient) {
+						CloseAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+					}
+					else {
+						Close();
+					}
+					RealConnectionState = FtpRealConnectionStates.Down;
 				}
 
 				return RealConnectionState == FtpRealConnectionStates.Up;

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -558,15 +558,12 @@ namespace FluentFTP {
 			m_lastActivity = DateTime.UtcNow;
 			using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token)) {
 				cts.CancelAfter(ReadTimeout);
+				cts.Token.Register(async () => await CloseAsync(token));
 				try {
 					var res = await BaseStream.ReadAsync(buffer, cts.Token);
 					return res;
 				}
 				catch {
-					if (cts.IsCancellationRequested) {
-						await CloseAsync(token);
-					}
-
 					// CTS for Cancellation triggered and caused the exception
 					if (token.IsCancellationRequested) {
 						throw new OperationCanceledException("Cancelled read from socket stream");

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1596,7 +1596,10 @@ namespace FluentFTP {
 		/// </summary>
 		protected new void Dispose() {
 			if (IsControlConnection) {
-				Client.Status.NoopDaemonEnable = false;
+				if (Client.Status.NoopDaemonEnable) {
+					Client.Status.NoopDaemonEnable = false;
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon disabled");
+				}
 			}
 			else {
 				Client.Status.NoopDaemonCmdMode = true;
@@ -1718,8 +1721,10 @@ namespace FluentFTP {
 		protected async Task DisposeAsyncCore() {
 #endif
 			if (IsControlConnection) {
-				Client.Status.NoopDaemonEnable = false;
-				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon disabled");
+				if (Client.Status.NoopDaemonEnable) {
+					Client.Status.NoopDaemonEnable = false;
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon disabled");
+				}
 			}
 			else {
 				Client.Status.NoopDaemonCmdMode = true;


### PR DESCRIPTION
### Do not merge - still in testing

### Daemon:
**Use** Task.Factory.StartNew
**Use** CancellationToken
**Improve** code and use intermediate connection state to indicate lost connection

### FtpSocketStream
**Improve** IsConnected - handle sync **and async** close situations, remove extranseous socket.Poll calls, use intermediate connections state to decide return valie
**Improve** Close/Dispose logic further - add detailed logging of Close/Dispose failures for future debugging in possible user logs when issues are reported

### New Enum FtpRealConnectionStates
**Allow connection failure status tracking** with the help of NoopDaemon before IsConnected decides true/false based on socket state only.

