### PR TITLE
As of Docker 4.42.0 all integration tests were failing. Here is the fix!

### DIFF
--- a/FluentFTP.Tests/FluentFTP.Tests.csproj
+++ b/FluentFTP.Tests/FluentFTP.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -16,13 +16,13 @@
 
   <ItemGroup>
     <PackageReference Include="FluentFTP.GnuTLS" Version="1.0.24" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/FluentFTP.Tests/Integration/IntegrationTests_GnuTSL.cs
+++ b/FluentFTP.Tests/Integration/IntegrationTests_GnuTSL.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using FluentFTP.Tests.Integration.System;
 

--- a/FluentFTP.Tests/Integration/IntegrationTests_SslStream.cs
+++ b/FluentFTP.Tests/Integration/IntegrationTests_SslStream.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using FluentFTP.Tests.Integration.System;
 

--- a/FluentFTP.Tests/Integration/System/IntegrationTestRunner.cs
+++ b/FluentFTP.Tests/Integration/System/IntegrationTestRunner.cs
@@ -34,7 +34,7 @@ namespace FluentFTP.Tests.Integration.System {
 
 			}
 			catch (Exception ex) {
-				Assert.True(false, $"Integration test failed : " + ex.ToString());
+				Assert.Fail($"Integration test failed : " + ex.ToString());
 			}
 
 		}

--- a/FluentFTP.Tests/Integration/Tests/ConnectTests.cs
+++ b/FluentFTP.Tests/Integration/Tests/ConnectTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 
 using FluentFTP.Xunit.Docker;

--- a/FluentFTP.Tests/Integration/Tests/FileTransferTests.cs
+++ b/FluentFTP.Tests/Integration/Tests/FileTransferTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using FluentFTP.Xunit.Docker;
-using FluentFTP.Xunit.Attributes;
 using FluentFTP.Tests.Integration.System;
 using FluentFTP.Exceptions;
 

