### PR TITLE
Improve dictionary lookups

### DIFF
--- a/FluentFTP/Helpers/Hashing/HashAlgorithms.cs
+++ b/FluentFTP/Helpers/Hashing/HashAlgorithms.cs
@@ -29,11 +29,9 @@ namespace FluentFTP.Helpers.Hashing {
 		/// <param name="name">Name of the hash algorithm</param>
 		/// <returns>The FtpHashAlgorithm</returns>
 		public static FtpHashAlgorithm FromString(string name) {
-			if (!NameToEnum.ContainsKey(name.ToUpper())) {
-				throw new NotImplementedException("Unknown hash algorithm: " + name);
-			}
-
-			return NameToEnum[name];
+			return NameToEnum.TryGetValue(name, out var value)
+				? value
+				: throw new NotImplementedException("Unknown hash algorithm: " + name);
 		}
 
 		/// <summary>
@@ -42,11 +40,9 @@ namespace FluentFTP.Helpers.Hashing {
 		/// <param name="name">FtpHashAlgorithm to be converted into string</param>
 		/// <returns>Name of the hash algorithm</returns>
 		public static string PrintToString(this FtpHashAlgorithm name) {
-			if (!EnumToName.ContainsKey(name)) {
-				return name.ToString();
-			}
-
-			return EnumToName[name];
+			return EnumToName.TryGetValue(name, out var value)
+				? value
+				: name.ToString();
 		}
 
 		private static readonly List<FtpHashAlgorithm> AlgoPreference = new List<FtpHashAlgorithm> {

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -869,7 +869,7 @@ namespace FluentFTP {
 #else
 				ipads = Dns.GetHostAddresses(host);
 #endif
-				Client.Status.CachedHostIpads.Add(host, ipads);
+				Client.Status.CachedHostIpads[host] = ipads;
 			}
 
 			return ipads;
@@ -1019,7 +1019,7 @@ namespace FluentFTP {
 #else
 				ipads = await Dns.GetHostAddressesAsync(host);
 #endif
-				Client.Status.CachedHostIpads.Add(host, ipads);
+				Client.Status.CachedHostIpads[host] = ipads;
 			}
 
 			return ipads;

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -862,12 +862,8 @@ namespace FluentFTP {
 		/// </summary>
 		/// <param name="host">The host to query</param>
 		private IPAddress[] GetCachedHostAddresses(string host) {
-			IPAddress[] ipads;
 
-			if (Client.Status.CachedHostIpads.ContainsKey(host)) {
-				ipads = Client.Status.CachedHostIpads[host];
-			}
-			else {
+			if (!Client.Status.CachedHostIpads.TryGetValue(host, out IPAddress[] ipads)) {
 #if NETSTANDARD || NET5_0_OR_GREATER
 				ipads = Dns.GetHostAddressesAsync(host).Result;
 #else
@@ -885,12 +881,7 @@ namespace FluentFTP {
 		/// <param name="host">The host to query</param>
 		/// <param name="ipad">The IP address to store in the cache</param>
 		private void SetCachedHostAddresses(string host, IPAddress ipad) {
-			if (Client.Status.CachedHostIpads.ContainsKey(host)) {
-				Client.Status.CachedHostIpads[host] = new IPAddress[1] { ipad };
-			}
-			else {
-				Client.Status.CachedHostIpads.Add(host, new IPAddress[1] { ipad });
-			}
+			Client.Status.CachedHostIpads[host] = new IPAddress[1] { ipad };
 		}
 
 		/// <summary>
@@ -1021,12 +1012,8 @@ namespace FluentFTP {
 		/// <param name="host">The host to query</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		private async Task<IPAddress[]> GetCachedHostAddressesAsync(string host, CancellationToken token) {
-			IPAddress[] ipads;
 
-			if (Client.Status.CachedHostIpads.ContainsKey(host)) {
-				ipads = Client.Status.CachedHostIpads[host];
-			}
-			else {
+			if (!Client.Status.CachedHostIpads.TryGetValue(host, out IPAddress[] ipads)) {
 #if NET6_0_OR_GREATER
 				ipads = await Dns.GetHostAddressesAsync(host, token);
 #else


### PR DESCRIPTION
I was investigating a race condition in my app. I haven't found the root cause yet, but this part took my attention in FluentFTP's code when browsing through the stack:

- The `ContainsKey` + retrieve pairs are redundant when a single `TryGetValue` would work. 
- A dictionary `.Add` would throw `ArgumentException` for duplicate keys, but `cache[host] = value` wouldn't.

I know that there is no reason for those pieces of code to fail for a single-threaded type, but still it's marginally faster, and more fault tolerant :) 