### PR TITLE
Use `Task.Delay` instead of `Thread.Sleep`

### DIFF
--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -395,7 +395,7 @@ namespace FluentFTP.Client.BaseClient {
 					}
 
 					if (string.IsNullOrEmpty(response)) {
-						Thread.Sleep(100);
+						await Task.Delay(100, token);
 						continue;
 					}
 

--- a/FluentFTP/Client/BaseClient/ReadStaleData.cs
+++ b/FluentFTP/Client/BaseClient/ReadStaleData.cs
@@ -111,7 +111,7 @@ namespace FluentFTP.Client.BaseClient {
 						if (m_stream.SocketDataAvailable > 0 || !m_stream.IsConnected) {
 							break;
 						}
-						Thread.Sleep(250);
+						await Task.Delay(250, token);
 					} while (sw.ElapsedMilliseconds < 10000);
 
 					if (m_stream.SocketDataAvailable > 0) {


### PR DESCRIPTION
Use `Task.Delay` instead of `Thread.Sleep` in async methods.

Introduced in:
* https://github.com/robinrodricks/FluentFTP/commit/372ff88771023fe23fab65505594f17f0acc5f4e#diff-3d3d07d656110497cd0b89ccd49f2a2614e7296bfe0da620839ac6d0efae67beR110
* https://github.com/robinrodricks/FluentFTP/commit/dc511d8c2e46d986f4bf9d4ab26252650f45128f#diff-1295cd645e59fea47aeb890b57fab668a6945bd4442997e264f4e6f297015908R114