### PR TITLE
Fix incorrect call sequence (Obsolete OpenWrite/OpenRead)

### DIFF
--- a/FluentFTP.Tests/Integration/Tests/FileTransferTests.cs
+++ b/FluentFTP.Tests/Integration/Tests/FileTransferTests.cs
@@ -229,6 +229,7 @@ namespace FluentFTP.Tests.Integration.Tests {
 			await using (var dest = await client.OpenWrite(path)) {
 				await dest.WriteAsync(buffer);
 			}
+			await client.GetReply();
 
 			Memory<byte> outBuffer = new byte[buffer.Length];
 			var readBuffer = outBuffer;
@@ -256,6 +257,7 @@ namespace FluentFTP.Tests.Integration.Tests {
 			using (var dest = client.OpenWrite(path)) {
 				dest.Write(buffer);
 			}
+			client.GetReply();
 
 			Span<byte> outBuffer = new byte[buffer.Length];
 			var readBuffer = outBuffer;


### PR DESCRIPTION
This missing `GetReply()` causes stale data prior to the `OpenRead(...)`. Fortunately, this doesn't cause a failure in the test, but for cosmetic reasons, adding the `GetReply()` as stated in the Documentation is a good thing.