### PR TITLE
Remove redundant null checks

### DIFF
--- a/FluentFTP/Client/AsyncClient/FileExists.cs
+++ b/FluentFTP/Client/AsyncClient/FileExists.cs
@@ -27,7 +27,7 @@ namespace FluentFTP {
 
 			// since FTP does not include a specific command to check if a file exists
 			// here we check if file exists by attempting to get its filesize (SIZE)
-			if (HasFeature(FtpCapability.SIZE) && (ServerHandler == null || (ServerHandler != null && !ServerHandler.DontUseSizeEvenIfCapable(path)))) {
+			if (HasFeature(FtpCapability.SIZE) && (ServerHandler == null || !ServerHandler.DontUseSizeEvenIfCapable(path))) {
 				// Fix #328: get filesize in ASCII or Binary mode as required by server
 				FtpSizeReply sizeReply = new FtpSizeReply();
 				await GetFileSizeInternal(path, -1, token, sizeReply);
@@ -42,7 +42,7 @@ namespace FluentFTP {
 			}
 
 			// check if file exists by attempting to get its date modified (MDTM)
-			if (HasFeature(FtpCapability.MDTM) && (ServerHandler == null || (ServerHandler != null && !ServerHandler.DontUseMdtmEvenIfCapable(path)))) {
+			if (HasFeature(FtpCapability.MDTM) && (ServerHandler == null || !ServerHandler.DontUseMdtmEvenIfCapable(path))) {
 				FtpReply reply = await Execute("MDTM " + path, token);
 				if (reply.Code[0] == '2') {
 					return true;

--- a/FluentFTP/Client/SyncClient/FileExists.cs
+++ b/FluentFTP/Client/SyncClient/FileExists.cs
@@ -26,7 +26,7 @@ namespace FluentFTP {
 
 			// since FTP does not include a specific command to check if a file exists
 			// here we check if file exists by attempting to get its filesize (SIZE)
-			if (HasFeature(FtpCapability.SIZE) && (ServerHandler == null || (ServerHandler != null && !ServerHandler.DontUseSizeEvenIfCapable(path)))) {
+			if (HasFeature(FtpCapability.SIZE) && (ServerHandler == null || !ServerHandler.DontUseSizeEvenIfCapable(path))) {
 				// Fix #328: get filesize in ASCII or Binary mode as required by server
 				var sizeReply = new FtpSizeReply();
 				GetFileSizeInternal(path, sizeReply, -1);
@@ -41,7 +41,7 @@ namespace FluentFTP {
 			}
 
 			// check if file exists by attempting to get its date modified (MDTM)
-			if (HasFeature(FtpCapability.MDTM) && (ServerHandler == null || (ServerHandler != null && !ServerHandler.DontUseMdtmEvenIfCapable(path)))) {
+			if (HasFeature(FtpCapability.MDTM) && (ServerHandler == null || !ServerHandler.DontUseMdtmEvenIfCapable(path))) {
 				var reply = Execute("MDTM " + path);
 				if (reply.Code[0] == '2') {
 					return true;


### PR DESCRIPTION
For the changed C# expressions, let:
* `a` be `HasFeature(FtpCapability.SIZE)`, 
* `b` be `ServerHandler == null` and
* `c` be `ServerHandler.DontUseSizeEvenIfCapable(path)`.

On mathematical form, the expressions are now `a && (b || !b && c)`.
As proven by [Wolfram Alpha](https://www.wolframalpha.com/input?i=%28a+%26%26+%28b+%7C%7C+%21b+%26%26+c%29%29+%3D+%28a+%26%26+%28b+%7C%7C+c%29%29) this is equal to writing `a && (b || c)`
<img width="601" alt="image" src="https://github.com/user-attachments/assets/acfafe12-f83e-4361-bd00-8096e2cb2604" />

Translating back to C# it means we can omit the `ServerHandler != null` checks.