### PR TITLE
Fixes #1747: Make sure a OperationCancelledException is thrown when cancelling a AsyncConnect

### DIFF
--- a/FluentFTP.Tests/Unit/TimeoutTests.cs
+++ b/FluentFTP.Tests/Unit/TimeoutTests.cs
@@ -61,5 +61,28 @@ namespace FluentFTP.Tests.Unit {
 			}
 		}
 
+		[Fact]
+		public async Task ConnectTimeoutAsyncCancel() {
+
+			var client = new AsyncFtpClient("test.github.com", new NetworkCredential("wrong", "password"));
+			client.Config.DataConnectionType = FtpDataConnectionType.PASVEX;
+			client.Config.ConnectTimeout = timeoutMillis;
+			var tokenSource = new System.Threading.CancellationTokenSource(1000);
+			var token = tokenSource.Token;
+			var start = DateTime.Now;
+			try {
+				await client.Connect(token);
+				Assert.True(false, "Connect succeeded. Was supposed to time out.");
+			}
+			catch (OperationCanceledException ex) {
+				Assert.True(true, "This is what we expect.");
+			}
+			catch (TimeoutException) {
+				Assert.True(false, "We should get an OperationCanceledException here.");
+			}
+			catch (SocketException) {
+				Assert.True(false, "We should get an OperationCanceledException here.");
+			}
+		}
 	}
 }

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1130,7 +1130,7 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
-		/// Helper for Async cancel in ConnectAsync 
+		/// Helper for Async cancel in ConnectAsync
 		/// </summary>
 		internal async Task EnableCancellation(Task task, CancellationToken token, Action action) {
 			var registration = token.Register(action);
@@ -1139,7 +1139,7 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
-		/// Helper for Async cancel in ConnectAsync 
+		/// Helper for Async cancel in ConnectAsync
 		/// </summary>
 		internal async Task<T> EnableCancellation<T>(Task<T> task, CancellationToken token, Action action) {
 			var registration = token.Register(action);
@@ -1172,6 +1172,7 @@ namespace FluentFTP {
 			}
 #endif
 			catch (SocketException ex) when (ex.SocketErrorCode is SocketError.OperationAborted or SocketError.TimedOut) {
+				token.ThrowIfCancellationRequested();
 				throw new TimeoutException("Timed out trying to connect!");
 			}
 


### PR DESCRIPTION
The cancellation token was combined with the timeout source and the resulting cancellation was interpreted as a timeout instead of and cancelled operation.