### PR TITLE
Remove unused code

### DIFF
--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -324,14 +324,14 @@ namespace FluentFTP.Client.BaseClient {
 			protected set => m_hashAlgorithms = value;
 		}
 
-		/// <summary>
-		/// The negotiated SSL/TLS protocol version.
-		/// Will return a valid value after connection is complete.
-		/// Before connection it will return `SslProtocols.None`.
-		/// </summary>
-		public SslProtocols SslProtocolActive {
-			get { return m_stream != null ? m_stream.SslProtocolActive : SslProtocols.None; }
-		}
+		///// <summary>
+		///// The negotiated SSL/TLS protocol version.
+		///// Will return a valid value after connection is complete.
+		///// Before connection it will return `SslProtocols.None`.
+		///// </summary>
+		//public SslProtocols SslProtocolActive {
+		//	get { return m_stream != null ? m_stream.SslProtocolActive : SslProtocols.None; }
+		//}
 
 		/// <summary>
 		/// Checks if FTPS/SSL encryption is currently active.

--- a/FluentFTP/Client/Interfaces/IBaseFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IBaseFtpClient.cs
@@ -45,7 +45,7 @@ namespace FluentFTP {
 		FtpClientState Status { get; }
 		FtpIpVersion? InternetProtocol { get; }
 		bool IsAuthenticated { get; }
-		SslProtocols SslProtocolActive { get; }
+		//SslProtocols SslProtocolActive { get; }
 		bool IsEncrypted { get; }
 		bool ValidateCertificateHandlerExists { get; }
 		bool RecursiveList { get; }

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -206,19 +206,20 @@ namespace FluentFTP {
 		/// </summary>
 		public int SslSessionLength = 0;
 
-		/// <summary>
-		/// The negotiated SSL/TLS protocol version. Will have a valid value after connection is complete.
-		/// </summary>
-		public SslProtocols SslProtocolActive {
-			get {
-				if (Client.Config.CustomStream != null) {
-					return IsEncrypted ? m_customStream.GetSslProtocol() : SslProtocols.None;
-				}
-				else {
-					return IsEncrypted ? m_sslStream.SslProtocol : SslProtocols.None;
-				}
-			}
-		}
+		///// <summary>
+		///// The negotiated SSL/TLS protocol version. Will have a valid value after connection is complete.
+		///// </summary>
+		//public SslProtocols SslProtocolActive {
+		//	get {
+		//		if (Client.Config.CustomStream != null) {
+		//			return IsEncrypted ? m_customStream.GetSslProtocol() : SslProtocols.None;
+		//		}
+		//		else {
+		//			return IsEncrypted ? m_sslStream.SslProtocol : SslProtocols.None;
+		//		}
+		//	}
+		//}
+
 		/// <summary>
 		/// Gets a value indicating if this stream can be read
 		/// </summary>


### PR DESCRIPTION
This was well meant, but it conflicts with .NET definitions. See also #1623. And: It is not even used.
