### PR TITLE
Do not call CancellationToken.Register with async delegate

### DIFF
--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -585,7 +585,7 @@ namespace FluentFTP {
 
 			m_lastActivity = DateTime.UtcNow;
 			using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token)) {
-				cts.Token.Register(async () => await CloseAsync(token));
+				cts.CancelAfter(ReadTimeout);
 				try {
 					var res = await BaseStream.ReadAsync(buffer, cts.Token);
 					return res;


### PR DESCRIPTION
If the delegate throws an exception this is not properly caught. 
This change aligns with #1613

Caught by [CS4014](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs4014)
![image](https://github.com/user-attachments/assets/a37a4b36-60fa-4339-9f5d-a483c4a25301)


This fixes #1742 