### PR TITLE
Remove socketPoll, improve Daemon, fix/maintain code

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -86,7 +86,6 @@ namespace FluentFTP {
 
 			m_hashAlgorithms = FtpHashAlgorithm.NONE;
 			m_stream.ConnectTimeout = Config.ConnectTimeout;
-			m_stream.SocketPollInterval = Config.SocketPollInterval;
 			await ConnectAsync(m_stream, token);
 
 			m_stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);
@@ -236,11 +235,15 @@ namespace FluentFTP {
 
 			// FIX #922: disable checking for stale data during connection
 			Status.AllowCheckStaleData = true;
+						Status.InCriticalSequence = false;
 
-			Status.InCriticalSequence = false;
-
-			if (Config.Noop && !Status.NoopDaemonRunning) { 
-				m_task = Task.Run(() => { NoopDaemon(); });
+			if (Config.Noop) {
+				if (Status.NoopDaemonTask == null) {
+					Status.NoopDaemonTask = Task.Factory.StartNew(() => { NoopDaemon(Status.NoopDaemonTokenSource.Token); }, Status.NoopDaemonTokenSource.Token);
+				}
+				Status.NoopDaemonEnable = true;
+				Status.NoopDaemonCmdMode = true;
+				LogWithPrefix(FtpTraceLevel.Verbose, "NoopDaemon enabled");
 			}
 		}
 

--- a/FluentFTP/Client/AsyncClient/Disconnect.cs
+++ b/FluentFTP/Client/AsyncClient/Disconnect.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,9 +25,11 @@ namespace FluentFTP {
 					// from the remote side, thus causing an exception here, so check for null
 					if (m_stream != null) {
 						await m_stream.CloseAsync(token);
-						m_stream = null;
 					}
 				}
+			}
+			else {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Connection already closed, nothing to do.");
 			}
 		}
 

