### PR TITLE
No reply (see #1746)

### DIFF
--- a/FluentFTP.Tests/Unit/TimeoutTests.cs
+++ b/FluentFTP.Tests/Unit/TimeoutTests.cs
@@ -74,7 +74,7 @@ namespace FluentFTP.Tests.Unit {
 				await client.Connect(token);
 				Assert.True(false, "Connect succeeded. Was supposed to time out.");
 			}
-			catch (OperationCanceledException ex) {
+			catch (OperationCanceledException) {
 				Assert.True(true, "This is what we expect.");
 			}
 			catch (TimeoutException) {

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -112,7 +112,7 @@ namespace FluentFTP {
 				LastCommandTimestamp = DateTime.UtcNow;
 
 				// get the reply
-				reply = await ((IInternalFtpClient)this).GetReplyInternal(token, command, false, 0, false);
+				reply = await ((IInternalFtpClient)this).GetReplyInternal(token, command, false, 0, false, linesExpected);
 			}
 			finally {
 				m_daemonSemaphore.Release();

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -16,6 +16,17 @@ namespace FluentFTP {
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <returns>The servers reply to the command</returns>
 		public async Task<FtpReply> Execute(string command, CancellationToken token = default(CancellationToken)) {
+			return await Execute(command, -1, token);
+		}
+
+		/// <summary>
+		/// Performs an asynchronous execution of the specified command
+		/// </summary>
+		/// <param name="command">The command to execute</param>
+		/// <param name="linesExpected">-1 normal operation, 0 accumulate until timeOut, >0 accumulate until n msgs received</param>
+		/// <param name="token">The token that can be used to cancel the entire process</param>
+		/// <returns>The servers reply to the command</returns>
+		public async Task<FtpReply> Execute(string command, int linesExpected, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 
 			bool reconnect = false;

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using FluentFTP.Client.Modules;
 using FluentFTP.Exceptions;
 using FluentFTP.Helpers;
@@ -15,6 +16,16 @@ namespace FluentFTP.Client.BaseClient {
 		/// <param name="command">The command to execute</param>
 		/// <returns>The servers reply to the command</returns>
 		FtpReply IInternalFtpClient.ExecuteInternal(string command) {
+			return ((IInternalFtpClient)this).ExecuteInternal(command, -1);
+		}
+
+		/// <summary>
+		/// Executes a command
+		/// </summary>
+		/// <param name="command">The command to execute</param>
+ 		/// <param name="linesExpected">-1 normal operation, 0 accumulate until timeOut, >0 accumulate until n msgs received</param>
+		/// <returns>The servers reply to the command</returns>
+		FtpReply IInternalFtpClient.ExecuteInternal(string command, int linesExpected) {
 			FtpReply reply;
 
 			bool reconnect = false;

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -107,7 +107,7 @@ namespace FluentFTP.Client.BaseClient {
 				LastCommandTimestamp = DateTime.UtcNow;
 
 				// get the reply
-				reply = ((IInternalFtpClient)this).GetReplyInternal(command, false, 0, false);
+				reply = ((IInternalFtpClient)this).GetReplyInternal(command, false, 0, false, linesExpected);
 			}
 			finally {
 				m_daemonSemaphore.Release();

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -165,9 +165,6 @@ namespace FluentFTP.Client.BaseClient {
 								break;
 							}
 
-							if (useSema) {
-								m_daemonSemaphore.Release();
-							}
 							throw new TimeoutException();
 						}
 
@@ -400,9 +397,6 @@ namespace FluentFTP.Client.BaseClient {
 								break;
 							}
 
-							if (useSema) {
-								m_daemonSemaphore.Release();
-							}
 							throw new TimeoutException();
 						}
 

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -161,7 +161,7 @@ namespace FluentFTP.Client.BaseClient {
 						// If we are not exhausting NOOPs, i.e. doing a normal GetReply(...)
 
 						if (elapsedTime > Config.ReadTimeout) {
-							if (linesExpected >= 0) {
+							if (linesExpected == 0) {
 								break;
 							}
 
@@ -396,7 +396,7 @@ namespace FluentFTP.Client.BaseClient {
 						// If we are not exhausting NOOPs, i.e. doing a normal GetReply(...)
 
 						if (elapsedTime > Config.ReadTimeout) {
-							if (linesExpected >= 0) {
+							if (linesExpected == 0) {
 								break;
 							}
 

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -63,6 +63,22 @@ namespace FluentFTP.Client.BaseClient {
 		/// <param name="exhaustNoop">Set to true to select the NOOP devouring mode</param>
 		/// <param name="timeOut">-1 non-blocking, no timeout, >0 exhaustNoop mode, timeOut in seconds</param>
 		/// <param name="useSema">Put a semaphore wait around the entire GetReply invocation</param>
+		/// <returns>FtpReply representing the response from the server</returns>
+		/// <exception cref="TimeoutException"></exception>
+		/// <exception cref="InvalidOperationException"></exception>
+		FtpReply IInternalFtpClient.GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema) {
+			return ((IInternalFtpClient)this).GetReplyInternal(command, exhaustNoop, timeOut, useSema, -1);
+		}
+
+		/// <summary>
+		/// Retrieves a reply from the server.
+		/// Support "normal" mode waiting for a command reply, subject to timeout exception
+		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
+		/// </summary>
+		/// <param name="command">We are waiting for the response to which command?</param>
+		/// <param name="exhaustNoop">Set to true to select the NOOP devouring mode</param>
+		/// <param name="timeOut">-1 non-blocking, no timeout, >0 exhaustNoop mode, timeOut in seconds</param>
+		/// <param name="useSema">Put a semaphore wait around the entire GetReply invocation</param>
 		/// <param name="linesExpected">-1 normal operation, 0 accumulate until timeOut, >0 accumulate until n msgs received</param>
 		/// <returns>FtpReply representing the response from the server</returns>
 		/// <exception cref="TimeoutException"></exception>
@@ -269,6 +285,23 @@ namespace FluentFTP.Client.BaseClient {
 		/// <exception cref="InvalidOperationException"></exception>
 		async Task<FtpReply> IInternalFtpClient.GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut) {
 			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, exhaustNoop, timeOut, true, -1);
+		}
+
+		/// <summary>
+		/// Retrieves a reply from the server.
+		/// Support "normal" mode waiting for a command reply, subject to timeout exception
+		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
+		/// </summary>
+		/// <param name="token">The token that can be used to cancel the entire process.</param>
+		/// <param name="command">We are waiting for the response to which command?</param>
+		/// <param name="exhaustNoop">Set to true to select the NOOP devouring mode</param>
+		/// <param name="timeOut">-1 non-blocking, no timeout, >0 exhaustNoop mode, timeOut in seconds</param>
+		/// <param name="useSema">Put a semaphore wait around the entire GetReply invocation</param>
+		/// <returns>FtpReply representing the response from the server</returns>
+		/// <exception cref="TimeoutException"></exception>
+		/// <exception cref="InvalidOperationException"></exception>
+		async Task<FtpReply> IInternalFtpClient.GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut, bool useSema) {
+			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, exhaustNoop, timeOut, useSema, -1);
 		}
 
 		/// <summary>

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -17,18 +17,6 @@ namespace FluentFTP.Client.BaseClient {
 		/// Support "normal" mode waiting for a command reply, subject to timeout exception
 		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
 		/// </summary>
-		/// <returns>FtpReply representing the response from the server</returns>
-		/// <exception cref="TimeoutException"></exception>
-		/// <exception cref="InvalidOperationException"></exception>
-		FtpReply IInternalFtpClient.GetReplyInternal() {
-			return ((IInternalFtpClient)this).GetReplyInternal(null, false, 0, true, -1);
-		}
-
-		/// <summary>
-		/// Retrieves a reply from the server.
-		/// Support "normal" mode waiting for a command reply, subject to timeout exception
-		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
-		/// </summary>
 		/// <param name="command">We are waiting for the response to which command?</param>
 		/// <returns>FtpReply representing the response from the server</returns>
 		/// <exception cref="TimeoutException"></exception>
@@ -236,19 +224,6 @@ namespace FluentFTP.Client.BaseClient {
 			reply = ProcessGetReply(reply, command);
 
 			return reply;
-		}
-
-		/// <summary>
-		/// Retrieves a reply from the server.
-		/// Support "normal" mode waiting for a command reply, subject to timeout exception
-		/// and "exhaustNoop" mode, which waits for 10 seconds to collect out of band NOOP responses
-		/// </summary>
-		/// <param name="token">The token that can be used to cancel the entire process.</param>
-		/// <returns>FtpReply representing the response from the server</returns>
-		/// <exception cref="TimeoutException"></exception>
-		/// <exception cref="InvalidOperationException"></exception>
-		async Task<FtpReply> IInternalFtpClient.GetReplyInternal(CancellationToken token) {
-			return await ((IInternalFtpClient)this).GetReplyInternal(token, null, false, 0, true, -1);
 		}
 
 		/// <summary>

--- a/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
@@ -32,6 +32,7 @@ namespace FluentFTP {
 		Task Connect(bool reConnect, CancellationToken token = default(CancellationToken));
 		Task Disconnect(CancellationToken token = default(CancellationToken));
 		Task<FtpReply> Execute(string command, CancellationToken token = default(CancellationToken));
+		Task<FtpReply> Execute(string command, int linesExpected, CancellationToken token = default(CancellationToken));
 		Task<List<string>> ExecuteDownloadText(string command, CancellationToken token = default(CancellationToken));
 		Task<FtpReply> GetReply(CancellationToken token = default(CancellationToken));
 

--- a/FluentFTP/Client/Interfaces/IFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IFtpClient.cs
@@ -27,6 +27,7 @@ namespace FluentFTP {
 		void Connect(bool reConnect);
 		void Disconnect();
 		FtpReply Execute(string command);
+		FtpReply Execute(string command, int linesExpected);
 		List<string> ExecuteDownloadText(string command);
 		FtpReply GetReply();
 

--- a/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
@@ -33,12 +33,14 @@ namespace FluentFTP {
 		FtpReply GetReplyInternal(string command, bool exhaustNoop);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema);
+		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema, int linesExpected);
 
 		Task<FtpReply> GetReplyInternal(CancellationToken token);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut, bool useSema);
+		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut, bool useSema, int linesExpected);
 
 		bool IsStillConnectedInternal(int timeout = 10000);
 

--- a/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
@@ -27,6 +27,7 @@ namespace FluentFTP {
 #endif
 
 		FtpReply ExecuteInternal(string command);
+		FtpReply ExecuteInternal(string command, int linesExpected);
 
 		FtpReply GetReplyInternal(string command);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop);

--- a/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
@@ -28,14 +28,12 @@ namespace FluentFTP {
 
 		FtpReply ExecuteInternal(string command);
 
-		FtpReply GetReplyInternal();
 		FtpReply GetReplyInternal(string command);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema, int linesExpected);
 
-		Task<FtpReply> GetReplyInternal(CancellationToken token);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut);

--- a/FluentFTP/Client/SyncClient/Execute.cs
+++ b/FluentFTP/Client/SyncClient/Execute.cs
@@ -20,5 +20,15 @@ namespace FluentFTP {
 			return ((IInternalFtpClient)this).ExecuteInternal(command);
 		}
 
+		/// <summary>
+		/// Executes a command
+		/// </summary>
+		/// <param name="command">The command to execute</param>
+		/// <param name="linesExpected">-1 normal operation, 0 accumulate until timeOut, >0 accumulate until n msgs received</param>
+		/// <returns>The servers reply to the command</returns>
+		public FtpReply Execute(string command, int linesExpected) {
+			return ((IInternalFtpClient)this).ExecuteInternal(command);
+		}
+
 	}
 }


### PR DESCRIPTION
Issue #1746 describes a scenario where a server does not (always) reply with a success/failure code in front and possibly also with non-standard multi-line responses.

By adding an `Execute` overload, minor modification in that, and some also minor modification to yet another new overload to our infamous `GetReply`, this enhancement request can be made a reality.

So please see #1746 for more information.
