### PR TITLE
apt-smart (select fastest debian mirror) will fail from py 3.13 onwar…

### DIFF
--- a/FluentFTP.Dockers/common-mirror/Dockerfile
+++ b/FluentFTP.Dockers/common-mirror/Dockerfile
@@ -2,7 +2,7 @@
 # FluentFTP Integration Test: Debian Mirror Selection
 #
 
-FROM	python:3-slim AS prebuild
+FROM	python:3.10-slim AS prebuild
 
 SHELL	["/bin/bash", "-c"]
 


### PR DESCRIPTION
…ds. (module pipes deprecated)