--- a/FluentFTP.Tests/Integration/Tests/ListingTests.cs
+++ b/FluentFTP.Tests/Integration/Tests/ListingTests.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using FluentFTP.Xunit.Docker;
-using FluentFTP.Xunit.Attributes;
 using FluentFTP.Tests.Integration.System;
 
 namespace FluentFTP.Tests.Integration.Tests {

--- a/FluentFTP.Tests/Unit/CustomTests.cs
+++ b/FluentFTP.Tests/Unit/CustomTests.cs
@@ -1,12 +1,6 @@
-﻿using FluentFTP.Helpers;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Net;
-using System.Net.Sockets;
+﻿using System.Net;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Sdk;
 
 namespace FluentFTP.Tests.Unit {
 	public class CustomTests {

--- a/FluentFTP.Tests/Unit/DateTimesTests.cs
+++ b/FluentFTP.Tests/Unit/DateTimesTests.cs
@@ -31,7 +31,7 @@ public class DateTimesTests {
 		var actual = DateTimes.ParseFtpDate(unsupportedDateString, client);
 		Assert.Equal(DateTime.MinValue, actual);
 
-		Assert.Equal(1, logger.LogEntries.Count);
+		Assert.Single(logger.LogEntries);
 		var entry = logger.LogEntries.Single();
 		Assert.Equal(FtpTraceLevel.Error, entry.Severity);
 		Assert.Equal($"Failed to parse date string '{unsupportedDateString}'", entry.Message);

--- a/FluentFTP.Tests/Unit/ExceptionTests.cs
+++ b/FluentFTP.Tests/Unit/ExceptionTests.cs
@@ -1,8 +1,5 @@
 using FluentFTP.Exceptions;
-using FluentFTP.Helpers;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using Xunit;
 
 namespace FluentFTP.Tests.Unit {

--- a/FluentFTP.Tests/Unit/HelperTests.cs
+++ b/FluentFTP.Tests/Unit/HelperTests.cs
@@ -1,13 +1,6 @@
 ﻿using FluentFTP.Helpers;
 using FluentFTP.Model.Functions;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Net;
-using System.Net.Sockets;
-using System.Threading.Tasks;
 using Xunit;
-using Xunit.Sdk;
 
 namespace FluentFTP.Tests.Unit {
 	public class HelperTests {

--- a/FluentFTP.Tests/Unit/TimeoutTests.cs
+++ b/FluentFTP.Tests/Unit/TimeoutTests.cs
@@ -1,12 +1,8 @@
-﻿using FluentFTP.Helpers;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Sdk;
 
 namespace FluentFTP.Tests.Unit {
 	public class TimeoutTests {
@@ -16,7 +12,7 @@ namespace FluentFTP.Tests.Unit {
 		private void ValidateTime(DateTime callStart, string methodName) {
 			var maxElapsedMillis = (timeoutMillis + 500);
 			if ((DateTime.Now - callStart).TotalMilliseconds > maxElapsedMillis) {
-				Assert.True(false, $"ConnectTimeout is being ignored with {methodName}() method!");
+				Assert.Fail($"ConnectTimeout is being ignored with {methodName}() method!");
 			}
 			else {
 				Assert.True(true);
@@ -32,7 +28,7 @@ namespace FluentFTP.Tests.Unit {
 			var start = DateTime.Now;
 			try {
 				client.Connect();
-				Assert.True(false, "Connect succeeded. Was supposed to time out.");
+				Assert.Fail("Connect succeeded. Was supposed to time out.");
 			}
 			catch (TimeoutException) {
 				ValidateTime(start, "Connect");
@@ -48,7 +44,7 @@ namespace FluentFTP.Tests.Unit {
 			var start = DateTime.Now;
 			try {
 				await client.Connect();
-				Assert.True(false, "Connect succeeded. Was supposed to time out.");
+				Assert.Fail("Connect succeeded. Was supposed to time out.");
 			}
 			catch (TimeoutException) {
 				ValidateTime(start, "ConnectAsync");
@@ -72,16 +68,16 @@ namespace FluentFTP.Tests.Unit {
 			var start = DateTime.Now;
 			try {
 				await client.Connect(token);
-				Assert.True(false, "Connect succeeded. Was supposed to time out.");
+				Assert.Fail("Connect succeeded. Was supposed to time out.");
 			}
 			catch (OperationCanceledException) {
 				Assert.True(true, "This is what we expect.");
 			}
 			catch (TimeoutException) {
-				Assert.True(false, "We should get an OperationCanceledException here.");
+				Assert.Fail("We should get an OperationCanceledException here.");
 			}
 			catch (SocketException) {
-				Assert.True(false, "We should get an OperationCanceledException here.");
+				Assert.Fail("We should get an OperationCanceledException here.");
 			}
 		}
 	}

--- a/FluentFTP.Tests/Unit/TimezoneTests.cs
+++ b/FluentFTP.Tests/Unit/TimezoneTests.cs
@@ -1,7 +1,5 @@
 ﻿using FluentFTP.Helpers;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using Xunit;
 

--- a/FluentFTP.Xunit/Attributes/SkipTestException.cs
+++ b/FluentFTP.Xunit/Attributes/SkipTestException.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace FluentFTP.Xunit.Attributes {
 	public class SkipTestException : Exception {
 		public SkipTestException(string reason)

--- a/FluentFTP.Xunit/Attributes/SkippableFactAttribute.cs
+++ b/FluentFTP.Xunit/Attributes/SkippableFactAttribute.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
+﻿using Xunit;
 using Xunit.Sdk;
 
 namespace FluentFTP.Xunit.Attributes {

--- a/FluentFTP.Xunit/Attributes/SkippableState.cs
+++ b/FluentFTP.Xunit/Attributes/SkippableState.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace FluentFTP.Xunit.Attributes {
 	internal static class SkippableState {
 		internal static bool ShouldSkip { get; set; }

--- a/FluentFTP.Xunit/Attributes/SkippableTheoryAttribute.cs
+++ b/FluentFTP.Xunit/Attributes/SkippableTheoryAttribute.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
+﻿using Xunit;
 using Xunit.Sdk;
 
 namespace FluentFTP.Xunit.Attributes {

--- a/FluentFTP.Xunit/Docker/Containers/ApacheContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/ApacheContainer.cs
@@ -1,36 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-
-namespace FluentFTP.Xunit.Docker.Containers {
+﻿namespace FluentFTP.Xunit.Docker.Containers {
 	internal class ApacheContainer : DockerFtpContainer {
 
+		//without SSL:
+		// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 apache:fluentftp";
+		//with SSL:
+		// not possible
 		public ApacheContainer() {
 			ServerType = FtpServer.Apache;
 			ServerName = "apache";
 			DockerImage = "apache:fluentftp";
-			//without SSL:
-			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 apache:fluentftp";
-			//with SSL:
-			// not possible
 		}
-
-		/// <summary>
-		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
-		/// </summary>
-		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
-
-			builder = builder.WithPortBinding(20);
-
-			builder = ExposePortRange(builder, 21100, 21199);
-
-			return builder;
-		}
-
 	}
-
 }

--- a/FluentFTP.Xunit/Docker/Containers/BFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/BFtpdContainer.cs
@@ -1,36 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-
-namespace FluentFTP.Xunit.Docker.Containers {
+﻿namespace FluentFTP.Xunit.Docker.Containers {
 	internal class BFtpdContainer : DockerFtpContainer {
 
+		//without SSL:
+		// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 bftpd:fluentftp";
+		//with SSL:
+		// not possible
 		public BFtpdContainer() {
 			ServerType = FtpServer.BFTPd;
 			ServerName = "bftpd";
 			DockerImage = "bftpd:fluentftp";
-			//without SSL:
-			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 bftpd:fluentftp";
-			//with SSL:
-			// not possible
 		}
-
-		/// <summary>
-		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
-		/// </summary>
-		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
-
-			builder = builder.WithPortBinding(20);
-
-			builder = ExposePortRange(builder, 21100, 21199);
-
-			return builder;
-		}
-
 	}
-
 }

--- a/FluentFTP.Xunit/Docker/Containers/FileZillaContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/FileZillaContainer.cs
@@ -1,36 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-
-namespace FluentFTP.Xunit.Docker.Containers {
+﻿namespace FluentFTP.Xunit.Docker.Containers {
 	internal class FileZillaContainer : DockerFtpContainer {
 
+		//without SSL:
+		// not possible
+		//with SSL:
+		// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 filezilla:fluentftp";
 		public FileZillaContainer() {
 			ServerType = FtpServer.FileZilla;
 			ServerName = "filezilla";
 			DockerImage = "filezilla:fluentftp";
-			//without SSL:
-			// not possible
-			//with SSL:
-			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 filezilla:fluentftp";
 		}
-
-		/// <summary>
-		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
-		/// </summary>
-		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
-
-			builder = builder.WithPortBinding(20);
-
-			builder = ExposePortRange(builder, 21100, 21199);
-
-			return builder;
-		}
-
 	}
-
 }

--- a/FluentFTP.Xunit/Docker/Containers/GlFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/GlFtpdContainer.cs
@@ -1,36 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-
-namespace FluentFTP.Xunit.Docker.Containers {
+﻿namespace FluentFTP.Xunit.Docker.Containers {
 	internal class GlFtpdContainer : DockerFtpContainer {
 
+		//without SSL:
+		// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 glftpd:fluentftp";
+		//with SSL:
+		// not possible
 		public GlFtpdContainer() {
 			ServerType = FtpServer.glFTPd;
 			ServerName = "glftpd";
 			DockerImage = "glftpd:fluentftp";
-			//without SSL:
-			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 glftpd:fluentftp";
-			//with SSL:
-			// not possible
 		}
-
-		/// <summary>
-		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
-		/// </summary>
-		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
-
-			builder = builder.WithPortBinding(20);
-
-			builder = ExposePortRange(builder, 21100, 21199);
-
-			return builder;
-		}
-
 	}
-
 }

--- a/FluentFTP.Xunit/Docker/Containers/ProFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/ProFtpdContainer.cs
@@ -1,34 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-
-namespace FluentFTP.Xunit.Docker.Containers {
+﻿namespace FluentFTP.Xunit.Docker.Containers {
 	internal class ProFtpdContainer : DockerFtpContainer {
 
+		//without SSL:
+		// RunCommand = "docker run -d --net host proftpd:fluentftp";
+		//with SSL:
+		// RunCommand = "docker run -d --net host -e USE_SSL=YES proftpd:fluentftp";
 		public ProFtpdContainer() {
 			ServerType = FtpServer.ProFTPD;
 			ServerName = "proftpd";
 			DockerImage = "proftpd:fluentftp";
-			//without SSL:
-			// RunCommand = "docker run -d --net host proftpd:fluentftp";
-			//with SSL:
-			// RunCommand = "docker run -d --net host -e USE_SSL=YES proftpd:fluentftp";
-		}
-
-		/// <summary>
-		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
-		/// </summary>
-		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
-
-			builder = builder.WithPortBinding(20);
-
-			builder = ExposePortRange(builder, 21100, 21199);
-
-			return builder;
 		}
 	}
 }

--- a/FluentFTP.Xunit/Docker/Containers/PureFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/PureFtpdContainer.cs
@@ -1,43 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-
-namespace FluentFTP.Xunit.Docker.Containers {
+﻿namespace FluentFTP.Xunit.Docker.Containers {
 	internal class PureFtpdContainer : DockerFtpContainer {
 
+		//without SSL:
+		// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 pureftpd:fluentftp";
+		//with SSL:
+		// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 -e USE_SSL=YES pureftpd:fluentftp";
 		public PureFtpdContainer() {
 			ServerType = FtpServer.PureFTPd;
 			ServerName = "pureftpd";
 			DockerImage = "pureftpd:fluentftp";
-			//without SSL:
-			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 pureftpd:fluentftp";
-			//with SSL:
-			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 -e USE_SSL=YES pureftpd:fluentftp";
-		}
-
-		/// <summary>
-		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
-		/// </summary>
-
-		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
-
-			builder = builder.WithPortBinding(20);
-
-			builder = ExposePortRange(builder, 21100, 21199);
-
-			builder = builder.WithCreateContainerParametersModifier(x => {
-				x.HostConfig.CapAdd = new List<string> {
+			CreateParms = new List<string> {
 					"SYS_NICE",
 					"DAC_READ_SEARCH"
-				};
-			});
-
-			return builder;
+			};
 		}
-
 	}
 }

--- a/FluentFTP.Xunit/Docker/Containers/PyFtpdLibContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/PyFtpdLibContainer.cs
@@ -1,31 +1,18 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-
 namespace FluentFTP.Xunit.Docker.Containers {
 	internal class PyFtpdLibContainer : DockerFtpContainer {
+
+		//RunCommand = "docker run -it --rm -p 21:21 pyftpdlib:fluentftp";
 		public PyFtpdLibContainer() {
 			ServerType = FtpServer.PyFtpdLib;
 			ServerName = "pyftpdlib";
 			DockerImage = "pyftpdlib:fluentftp";
 			DockerImageOriginal = "akogut/docker-pyftpdlib";
 			DockerGithub = "https://github.com/andriykohut/docker-pyftpdlib";
-			//RunCommand = "docker run -it --rm -p 21:21 pyftpdlib:fluentftp";
 			FixedUsername = "user";
 			FixedPassword = "password";
-		}
-
-		/// <summary>
-		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
-		/// </summary>
-		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
-
-			builder = base.ExposePortRange(builder, 3000, 3010);
-			return builder;
+			ExposedPortRangeBegin = 3000;
+			ExposedPortRangeEnd = 3010;
 		}
 	}
 }

--- a/FluentFTP.Xunit/Docker/Containers/VsFtpdContainer.cs
+++ b/FluentFTP.Xunit/Docker/Containers/VsFtpdContainer.cs
@@ -1,36 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-
-namespace FluentFTP.Xunit.Docker.Containers {
+﻿namespace FluentFTP.Xunit.Docker.Containers {
 	internal class VsFtpdContainer : DockerFtpContainer {
 
+		//without SSL:
+		// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 vsftpd:fluentftp";
+		//with SSL:
+		// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 -e USE_SSL=YES vsftpd:fluentftp";
 		public VsFtpdContainer() {
 			ServerType = FtpServer.VsFTPd;
 			ServerName = "vsftpd";
 			DockerImage = "vsftpd:fluentftp";
-			//without SSL:
-			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 vsftpd:fluentftp";
-			//with SSL:
-			// RunCommand = "docker run --rm -it -p 21:21 -p 21100-21199:21100-21199 -e USE_SSL=YES vsftpd:fluentftp";
 		}
-
-		/// <summary>
-		/// For help creating this section see https://github.com/testcontainers/testcontainers-dotnet#supported-commands
-		/// </summary>
-		public override ITestcontainersBuilder<TestcontainersContainer> Configure(ITestcontainersBuilder<TestcontainersContainer> builder) {
-
-			builder = builder.WithPortBinding(20);
-
-			builder = ExposePortRange(builder, 21100, 21199);
-
-			return builder;
-		}
-
 	}
-
 }

--- a/FluentFTP.Xunit/Docker/DockerFtpConfig.cs
+++ b/FluentFTP.Xunit/Docker/DockerFtpConfig.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace FluentFTP.Xunit.Docker {
+﻿namespace FluentFTP.Xunit.Docker {
 	public static class DockerFtpConfig {
 
 		/// <summary>

--- a/FluentFTP.Xunit/Docker/DockerFtpContainerIndex.cs
+++ b/FluentFTP.Xunit/Docker/DockerFtpContainerIndex.cs
@@ -1,9 +1,4 @@
 ﻿using FluentFTP.Xunit.Docker.Containers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FluentFTP.Xunit.Docker {
 	internal static class DockerFtpContainerIndex {

--- a/FluentFTP.Xunit/Docker/DockerFtpServer.cs
+++ b/FluentFTP.Xunit/Docker/DockerFtpServer.cs
@@ -4,7 +4,7 @@ using FluentFTP.Xunit.Attributes;
 namespace FluentFTP.Xunit.Docker {
 	public class DockerFtpServer : IDisposable {
 		internal DockerFtpContainer _server;
-		internal TestcontainersContainer? _container;
+		internal DockerContainer? _container;
 		internal bool _useSsl;
 		internal string _useStream;
 

--- a/FluentFTP.Xunit/FluentFTP.Xunit.csproj
+++ b/FluentFTP.Xunit/FluentFTP.Xunit.csproj
@@ -9,14 +9,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-		<PackageReference Include="Testcontainers" Version="2.1.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Testcontainers" Version="4.5.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/FluentFTP.Xunit/System/SystemProcess.cs
+++ b/FluentFTP.Xunit/System/SystemProcess.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 
 namespace FluentFTP.Xunit.System {
 	public static class SystemProcess {


### PR DESCRIPTION
After updating Docker (Desktop) on Windows, all integration tests failed. Previous Docker versions did not exhibit this behaviour.

A corresponding update to the Nuget TestContainers was needed. 

But - TestContainers had numberous major breaking changes ([see here](https://github.com/testcontainers/testcontainers-dotnet/releases?page=2)) beyond our installed version at 2.4.0 and also 3.0.0.

What a drag!

So, time to clean up and recode a few parts, remove unused usings, update the other related Nuget for the Test and Xunit stuff.

Spent some time testing the tests.

Next steps perhaps will be, as time permits:
1. Update GnuTLS libs to newest versions
2. Test the docker image build process (are all images built? Especially filezilla!)