### PR TITLE
Rename FEAT capability MLSD -> MLST

### DIFF
--- a/FluentFTP.Tests/Unit/ParserTests.cs
+++ b/FluentFTP.Tests/Unit/ParserTests.cs
@@ -62,7 +62,7 @@ namespace FluentFTP.Tests.Unit {
 		public void Machine() {
 
 			var client = new FtpClient();
-			client.SetFeatures(new List<FtpCapability> { FtpCapability.MLSD });
+			client.SetFeatures(new List<FtpCapability> { FtpCapability.MLST });
 			var parser = new FtpListParser(client);
 			parser.Init(FtpOperatingSystem.Unix, FtpParser.Machine);
 

--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -195,7 +195,7 @@ namespace FluentFTP {
 			// FIX : #739 prefer using machine listings to fix issues with GetListing and DeleteDirectory
 			if (Config.ListingParser != FtpParser.Custom) {
 				Config.ListingParser = ServerHandler != null ? ServerHandler.GetParser() : FtpParser.Auto;
-				if (HasFeature(FtpCapability.MLSD)) {
+				if (HasFeature(FtpCapability.MLST)) {
 					Config.ListingParser = FtpParser.Machine;
 				}
 			}

--- a/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
+++ b/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
@@ -18,7 +18,7 @@ namespace FluentFTP {
 		/// Return information about a remote file system object asynchronously.
 		/// </summary>
 		/// <remarks>
-		/// You should check the <see cref="BaseFtpClient.Capabilities"/> property for the <see cref="FtpCapability.MLSD"/>
+		/// You should check the <see cref="BaseFtpClient.Capabilities"/> property for the <see cref="FtpCapability.MLST"/>
 		/// flag before calling this method. Failing to do so will result in an InvalidOperationException
 		/// being thrown when the server does not support machine listings. Returns null if the server response can't
 		/// be parsed or the server returns a failure completion code. The error for a failure
@@ -41,7 +41,7 @@ namespace FluentFTP {
 
 			FtpReply reply;
 
-			var supportsMachineList = HasFeature(FtpCapability.MLSD);
+			var supportsMachineList = HasFeature(FtpCapability.MLST);
 
 			FtpListItem result = null;
 

--- a/FluentFTP/Client/BaseClient/Listing.cs
+++ b/FluentFTP/Client/BaseClient/Listing.cs
@@ -106,7 +106,7 @@ namespace FluentFTP.Client.BaseClient {
 			}
 			else {
 				// use machine listing if supported by the server
-				if (!isForceList && Config.ListingParser == FtpParser.Machine && HasFeature(FtpCapability.MLSD)) {
+				if (!isForceList && Config.ListingParser == FtpParser.Machine && HasFeature(FtpCapability.MLST)) {
 					listcmd = "MLSD";
 					machineList = true;
 				}
@@ -164,7 +164,7 @@ namespace FluentFTP.Client.BaseClient {
 				if (!isUseStat) {
 
 					// if not using machine listing (MSLD)
-					if ((!isForceList || Config.ListingParser == FtpParser.Machine) && HasFeature(FtpCapability.MLSD)) {
+					if ((!isForceList || Config.ListingParser == FtpParser.Machine) && HasFeature(FtpCapability.MLST)) {
 					}
 					else {
 

--- a/FluentFTP/Client/Modules/ServerFeatureModule.cs
+++ b/FluentFTP/Client/Modules/ServerFeatureModule.cs
@@ -22,7 +22,7 @@ namespace FluentFTP.Client.Modules {
 				}
 
 				if (featName.StartsWith("MLST") || featName.StartsWith("MLSD")) {
-					capabilities.AddOnce(FtpCapability.MLSD);
+					capabilities.AddOnce(FtpCapability.MLST);
 				}
 				else if (featName.StartsWith("MDTM")) {
 					capabilities.AddOnce(FtpCapability.MDTM);

--- a/FluentFTP/Client/Modules/ServerStringModule.cs
+++ b/FluentFTP/Client/Modules/ServerStringModule.cs
@@ -125,6 +125,7 @@ namespace FluentFTP.Client.Modules {
 			"LIST",
 			"NLST",
 			"MLSD",
+			"MLST",
 			"STOR",
 			"STOU",
 			"APPE",

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -192,7 +192,7 @@ namespace FluentFTP {
 			// FIX : #739 prefer using machine listings to fix issues with GetListing and DeleteDirectory
 			if (Config.ListingParser != FtpParser.Custom) {
 				Config.ListingParser = ServerHandler != null ? ServerHandler.GetParser() : FtpParser.Auto;
-				if (HasFeature(FtpCapability.MLSD)) {
+				if (HasFeature(FtpCapability.MLST)) {
 					Config.ListingParser = FtpParser.Machine;
 				}
 			}

--- a/FluentFTP/Client/SyncClient/GetObjectInfo.cs
+++ b/FluentFTP/Client/SyncClient/GetObjectInfo.cs
@@ -33,7 +33,7 @@ namespace FluentFTP {
 
 			FtpReply reply;
 
-			var supportsMachineList = HasFeature(FtpCapability.MLSD);
+			var supportsMachineList = HasFeature(FtpCapability.MLST);
 
 			FtpListItem result = null;
 

--- a/FluentFTP/Enums/FtpCapability.cs
+++ b/FluentFTP/Enums/FtpCapability.cs
@@ -14,7 +14,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Supports the MLST command (machine listings)
 		/// </summary>
-		MLSD = 2,
+		MLST = 2,
 
 		/// <summary>
 		/// Supports the SIZE command (get file size)

--- a/FluentFTP/Enums/FtpListOption.cs
+++ b/FluentFTP/Enums/FtpListOption.cs
@@ -15,7 +15,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// Load the modify date using MDTM when it could not
 		/// be parsed from the server listing. This only pertains
-		/// to servers that do not implement the MLSD command.
+		/// to servers that do not implement the MLST command.
 		/// </summary>
 		Modify = 1,
 
@@ -23,7 +23,7 @@ namespace FluentFTP {
 		/// Load the file size using the SIZE command when it
 		/// could not be parsed from the server listing. This
 		/// only pertains to servers that do not support the
-		/// MLSD command.
+		/// MLST command.
 		/// </summary>
 		Size = 2,
 
@@ -34,10 +34,10 @@ namespace FluentFTP {
 
 		/// <summary>
 		/// Show hidden/dot files. This only pertains to servers
-		/// that do not support the MLSD command. This option
+		/// that do not support the MLST command. This option
 		/// makes use the non standard -a parameter to LIST to
 		/// tell the server to show hidden files. Since it's a
-		/// non-standard option it may not always work. MLSD listings
+		/// non-standard option it may not always work. MLST listings
 		/// have no such option and whether or not a hidden file is
 		/// shown is at the discretion of the server.
 		/// </summary>
@@ -45,7 +45,7 @@ namespace FluentFTP {
 
 		/// <summary>
 		/// Force the use of OS-specific listings (LIST command) even if
-		/// machine listings (MLSD command) are supported by the server
+		/// machine listings (MLST command) are supported by the server
 		/// </summary>
 		ForceList = 8,
 

--- a/FluentFTP/Helpers/FtpListParser.cs
+++ b/FluentFTP/Helpers/FtpListParser.cs
@@ -222,7 +222,7 @@ namespace FluentFTP.Helpers {
 		}
 
 		private bool IsWrongMachineListing() {
-			return CurrentParser == FtpParser.Machine && client != null && !client.HasFeature(FtpCapability.MLSD);
+			return CurrentParser == FtpParser.Machine && client != null && !client.HasFeature(FtpCapability.MLST);
 		}
 
 		/// <summary>


### PR DESCRIPTION
See #1635 

The capability should be called MLST in the code and not MLSD. Global rename needed.