--- a/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadFileInternal.cs
@@ -197,9 +197,6 @@ namespace FluentFTP {
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// disconnect FTP streams before exiting

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -20,16 +20,15 @@ namespace FluentFTP {
 			bool reconnect = false;
 			string reconnectReason = string.Empty;
 
-			m_daemonSemaphore.Wait();
+			await m_daemonSemaphore.WaitAsync(token);
 			m_daemonSemaphore.Release();
 
 			// Automatic reconnect because we lost the control channel?
-
 			if (!IsConnected ||
 				(Config.NoopTestConnectivity
 				 && command != "QUIT"
 		 		 && IsAuthenticated
-				 && Status.NoopDaemonRunning
+				 && Status.NoopDaemonEnable
 				 && !await IsStillConnected(token: token))) {
 				if (command == "QUIT") {
 					LogWithPrefix(FtpTraceLevel.Info, "Not sending QUIT because the connection has already been closed.");
@@ -75,7 +74,6 @@ namespace FluentFTP {
 					}
 
 					await m_stream.CloseAsync(token);
-					m_stream = null;
 				}
 
 				if (command == "QUIT") {

--- a/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/AsyncClient/UploadFileInternal.cs
@@ -268,13 +268,10 @@ namespace FluentFTP {
 				long tot = upStream.Position;
 				long ems = sw.ElapsedMilliseconds;
 				string bps = ems == 0 ? "?" : (tot / ems * 1000L).FileSizeToString();
-				string successText = "Uploaded " + tot + " bytes " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
+				string successText = "Uploaded " + tot + " bytes, " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// send progress reports

--- a/FluentFTP/Client/AsyncFtpClient.cs
+++ b/FluentFTP/Client/AsyncFtpClient.cs
@@ -89,10 +89,12 @@ namespace FluentFTP {
 			Logger = logger;
 		}
 
+		protected override BaseFtpClient Create() {
+			return new AsyncFtpClient();
+		}
 		#endregion
 
 		#region Destructor
-
 		public override void Dispose() {
 			LogFunction(nameof(Dispose));
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
@@ -104,67 +106,45 @@ namespace FluentFTP {
 
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 		public async ValueTask DisposeAsync() {
-			await DisposeAsyncCore();
-			GC.SuppressFinalize(this);
-		}
 #else
 		public async Task DisposeAsync() {
+#endif
+			if (IsDisposed) {
+				return;
+			}
+
+			LogFunction(nameof(DisposeAsync));
+			LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(async) " + this.ClientType);
+
 			await DisposeAsyncCore();
+
+			await Task.Run(() => {
+				WaitForDaemonTermination();
+			});
+
+			IsDisposed = true;
+
 			GC.SuppressFinalize(this);
 		}
-#endif
 
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 		protected virtual async ValueTask DisposeAsyncCore() {
 #else
 		protected virtual async Task DisposeAsyncCore() {
 #endif
-			if (IsDisposed) {
-				return;
-			}
-
-			// Fix: Hard catch and suppress all exceptions during disposing as there are constant issues with this method
-			try {
-				LogFunction(nameof(DisposeAsync));
-				LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(async) " + this.ClientType);
-			}
-			catch {
-			}
-
-			try {
-				if (IsConnected) {
-					await Disconnect();
-				}
-			}
-			catch {
-			}
+			await Disconnect();
 
 			if (m_stream != null) {
-				try {
-					await m_stream.DisposeAsync();
-				}
-				catch {
-				}
-
+				await m_stream.CloseAsync();
 				m_stream = null;
 			}
 
-			try {
-				m_credentials = null;
-				m_textEncoding = null;
-				m_host = null;
-			}
-			catch {
-			}
-
-			IsDisposed = true;
+			m_credentials = null;
+			m_textEncoding = null;
+			m_host = null;
 		}
 
-#endregion
-
-		protected override BaseFtpClient Create() {
-			return new AsyncFtpClient();
-		}
+		#endregion
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 

--- a/FluentFTP/Client/BaseClient/CloseDataStream.cs
+++ b/FluentFTP/Client/BaseClient/CloseDataStream.cs
@@ -21,10 +21,6 @@ namespace FluentFTP.Client.BaseClient {
 				throw new ArgumentException("The data stream parameter was null");
 			}
 
-			// A socket poll in here would be trouble, so disable by setting to zero.
-			int saveSocketPollInterval = stream.SocketPollInterval;
-			stream.SocketPollInterval = 0;
-
 			try {
 				if (IsConnected) {
 					// Because the data connection was closed, if the command that required the data
@@ -45,8 +41,6 @@ namespace FluentFTP.Client.BaseClient {
 				}
 			}
 
-			stream.SocketPollInterval = saveSocketPollInterval;
-
 			return reply;
 		}
 
@@ -62,10 +56,6 @@ namespace FluentFTP.Client.BaseClient {
 			if (stream == null) {
 				throw new ArgumentException("The data stream parameter was null");
 			}
-
-			// A socket poll in here would be trouble, so disable by setting to zero.
-			int saveSocketPollInterval = stream.SocketPollInterval;
-			stream.SocketPollInterval = 0;
 
 			try {
 				if (IsConnected) {
@@ -86,8 +76,6 @@ namespace FluentFTP.Client.BaseClient {
 					await ((IInternalFtpClient)this).DisposeInternal(token);
 				}
 			}
-
-			stream.SocketPollInterval = saveSocketPollInterval;
 
 			return reply;
 		}

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
 
@@ -26,7 +27,7 @@ namespace FluentFTP.Client.BaseClient {
 				(Config.NoopTestConnectivity
 				 && command != "QUIT"
 				 && IsAuthenticated
-				 && Status.NoopDaemonRunning
+				 && Status.NoopDaemonEnable
 				 && !((IInternalFtpClient)this).IsStillConnectedInternal())) {
 				if (command == "QUIT") {
 					LogWithPrefix(FtpTraceLevel.Info, "Not sending QUIT because the connection has already been closed.");
@@ -68,7 +69,6 @@ namespace FluentFTP.Client.BaseClient {
 					}
 
 					m_stream.Close();
-					m_stream = null;
 				}
 
 				if (command == "QUIT") {

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -106,8 +106,6 @@ namespace FluentFTP.Client.BaseClient {
 			try {
 
 				if (exhaustNoop) {
-					Status.NoopDaemonEnable = false;
-
 					// tickle the server
 					m_stream.WriteLine(Encoding, "NOOP");
 				}
@@ -115,7 +113,7 @@ namespace FluentFTP.Client.BaseClient {
 				sw.Start();
 
 				do {
-					if (!IsConnected) {
+					if (useSema && !IsConnected) {
 						throw new InvalidOperationException("No connection to the server exists.");
 					}
 
@@ -215,7 +213,6 @@ namespace FluentFTP.Client.BaseClient {
 					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
 
-				Status.NoopDaemonEnable = true;
 
 			}
 			finally {
@@ -328,8 +325,6 @@ namespace FluentFTP.Client.BaseClient {
 			try {
 
 				if (exhaustNoop) {
-					Status.NoopDaemonEnable = false;
-
 					// tickle the server
 					m_stream.WriteLine(Encoding, "NOOP");
 				}
@@ -337,7 +332,7 @@ namespace FluentFTP.Client.BaseClient {
 				sw.Start();
 
 				do {
-					if (!IsConnected) {
+					if (useSema && !IsConnected) {
 						throw new InvalidOperationException("No connection to the server exists.");
 					}
 
@@ -436,8 +431,6 @@ namespace FluentFTP.Client.BaseClient {
 				if (exhaustNoop) {
 					LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) sequence: " + sequence.TrimStart(','));
 				}
-
-				Status.NoopDaemonEnable = true;
 
 			}
 			finally {

--- a/FluentFTP/Client/BaseClient/NoopDaemon.cs
+++ b/FluentFTP/Client/BaseClient/NoopDaemon.cs
@@ -8,117 +8,115 @@ namespace FluentFTP.Client.BaseClient {
 		/// <summary>
 		/// NoopDaemon for NOOP handling
 		/// </summary>
-		protected void NoopDaemon() {
+		protected void NoopDaemon(CancellationToken ct) {
 
-			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon is initialized");
+			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon(" + this.ClientType + ") is initialized, NoopInterval = " + Config.NoopInterval + "ms");
 
 			Random rnd = new Random();
 
-			Status.NoopDaemonRunning = true;
-			Status.NoopDaemonCmdMode = true;
 			Status.NoopDaemonEnable = true;
 			Status.NoopDaemonAnyNoops = 0;
-
-			bool gotEx = false;
+			Status.NoopDaemonCmdMode = true;
 
 			do { // while(true)
 
-				if (!IsConnected) {
+				if (ct.IsCancellationRequested) {
 					break;
 				}
 
-				if (Status.NoopDaemonEnable &&
-					Config.NoopInterval > 0 &&
-					DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval) {
+				if (m_stream != null &&
+					m_stream.RealConnectionState == FtpRealConnectionStates.Up &&
+					Status.NoopDaemonEnable) {
 
-					// choose one of the normal or the safe commands
-					string rndCmd = Status.NoopDaemonCmdMode ?
-						Config.NoopInactiveCommands[rnd.Next(Config.NoopInactiveCommands.Count)] :
-						Config.NoopActiveCommands[rnd.Next(Config.NoopActiveCommands.Count)];
+					bool gotEx = false;
 
-					// only log this if we have an active data connection
-					if (Status.NoopDaemonCmdMode) {
-						Log(FtpTraceLevel.Verbose, "Command:  " + rndCmd + " (<-NoopDaemon)");
-					}
-					else {
-						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (<-NoopDaemon)");
-					}
+					if (Config.NoopInterval > 0 &&
+						DateTime.UtcNow.Subtract(LastCommandTimestamp).TotalMilliseconds > Config.NoopInterval) {
 
-					try {
-						m_daemonSemaphore.Wait();
+						m_daemonSemaphore.Wait(ct);
 
-						LastCommandTimestamp = DateTime.UtcNow;
-
-						// send the random NOOP command
 						try {
-							m_stream.WriteLine(m_textEncoding, rndCmd);
+							// choose one of the normal or the safe commands
+							string rndCmd = Status.NoopDaemonCmdMode ?
+								Config.NoopInactiveCommands[rnd.Next(Config.NoopInactiveCommands.Count)] :
+								Config.NoopActiveCommands[rnd.Next(Config.NoopActiveCommands.Count)];
+
+							// only log this if we have an active data connection
+							if (Status.NoopDaemonCmdMode) {
+								Log(FtpTraceLevel.Verbose, "Command:  " + rndCmd + " (<-NoopDaemon)");
+							}
+							else {
+								((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Sending " + rndCmd + " (<-NoopDaemon)");
+							}
+
+							LastCommandTimestamp = DateTime.UtcNow;
+
+							// send the random NOOP command
+							try {
+								m_stream.WriteLine(m_textEncoding, rndCmd);
+							}
+							catch (Exception ex) {
+								((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#1): " + ex.Message + " (NoopDaemon)");
+								gotEx = true;
+							}
+
+							if (!gotEx) {
+								// tell the outside world, NOOPs have actually been sent.
+								Status.NoopDaemonAnyNoops += 1;
+
+								// pick the command reply if this is just an idle control connection
+								if (Status.NoopDaemonCmdMode) {
+									bool success = false;
+
+									m_stream.RealConnectionState = FtpRealConnectionStates.Unknown;
+
+									try {
+										success = ((IInternalFtpClient)this).GetReplyInternal(rndCmd + " (<-NoopDaemon)", false, 10000, false).Success;
+									}
+									catch (Exception ex) {
+										((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#2): " + ex.Message + " (NoopDaemon)");
+										gotEx = true;
+									}
+									finally {
+										LastCommandTimestamp = DateTime.UtcNow;
+									}
+
+									if (success) {
+										m_stream.RealConnectionState = FtpRealConnectionStates.Up;
+
+										// in case one of these commands was successfully issued, make sure we store that
+										if (rndCmd.StartsWith("TYPE I")) {
+											Status.CurrentDataType = FtpDataType.Binary;
+										}
+										if (rndCmd.StartsWith("TYPE A")) {
+											Status.CurrentDataType = FtpDataType.ASCII;
+										}
+									}
+								}
+							}
 						}
 						catch (Exception ex) {
-							((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#1): " + ex.Message + " (NoopDaemon)");
+							((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#3): " + ex.Message + " (NoopDaemon)");
 							gotEx = true;
 						}
 
-						if (!gotEx) {
-							// tell the outside world, NOOPs have actually been sent.
-							Status.NoopDaemonAnyNoops += 1;
-
-							// pick the command reply if this is just an idle control connection
-							if (Status.NoopDaemonCmdMode) {
-								bool success = false;
-								try {
-									success = ((IInternalFtpClient)this).GetReplyInternal(rndCmd + " (<-NoopDaemon)", false, 10000, false).Success;
-								}
-								catch (Exception ex) {
-									((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#2): " + ex.Message + " (NoopDaemon)");
-									gotEx = true;
-								}
-								finally {
-									LastCommandTimestamp = DateTime.UtcNow;
-								}
-
-								// in case one of these commands was successfully issued, make sure we store that
-								if (success) {
-									if (rndCmd.StartsWith("TYPE I")) {
-										Status.CurrentDataType = FtpDataType.Binary;
-									}
-
-									if (rndCmd.StartsWith("TYPE A")) {
-										Status.CurrentDataType = FtpDataType.ASCII;
-									}
-								}
-							}
-						}
-					}
-					catch (Exception ex) {
-						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Got exception (#3): " + ex.Message + " (NoopDaemon)");
-						gotEx = true;
-					}
-					finally {
-						if (gotEx) {
-							if (m_stream != null) {
-								m_stream.Close();
-								m_stream = null;
-							}
-						}
 						m_daemonSemaphore.Release();
 					}
+
+					if (gotEx) {
+						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Indicating connection lost (NoopDaemon)");
+						Status.NoopDaemonEnable = false;
+						m_stream.RealConnectionState = FtpRealConnectionStates.PendingDown;
+					}
+
+
 				}
 
-				if (gotEx) {
-					break;
-				}
-
-				Thread.Sleep(100);
+				Thread.Sleep(250);
 
 			} while (true);
 
-			string reason = string.Empty;
-			if (gotEx) {
-				reason = " due to detected connection problem";
-			}
-
-			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon terminated" + reason);
-			Status.NoopDaemonRunning = false;
+			((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon terminated");
 		}
 	}
 }

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -100,11 +100,6 @@ namespace FluentFTP.Client.BaseClient {
 
 		protected FtpListParser CurrentListParser;
 
-		/// <summary>
-		/// A thread for background tasks
-		/// </summary>
-		protected Task m_task;
-
 		// Holds the cached resolved address
 		protected string m_Address;
 
@@ -139,6 +134,7 @@ namespace FluentFTP.Client.BaseClient {
 		FtpSocketStream IInternalFtpClient.GetBaseStream() {
 			return m_stream;
 		}
+
 		void IInternalFtpClient.SetListingParser(FtpParser parser) {
 			CurrentListParser.CurrentParser = parser;
 			CurrentListParser.ParserConfirmed = false;

--- a/FluentFTP/Client/BaseFtpClient.cs
+++ b/FluentFTP/Client/BaseFtpClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace FluentFTP.Client.BaseClient {
 	public partial class BaseFtpClient : IDisposable, IInternalFtpClient {
@@ -15,6 +16,12 @@ namespace FluentFTP.Client.BaseClient {
 			Config = config ?? new FtpConfig();
 		}
 
+		/// <summary>
+		/// Creates a new instance of this class. Useful in FTP proxy classes.
+		/// </summary>
+		protected virtual BaseFtpClient Create() {
+			return new BaseFtpClient(null);
+		}
 		#endregion
 
 		#region Clone
@@ -63,7 +70,6 @@ namespace FluentFTP.Client.BaseClient {
 
 		}
 
-
 		#endregion
 
 		#region Destructor
@@ -81,25 +87,18 @@ namespace FluentFTP.Client.BaseClient {
 				}
 			}
 		}
-		/// <summary>
-		/// Check if the host parameter is valid
-		/// </summary>
-		/// <param name="host"></param>
-		protected string ValidateHost(Uri host) {
-			if (host == null) {
-				throw new ArgumentNullException(nameof(host), "Host is required");
-			}
-			if (host.Scheme != Uri.UriSchemeFtp) {
-				throw new ArgumentException("Host is not a valid FTP path");
-			}
-			return host.Host;
-		}
 
-		/// <summary>
-		/// Creates a new instance of this class. Useful in FTP proxy classes.
-		/// </summary>
-		protected virtual BaseFtpClient Create() {
-			return new BaseFtpClient(null);
+		public void WaitForDaemonTermination() {
+			if (Config.Noop) {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Waiting for Daemon termination(" + this.ClientType + ")");
+				Status.NoopDaemonTokenSource.Cancel();
+				DateTime startTime = DateTime.UtcNow;
+				while (Status.NoopDaemonTask != null && Status.NoopDaemonTask.Status == TaskStatus.Running &&
+					DateTime.UtcNow.Subtract(startTime).TotalMilliseconds < 20000) {
+					Thread.Sleep(250);
+				}
+				LogWithPrefix(FtpTraceLevel.Verbose, "Daemon terminated");
+			}
 		}
 
 		/// <summary>
@@ -111,49 +110,25 @@ namespace FluentFTP.Client.BaseClient {
 				return;
 			}
 
-			// Fix: Hard catch and suppress all exceptions during disposing as there are constant issues with this method
-			try {
-				LogFunction(nameof(Dispose));
-				LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(sync) " + this.ClientType);
-			}
-			catch {
-			}
+			LogFunction(nameof(Dispose));
+			LogWithPrefix(FtpTraceLevel.Verbose, "Disposing(sync) " + this.ClientType);
 
-			try {
-				if (IsConnected) {
-					((IInternalFtpClient)this).DisconnectInternal();
-				}
-			}
-			catch {
-			}
+			((IInternalFtpClient)this).DisconnectInternal();
 
 			if (m_stream != null) {
-				try {
-					m_stream.Dispose();
-				}
-				catch {
-				}
-
+				m_stream.Dispose();
 				m_stream = null;
 			}
 
-			try {
-				m_credentials = null;
-				m_textEncoding = null;
-				m_host = null;
-			}
-			catch {
-			}
+			m_credentials = null;
+			m_textEncoding = null;
+			m_host = null;
+
+			WaitForDaemonTermination();
 
 			IsDisposed = true;
-			GC.SuppressFinalize(this);
-		}
 
-		/// <summary>
-		/// Finalizer
-		/// </summary>
-		~BaseFtpClient() {
-			Dispose();
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion

--- a/FluentFTP/Client/Modules/ConnectModule.cs
+++ b/FluentFTP/Client/Modules/ConnectModule.cs
@@ -326,7 +326,6 @@ namespace FluentFTP.Client.Modules {
 			if (knownProfile != null) {
 				client.Config.ConnectTimeout = knownProfile.Timeout;
 				client.Config.RetryAttempts = knownProfile.RetryAttempts;
-				client.Config.SocketPollInterval = knownProfile.SocketPollInterval;
 			}
 		}
 
@@ -456,9 +455,6 @@ namespace FluentFTP.Client.Modules {
 				client.Config.ReadTimeout = profile.Timeout;
 				client.Config.DataConnectionConnectTimeout = profile.Timeout;
 				client.Config.DataConnectionReadTimeout = profile.Timeout;
-			}
-			if (client.Config.SocketPollInterval != 0) {
-				client.Config.SocketPollInterval = profile.SocketPollInterval;
 			}
 			if (client.Config.RetryAttempts != 0) {
 				client.Config.RetryAttempts = profile.RetryAttempts;

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -85,7 +85,6 @@ namespace FluentFTP {
 
 			m_hashAlgorithms = FtpHashAlgorithm.NONE;
 			m_stream.ConnectTimeout = Config.ConnectTimeout;
-			m_stream.SocketPollInterval = Config.SocketPollInterval;
 			Connect(m_stream);
 
 			m_stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);
@@ -236,8 +235,12 @@ namespace FluentFTP {
 
 			Status.InCriticalSequence = false;
 
-			if (Config.Noop && !Status.NoopDaemonRunning) {
-				m_task = Task.Run(() => { NoopDaemon(); });
+			if (Config.Noop) {
+				if (Status.NoopDaemonTask == null) {
+					Status.NoopDaemonTask = Task.Factory.StartNew(() => { NoopDaemon(Status.NoopDaemonTokenSource.Token); }, Status.NoopDaemonTokenSource.Token);
+				}
+				Status.NoopDaemonEnable = true;
+				Status.NoopDaemonCmdMode = true;
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/Disconnect.cs
+++ b/FluentFTP/Client/SyncClient/Disconnect.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace FluentFTP {
 	public partial class FtpClient {
@@ -26,9 +23,11 @@ namespace FluentFTP {
 					// from the remote side, thus causing an exception here, so check for null
 					if (m_stream != null) {
 						m_stream.Close();
-						m_stream = null;
 					}
 				}
+			}
+			else {
+				LogWithPrefix(FtpTraceLevel.Verbose, "Connection already closed, nothing to do.");
 			}
 		}
 

--- a/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/DownloadFileInternal.cs
@@ -194,9 +194,6 @@ namespace FluentFTP {
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// disconnect FTP streams before exiting

--- a/FluentFTP/Client/SyncClient/UploadFileInternal.cs
+++ b/FluentFTP/Client/SyncClient/UploadFileInternal.cs
@@ -259,13 +259,10 @@ namespace FluentFTP {
 				long tot = upStream.Position;
 				long ems = sw.ElapsedMilliseconds;
 				string bps = ems == 0 ? "?" : (tot / ems * 1000L).FileSizeToString();
-				string successText = "Uploaded " + tot + " bytes " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
+				string successText = "Uploaded " + tot + " bytes, " + sw.Elapsed.ToShortString() + ", " + bps + "/s";
 				if (Config.Noop) {
 					successText += ", " + Status.NoopDaemonAnyNoops + " NOOPs";
 				}
-				//if (Config.Poll) {
-				//	successText += ", " + Status.PollDaemonAnyPolls + " POLLs";
-				//}
 				LogWithPrefix(FtpTraceLevel.Verbose, successText);
 
 				// send progress reports

--- a/FluentFTP/Enums/FtpRealConnectionsStates.cs
+++ b/FluentFTP/Enums/FtpRealConnectionsStates.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace FluentFTP {
+	/// <summary>
+	/// Real transitional connection states
+	/// </summary>
+	public enum FtpRealConnectionStates {
+		/// <summary>
+		/// Deamon will determine the state in a short while
+		/// </summary>
+		Unknown,
+
+		/// <summary>
+		/// Not a good state and it will be brought down, closed and disposed soon
+		/// </summary>
+		PendingDown,
+
+		/// <summary>
+		/// Closed, disposed
+		/// </summary>
+		Down,
+
+		/// <summary>
+		/// Connected, at least the last time the NOOP daemon checked the connection
+		/// </summary>
+		Up,
+
+	};
+
+}

--- a/FluentFTP/Model/FtpClientState.cs
+++ b/FluentFTP/Model/FtpClientState.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace FluentFTP {
 
@@ -132,20 +134,24 @@ namespace FluentFTP {
 		public ushort zOSListingLRECL { get; set; }
 
 		/// <summary>
-		/// Background task status
+		/// NOOP Daemon Task
 		/// </summary>
-		public bool NoopDaemonRunning { get; set; }
+		public Task NoopDaemonTask { get; set; }
 		/// <summary>
-		/// Background task should GetReply
+		/// NOOP Daemon TokenSource
 		/// </summary>
-		public bool NoopDaemonCmdMode { get; set; }
+		public CancellationTokenSource NoopDaemonTokenSource { get; set; } = new CancellationTokenSource();
 		/// <summary>
-		/// Background task enabled
+		/// NOOP Daemon enabled
 		/// </summary>
-		public bool NoopDaemonEnable { get; set; }
+		public bool NoopDaemonEnable { get; set; } = false;
 		/// <summary>
-		/// Background task sent noops
+		/// NOOP Daemon sent noops
 		/// </summary>
-		public int NoopDaemonAnyNoops { get; set; }
+		public int NoopDaemonAnyNoops { get; set; } = 0;
+		/// <summary>
+		/// NOOP Daemon should GetReply
+		/// </summary>
+		public bool NoopDaemonCmdMode { get; set; } = true;
 	}
 }

--- a/FluentFTP/Streams/FtpDataStream.cs
+++ b/FluentFTP/Streams/FtpDataStream.cs
@@ -230,7 +230,6 @@ namespace FluentFTP {
 		/// Finalizer
 		/// </summary>
 		~FtpDataStream() {
-			// Fix: Hard catch and suppress all exceptions during disposing as there are constant issues with this method
 			try {
 				if (Client is AsyncFtpClient) {
 					DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
@@ -239,7 +238,8 @@ namespace FluentFTP {
 					Dispose();
 				}
 			}
-			catch {
+			catch (Exception ex) {
+				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Caught DATASTREAM(Dispose) exception: " + ex.Message);
 			}
 		}
 	}

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -97,66 +97,49 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
+		/// Real transitional connection states
+		/// </summary>
+		public FtpRealConnectionStates RealConnectionState { get; set; } = FtpRealConnectionStates.Down;
+
+		/// <summary>
 		/// Gets a value indicating if this socket stream is connected
 		/// </summary>
 		public bool IsConnected {
 			get {
-				try {
-					if (m_socket == null) {
-						return false;
+				if (m_socket == null || !m_socket.Connected || !CanRead || !CanWrite) {
+					if (RealConnectionState != FtpRealConnectionStates.Down) {
+						RealConnectionState = FtpRealConnectionStates.PendingDown;
 					}
+				}
 
-					if (!m_socket.Connected) {
-						Close();
-						return false;
-					}
-
-					if (!CanRead || !CanWrite) {
-						Close();
-						return false;
-					}
-
-					if (m_socketPollInterval > 0 && DateTime.UtcNow.Subtract(m_lastActivity).TotalMilliseconds > m_socketPollInterval) {
-						string connText = this.IsControlConnection ? "control" : "data";
-						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Testing connectivity of " + Client.ClientType + ".FtpSocketStream(" + connText + ") " + " using Socket.Poll()...");
-
-						// FIX : #273 update m_lastActivity to the current time
-						m_lastActivity = DateTime.UtcNow;
-
-						// Poll (SelectRead) returns true if:
-						// Listen has been called and connection is pending (cannot be the case)
-						// Data is available for reading
-						// Connection has been closed, reset or terminated <--- this is the one we want
-						// The ordering in the if-statement is important: Available is updated by the Poll
-						if (m_socket.Poll(500000, SelectMode.SelectRead) && m_socket.Available == 0) {
-							Close();
-							return false;
+				if (RealConnectionState == FtpRealConnectionStates.Unknown) {
+					Thread.Sleep(500);
+					if (RealConnectionState == FtpRealConnectionStates.Unknown) {
+						((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Connection state unknown. Waiting for timeout");
+						DateTime startTime = DateTime.UtcNow;
+						while (RealConnectionState == FtpRealConnectionStates.Unknown &&
+							DateTime.UtcNow.Subtract(startTime).TotalMilliseconds < 20000) {
+							Thread.Sleep(1000);
 						}
 					}
 				}
-				catch (SocketException sockex) {
-					Close();
-					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded SocketException while testing for connectivity", sockex);
-					return false;
-				}
-				catch (IOException ioex) {
-					Close();
-					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded IOException while testing for connectivity", ioex);
-					return false;
+
+				if (RealConnectionState == FtpRealConnectionStates.PendingDown) {
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Connection state pending down. Closing");
+					if (Client is AsyncFtpClient) {
+						CloseAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+					}
+					else {
+						Close();
+					}
 				}
 
-				return true;
+				return RealConnectionState == FtpRealConnectionStates.Up;
 			}
 		}
 
 		/// <summary>
 		/// Used for tracking read/write activity on the socket
-		/// to determine if Poll() should be used to test for
-		/// socket connectivity. The socket in this class will
-		/// not know it has been disconnected if the remote host
-		/// closes the connection first. Using Poll() avoids
-		/// the exception that would be thrown when trying to
-		/// read or write to the disconnected socket.
 		/// </summary>
 		private DateTime m_lastActivity = DateTime.UtcNow;
 
@@ -168,22 +151,6 @@ namespace FluentFTP {
 		protected Socket Socket {
 			get => m_socket;
 			private set => m_socket = value;
-		}
-
-		private int m_socketPollInterval = 15000;
-
-		/// <summary>
-		/// Gets or sets the length of time in milliseconds
-		/// that must pass since the last socket activity
-		/// before calling Poll() on the socket to test for
-		/// connectivity. Setting this interval too low will
-		/// have a negative impact on performance. Setting this
-		/// interval to 0 disables Poll()'ing all together.
-		/// The default value is 15 seconds.
-		/// </summary>
-		public int SocketPollInterval {
-			get => m_socketPollInterval;
-			set => m_socketPollInterval = value;
 		}
 
 		/// <summary>
@@ -412,14 +379,6 @@ namespace FluentFTP {
 		/// Flushes the stream
 		/// </summary>
 		public override void Flush() {
-			if (!IsConnected) {
-				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
-			}
-
-			if (BaseStream == null) {
-				throw new InvalidOperationException("The base stream of the FtpSocketStream object is null.");
-			}
-
 			BaseStream.Flush();
 		}
 
@@ -428,14 +387,6 @@ namespace FluentFTP {
 		/// </summary>
 		/// <param name="token">The <see cref="CancellationToken"/> for this task</param>
 		public override async Task FlushAsync(CancellationToken token) {
-			if (!IsConnected) {
-				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
-			}
-
-			if (BaseStream == null) {
-				throw new InvalidOperationException("The base stream of the FtpSocketStream object is null.");
-			}
-
 			await BaseStream.FlushAsync(token);
 		}
 
@@ -454,7 +405,27 @@ namespace FluentFTP {
 			return read;
 		}
 
-#if NETFRAMEWORK
+#if NETSTANDARD || NET5_0_OR_GREATER
+		/// <summary>
+		/// Bypass the stream and read directly off the socket.
+		/// </summary>
+		/// <param name="buffer">The buffer to read into</param>
+		/// <param name="token">The token that can be used to cancel the entire process</param>
+		/// <returns>The number of bytes read</returns>
+		internal async Task<int> RawSocketReadAsync(byte[] buffer, CancellationToken token) {
+			var read = 0;
+
+			if (m_socket != null && m_socket.Connected && !token.IsCancellationRequested) {
+#if NET6_0_OR_GREATER
+				read = await m_socket.ReceiveAsync(buffer, 0, token);
+#else
+				read = await m_socket.ReceiveAsync(new ArraySegment<byte>(buffer), 0);
+#endif
+			}
+
+			return read;
+		}
+#else
 		/// <summary>
 		/// Bypass the stream and read directly off the socket.
 		/// </summary>
@@ -471,28 +442,6 @@ namespace FluentFTP {
 					token,
 					() => DisposeSocket()
 				);
-			}
-
-			return read;
-		}
-#endif
-
-#if !NETFRAMEWORK
-		/// <summary>
-		/// Bypass the stream and read directly off the socket.
-		/// </summary>
-		/// <param name="buffer">The buffer to read into</param>
-		/// <param name="token">The token that can be used to cancel the entire process</param>
-		/// <returns>The number of bytes read</returns>
-		internal async Task<int> RawSocketReadAsync(byte[] buffer, CancellationToken token) {
-			var read = 0;
-
-			if (m_socket != null && m_socket.Connected && !token.IsCancellationRequested) {
-#if NET6_0_OR_GREATER
-				read = await m_socket.ReceiveAsync(buffer, 0, token);
-#else
-				read = await m_socket.ReceiveAsync(new ArraySegment<byte>(buffer), 0);
-#endif
 			}
 
 			return read;
@@ -608,7 +557,7 @@ namespace FluentFTP {
 
 			m_lastActivity = DateTime.UtcNow;
 			using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token)) {
-				cts.CancelAfter(ReadTimeout);
+				cts.Token.Register(async () => await CloseAsync(token));
 				try {
 					var res = await BaseStream.ReadAsync(buffer, cts.Token);
 					return res;
@@ -1006,11 +955,14 @@ namespace FluentFTP {
 				throw new IOException("Failed to connect to host.");
 			}
 
+
 			SetCachedHostAddresses(host, ipad);
 
 			m_netStream = new NetworkStream(m_socket);
 			m_netStream.ReadTimeout = m_readTimeout;
 			m_lastActivity = DateTime.UtcNow;
+
+			RealConnectionState = FtpRealConnectionStates.Up;
 
 			if (!IsControlConnection) {
 				// the NOOP daemon needs to know this
@@ -1154,6 +1106,8 @@ namespace FluentFTP {
 			m_netStream = new NetworkStream(m_socket);
 			m_netStream.ReadTimeout = m_readTimeout;
 			m_lastActivity = DateTime.UtcNow;
+
+			RealConnectionState = FtpRealConnectionStates.Up;
 
 			if (!IsControlConnection) {
 				// the NOOP daemon needs to know this
@@ -1634,20 +1588,22 @@ namespace FluentFTP {
 		/// </summary>
 		protected new void Dispose() {
 			if (IsControlConnection) {
-				Client.Status.NoopDaemonEnable = false;
+				if (Client.Status.NoopDaemonEnable) {
+					Client.Status.NoopDaemonEnable = false;
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon disabled");
+				}
 			}
 			else {
 				Client.Status.NoopDaemonCmdMode = true;
 			}
 
-			if (IsDisposed) {
-				return;
-			}
+			RealConnectionState = FtpRealConnectionStates.Down;
 
 			string connText = IsControlConnection ? "control" : "data";
+			string reduText = this.IsDisposed ? " (redundant)" : string.Empty;
 
 			if (Client != null) {
-				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing(sync) " + Client.ClientType + ".FtpSocketStream(" + connText + ")");
+				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing(sync) " + Client.ClientType + ".FtpSocketStream(" + connText + ")" + reduText);
 			}
 
 			// TODO: To support the CCC (Deactivate Encryption) command, some more additional logic
@@ -1757,20 +1713,22 @@ namespace FluentFTP {
 		protected async Task DisposeAsyncCore() {
 #endif
 			if (IsControlConnection) {
-				Client.Status.NoopDaemonEnable = false;
+				if (Client.Status.NoopDaemonEnable) {
+					Client.Status.NoopDaemonEnable = false;
+					((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "NoopDaemon disabled");
+				}
 			}
 			else {
 				Client.Status.NoopDaemonCmdMode = true;
 			}
 
-			if (IsDisposed) {
-				return;
-			}
+			RealConnectionState = FtpRealConnectionStates.Down;
 
 			string connText = this.IsControlConnection ? "control" : "data";
+			string reduText = this.IsDisposed ? " (redundant)" : string.Empty;
 
 			if (Client != null) {
-				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing(async) " + Client.ClientType + ".FtpSocketStream(" + connText + ")");
+				((IInternalFtpClient)Client).LogStatus(FtpTraceLevel.Verbose, "Disposing(async) " + Client.ClientType + ".FtpSocketStream(" + connText + ")" + reduText);
 			}
 
 			// TODO: To support the CCC (Deactivate Encryption) command, some more additional logic


### PR DESCRIPTION
### Finally ready to merge

### Daemon:
**Use** Task.Factory.StartNew
**Use** CancellationToken
**Improve** code and use intermediate connection state to indicate lost connection

### FtpSocketStream
**Improve** IsConnected - handle sync **and async** close situations, remove extranseous socket.Poll calls, use intermediate connections state to decide return valie
**Improve** Close/Dispose logic further - add detailed logging of Close/Dispose failures for future debugging in possible user logs when issues are reported

### New Enum FtpRealConnectionStates
**Allow connection failure status tracking** with the help of NoopDaemon before IsConnected decides true/false based on socket state only.

