### PR TITLE
Rework accepting custom responses (#1746)

### DIFF
--- a/FluentFTP.Tests/Unit/ParserTests.cs
+++ b/FluentFTP.Tests/Unit/ParserTests.cs
@@ -230,7 +230,7 @@ namespace FluentFTP.Tests.Unit {
 				new FtpListItem("data.0000", 9, FtpObjectType.Link, new DateTime(2011, 9, 27, 0, 0, 0, 0)),
 				new FtpListItem("data.6460", 512, FtpObjectType.Directory, new DateTime(2012, 6, 29, 0, 0, 0, 0)),
 				new FtpListItem("sys.0000", 8, FtpObjectType.Link, new DateTime(2011, 9, 27, 0, 0, 0, 0)),
-				new FtpListItem("sys.6460", 4096, FtpObjectType.Directory, new DateTime(2024, 6, 25, 16, 26, 0, 0)),
+				new FtpListItem("sys.6460", 4096, FtpObjectType.Directory, new DateTime(DateTime.UtcNow.Year, 6, 25, 16, 26, 0, 0)),
 				new FtpListItem("File001.xml dir", 512, FtpObjectType.Directory, new DateTime(1994, 4, 8, 0, 0, 0, 0)),
 				new FtpListItem("File003.xml dir", 512, FtpObjectType.Directory, new DateTime(1994, 4, 8, 0, 0, 0, 0)),
 				new FtpListItem("File-3.txt file", 1392298, FtpObjectType.File, new DateTime(1995, 11, 22, 0, 0, 0, 0)),

--- a/FluentFTP/Client/AsyncClient/Execute.cs
+++ b/FluentFTP/Client/AsyncClient/Execute.cs
@@ -17,17 +17,17 @@ namespace FluentFTP {
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <returns>The servers reply to the command</returns>
 		public async Task<FtpReply> Execute(string command, CancellationToken token = default(CancellationToken)) {
-			return await Execute(command, -1, token);
+			return await Execute(command, false, token);
 		}
 
 		/// <summary>
 		/// Performs an asynchronous execution of the specified command
 		/// </summary>
 		/// <param name="command">The command to execute</param>
-		/// <param name="linesExpected">-1 normal operation, 0 accumulate until timeOut, >0 accumulate until n msgs received</param>
+		/// <param name="acceptIllFormed">A flag indicating whether to accept ill-formed responses.</param>
 		/// <param name="token">The token that can be used to cancel the entire process</param>
 		/// <returns>The servers reply to the command</returns>
-		public async Task<FtpReply> Execute(string command, int linesExpected, CancellationToken token = default(CancellationToken)) {
+		public async Task<FtpReply> Execute(string command, bool acceptIllFormed, CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;
 
 			bool reconnect = false;
@@ -124,7 +124,7 @@ namespace FluentFTP {
 				LastCommandTimestamp = DateTime.UtcNow;
 
 				// get the reply
-				reply = await ((IInternalFtpClient)this).GetReplyInternal(token, command, false, 0, false, linesExpected);
+				reply = await ((IInternalFtpClient)this).GetReplyInternal(token, command, false, 0, false, acceptIllFormed);
 			}
 			finally {
 				m_daemonSemaphore.Release();

--- a/FluentFTP/Client/BaseClient/Execute.cs
+++ b/FluentFTP/Client/BaseClient/Execute.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 using FluentFTP.Client.Modules;
 using FluentFTP.Exceptions;
 using FluentFTP.Helpers;
@@ -16,16 +13,16 @@ namespace FluentFTP.Client.BaseClient {
 		/// <param name="command">The command to execute</param>
 		/// <returns>The servers reply to the command</returns>
 		FtpReply IInternalFtpClient.ExecuteInternal(string command) {
-			return ((IInternalFtpClient)this).ExecuteInternal(command, -1);
+			return ((IInternalFtpClient)this).ExecuteInternal(command, false);
 		}
 
 		/// <summary>
 		/// Executes a command
 		/// </summary>
 		/// <param name="command">The command to execute</param>
-		/// <param name="linesExpected">-1 normal operation, 0 accumulate until timeOut, >0 accumulate until n msgs received</param>
+		/// <param name="acceptIllFormed">A flag indicating whether to accept ill-formed responses.</param>
 		/// <returns>The servers reply to the command</returns>
-		FtpReply IInternalFtpClient.ExecuteInternal(string command, int linesExpected) {
+		FtpReply IInternalFtpClient.ExecuteInternal(string command, bool acceptIllFormed) {
 			FtpReply reply;
 
 			bool reconnect = false;
@@ -118,7 +115,7 @@ namespace FluentFTP.Client.BaseClient {
 				LastCommandTimestamp = DateTime.UtcNow;
 
 				// get the reply
-				reply = ((IInternalFtpClient)this).GetReplyInternal(command, false, 0, false, linesExpected);
+				reply = ((IInternalFtpClient)this).GetReplyInternal(command, false, 0, false, acceptIllFormed);
 			}
 			finally {
 				m_daemonSemaphore.Release();

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -1,12 +1,13 @@
 ﻿using System;
-using System.Linq;
-using FluentFTP.Helpers;
-using System.Text.RegularExpressions;
-using FluentFTP.Client.Modules;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentFTP.Client.Modules;
+using FluentFTP.Helpers;
 
 namespace FluentFTP.Client.BaseClient {
 
@@ -22,7 +23,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
 		FtpReply IInternalFtpClient.GetReplyInternal(string command) {
-			return ((IInternalFtpClient)this).GetReplyInternal(command, false, 0, true, -1);
+			return ((IInternalFtpClient)this).GetReplyInternal(command, false, 0, true, false);
 		}
 
 		/// <summary>
@@ -36,7 +37,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
 		FtpReply IInternalFtpClient.GetReplyInternal(string command, bool exhaustNoop) {
-			return ((IInternalFtpClient)this).GetReplyInternal(command, exhaustNoop, exhaustNoop ? 10000 : 0, true, -1);
+			return ((IInternalFtpClient)this).GetReplyInternal(command, exhaustNoop, exhaustNoop ? 10000 : 0, true, false);
 		}
 
 		/// <summary>
@@ -51,7 +52,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
 		FtpReply IInternalFtpClient.GetReplyInternal(string command, bool exhaustNoop, int timeOut) {
-			return ((IInternalFtpClient)this).GetReplyInternal(command, exhaustNoop, timeOut, true, -1);
+			return ((IInternalFtpClient)this).GetReplyInternal(command, exhaustNoop, timeOut, true, false);
 		}
 
 		/// <summary>
@@ -67,7 +68,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
 		FtpReply IInternalFtpClient.GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema) {
-			return ((IInternalFtpClient)this).GetReplyInternal(command, exhaustNoop, timeOut, useSema, -1);
+			return ((IInternalFtpClient)this).GetReplyInternal(command, exhaustNoop, timeOut, useSema, false);
 		}
 
 		/// <summary>
@@ -79,11 +80,11 @@ namespace FluentFTP.Client.BaseClient {
 		/// <param name="exhaustNoop">Set to true to select the NOOP devouring mode</param>
 		/// <param name="timeOut">-1 non-blocking, no timeout, >0 exhaustNoop mode, timeOut in seconds</param>
 		/// <param name="useSema">Put a semaphore wait around the entire GetReply invocation</param>
-		/// <param name="linesExpected">-1 normal operation, 0 accumulate until timeOut, >0 accumulate until n msgs received</param>
+		/// <param name="acceptIllFormed">A flag indicating whether to accept ill-formed responses.</param>
 		/// <returns>FtpReply representing the response from the server</returns>
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
-		FtpReply IInternalFtpClient.GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema, int linesExpected) {
+		FtpReply IInternalFtpClient.GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema, bool acceptIllFormed) {
 			var reply = new FtpReply();
 
 			if (string.IsNullOrEmpty(command)) {
@@ -94,8 +95,6 @@ namespace FluentFTP.Client.BaseClient {
 			}
 
 			Status.IgnoreStaleData = false;
-
-			int lines = 0;
 
 			string sequence = string.Empty;
 
@@ -121,6 +120,7 @@ namespace FluentFTP.Client.BaseClient {
 
 				sw.Start();
 
+				var isMultiline = false;
 				do {
 					if (useSema && !IsConnected) {
 						throw new InvalidOperationException("No connection to the server exists.");
@@ -143,7 +143,7 @@ namespace FluentFTP.Client.BaseClient {
 							response = m_stream.ReadLine(Encoding);
 						}
 						else {
-							if (elapsedTime > (previousElapsedTime + 1000)) {
+							if (elapsedTime > previousElapsedTime + 1000) {
 								previousElapsedTime = elapsedTime;
 								LogWithPrefix(FtpTraceLevel.Verbose, "Waiting - " + ((timeOut - elapsedTime) / 1000).ToString() + " seconds left");
 								// if we have more then 5 seconds left, tickle the server some more
@@ -161,10 +161,6 @@ namespace FluentFTP.Client.BaseClient {
 						// If we are not exhausting NOOPs, i.e. doing a normal GetReply(...)
 
 						if (elapsedTime > Config.ReadTimeout) {
-							if (linesExpected == 0) {
-								break;
-							}
-
 							throw new TimeoutException();
 						}
 
@@ -193,7 +189,7 @@ namespace FluentFTP.Client.BaseClient {
 					sequence += "," + response.Split(' ')[0];
 
 					if (exhaustNoop &&
-						((response.StartsWith("200") && (response.IndexOf("NOOP", StringComparison.OrdinalIgnoreCase) >= 0)) ||
+						((response.StartsWith("200") && response.IndexOf("NOOP", StringComparison.OrdinalIgnoreCase) >= 0) ||
 						response.StartsWith("500"))) {
 
 						Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
@@ -201,25 +197,9 @@ namespace FluentFTP.Client.BaseClient {
 						continue;
 					}
 
-					if (DecodeStringToReply(response, ref reply)) {
-						if (exhaustNoop) {
-							// We need to perhaps exhaust more NOOP responses
-							continue;
-						}
-						else {
-							// On a normal GetReply(...) we are happy to collect the first valid response
-							break;
-						}
-					}
+					DecodeStringToReply(response, acceptIllFormed, ref reply, ref isMultiline);
 
-					reply.InfoMessages += response + "\n";
-					lines++;
-
-					if (linesExpected > 0 && lines >= linesExpected) {
-						break;
-					}
-
-				} while (true);
+				} while (isMultiline || exhaustNoop);
 
 				sw.Stop();
 
@@ -258,7 +238,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
 		async Task<FtpReply> IInternalFtpClient.GetReplyInternal(CancellationToken token, string command) {
-			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, false, 0, true, -1);
+			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, false, 0, true, false);
 		}
 
 		/// <summary>
@@ -273,7 +253,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
 		async Task<FtpReply> IInternalFtpClient.GetReplyInternal(CancellationToken token, string command, bool exhaustNoop) {
-			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, exhaustNoop, exhaustNoop ? 10000 : 0, true, -1);
+			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, exhaustNoop, exhaustNoop ? 10000 : 0, true, false);
 		}
 
 		/// <summary>
@@ -289,7 +269,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
 		async Task<FtpReply> IInternalFtpClient.GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut) {
-			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, exhaustNoop, timeOut, true, -1);
+			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, exhaustNoop, timeOut, true, false);
 		}
 
 		/// <summary>
@@ -306,7 +286,7 @@ namespace FluentFTP.Client.BaseClient {
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
 		async Task<FtpReply> IInternalFtpClient.GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut, bool useSema) {
-			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, exhaustNoop, timeOut, useSema, -1);
+			return await ((IInternalFtpClient)this).GetReplyInternal(token, command, exhaustNoop, timeOut, useSema, false);
 		}
 
 		/// <summary>
@@ -319,11 +299,11 @@ namespace FluentFTP.Client.BaseClient {
 		/// <param name="exhaustNoop">Set to true to select the NOOP devouring mode</param>
 		/// <param name="timeOut">-1 non-blocking, no timeout, >0 exhaustNoop mode, timeOut in seconds</param>
 		/// <param name="useSema">Put a semaphore wait around the entire GetReply invocation</param>
-		/// <param name="linesExpected">-1 normal operation, 0 accumulate until timeOut, >0 accumulate until n msgs received</param>
+		/// <param name="acceptIllFormed">A flag indicating whether to accept ill-formed responses.</param>
 		/// <returns>FtpReply representing the response from the server</returns>
 		/// <exception cref="TimeoutException"></exception>
 		/// <exception cref="InvalidOperationException"></exception>
-		async Task<FtpReply> IInternalFtpClient.GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut, bool useSema, int linesExpected) {
+		async Task<FtpReply> IInternalFtpClient.GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut, bool useSema, bool acceptIllFormed) {
 			var reply = new FtpReply();
 
 			if (string.IsNullOrEmpty(command)) {
@@ -335,8 +315,6 @@ namespace FluentFTP.Client.BaseClient {
 
 			Status.IgnoreStaleData = false;
 
-			int lines = 0;
-
 			string sequence = string.Empty;
 
 			string response;
@@ -347,7 +325,7 @@ namespace FluentFTP.Client.BaseClient {
 			long previousElapsedTime = 0;
 
 			if (useSema) {
-				await m_daemonSemaphore.WaitAsync();
+				await m_daemonSemaphore.WaitAsync(token);
 			}
 
 			try {
@@ -355,12 +333,13 @@ namespace FluentFTP.Client.BaseClient {
 				if (exhaustNoop) {
 					// tickle the server
 					LogWithPrefix(FtpTraceLevel.Verbose, "Sending NOOP (<-GetReply)");
-					m_stream.WriteLine(Encoding, "NOOP");
+					await m_stream.WriteLineAsync(Encoding, "NOOP", token);
 					LastCommandTimestamp = DateTime.UtcNow;
 				}
 
 				sw.Start();
 
+				var isMultiline = false;
 				do {
 					if (useSema && !IsConnected) {
 						throw new InvalidOperationException("No connection to the server exists.");
@@ -383,9 +362,9 @@ namespace FluentFTP.Client.BaseClient {
 							response = await m_stream.ReadLineAsync(Encoding, token);
 						}
 						else {
-							if (elapsedTime > (previousElapsedTime + 1000)) {
+							if (elapsedTime > previousElapsedTime + 1000) {
 								previousElapsedTime = elapsedTime;
-								LogWithPrefix(FtpTraceLevel.Verbose, "Waiting - " + ((timeOut - elapsedTime) / 1000).ToString() + " seconds left");
+								LogWithPrefix(FtpTraceLevel.Verbose, "Waiting - " + (timeOut - elapsedTime) / 1000 + " seconds left");
 								// if we have more then 5 seconds left, tickle the server some more
 								if (timeOut - elapsedTime >= 5000) {
 									LogWithPrefix(FtpTraceLevel.Verbose, "Sending NOOP (<-GetReply)");
@@ -401,10 +380,6 @@ namespace FluentFTP.Client.BaseClient {
 						// If we are not exhausting NOOPs, i.e. doing a normal GetReply(...)
 
 						if (elapsedTime > Config.ReadTimeout) {
-							if (linesExpected == 0) {
-								break;
-							}
-
 							throw new TimeoutException();
 						}
 
@@ -433,7 +408,7 @@ namespace FluentFTP.Client.BaseClient {
 					sequence += "," + response.Split(' ')[0];
 
 					if (exhaustNoop &&
-						((response.StartsWith("200") && (response.IndexOf("NOOP", StringComparison.OrdinalIgnoreCase) >= 0)) ||
+						((response.StartsWith("200") && response.IndexOf("NOOP", StringComparison.OrdinalIgnoreCase) >= 0) ||
 						response.StartsWith("500"))) {
 
 						Log(FtpTraceLevel.Verbose, "Skipped:  " + response);
@@ -441,25 +416,9 @@ namespace FluentFTP.Client.BaseClient {
 						continue;
 					}
 
-					if (DecodeStringToReply(response, ref reply)) {
-						if (exhaustNoop) {
-							// We need to perhaps exhaust more NOOP responses
-							continue;
-						}
-						else {
-							// On a normal GetReply(...) we are happy to collect the first valid response
-							break;
-						}
-					}
+					DecodeStringToReply(response, acceptIllFormed, ref reply, ref isMultiline);
 
-					reply.InfoMessages += response + "\n";
-					lines++;
-
-					if (linesExpected > 0 && lines >= linesExpected) {
-						break;
-					}
-
-				} while (true);
+				} while (isMultiline || exhaustNoop);
 
 				sw.Stop();
 
@@ -470,7 +429,7 @@ namespace FluentFTP.Client.BaseClient {
 			}
 			catch (Exception ex) {
 				if (m_stream != null) {
-					await m_stream.CloseAsync();
+					await m_stream.CloseAsync(token);
 					m_stream = null;
 				}
 				LogWithPrefix(FtpTraceLevel.Verbose, "GetReply(...) failure: " + ex.Message);
@@ -546,16 +505,49 @@ namespace FluentFTP.Client.BaseClient {
 
 		/// <summary>
 		/// Decodes the given FTP response string into a FtpReply, separating the FTP return code and message.
-		/// Returns true if the string was decoded correctly or false if it is not a standard format FTP response.
 		/// </summary>
+		/// <param name="text">The FTP response text.</param>
+		/// <param name="reply">The FTP reply structure.</param>
+		/// <returns>True, if the string was decoded correctly, or false if it is not a standard format FTP response.</returns>
 		protected static bool DecodeStringToReply(string text, ref FtpReply reply) {
-			Match m = Regex.Match(text, "^(?<code>[0-9]{3}) (?<message>.*)$");
-			if (m.Success) {
-				reply.Code = m.Groups["code"].Value;
-				reply.Message = m.Groups["message"].Value;
-			}
-			return m.Success;
+			var isMultiline = false;
+			return DecodeStringToReply(text, false, ref reply, ref isMultiline);
 		}
 
+		/// <summary>
+		/// Decodes the given FTP response string into a FtpReply, separating the FTP return code and message.
+		/// </summary>
+		/// <param name="text">The FTP response text.</param>
+		/// <param name="acceptIllFormed">A flag indicating whether to accept ill-formed responses.</param>
+		/// <param name="reply">The FTP reply structure.</param>
+		/// <param name="isMultiline">A flag indicating whether we currently decode a multiline FTP response.</param>
+		/// <returns>True, if the string was decoded correctly, or false if it is not a standard format FTP response.</returns>
+		protected static bool DecodeStringToReply(string text, bool acceptIllFormed, ref FtpReply reply, ref bool isMultiline) {
+			text = text.Trim();
+			var m = Regex.Match(text, "^(?<code>[0-9]{3})(?<multiline>[- ])?(?<message>.*)$");
+			var code = m.Groups["code"].Value;
+
+			if (isMultiline && !string.Equals(reply.Code, code)) {
+				// We have a multiline response which isn't the last line
+				reply.InfoMessages += text + "\n";
+			}
+			else if (m.Success) {
+				// We have a well-formed response (i.e., single-line, or beginning/end of multiline)
+				reply.Code = code;
+				isMultiline = string.Equals(m.Groups["multiline"].Value, "-");
+				if (isMultiline) {
+					reply.InfoMessages += text + "\n";
+				}
+				else {
+					reply.Message = m.Groups["message"].Value.Trim();
+				}
+			}
+			else if (acceptIllFormed) {
+				// We have an ill-formed response
+				reply.Message = text;
+			}
+
+			return m.Success;
+		}
 	}
 }

--- a/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IAsyncFtpClient.cs
@@ -32,7 +32,7 @@ namespace FluentFTP {
 		Task Connect(bool reConnect, CancellationToken token = default(CancellationToken));
 		Task Disconnect(CancellationToken token = default(CancellationToken));
 		Task<FtpReply> Execute(string command, CancellationToken token = default(CancellationToken));
-		Task<FtpReply> Execute(string command, int linesExpected, CancellationToken token = default(CancellationToken));
+		Task<FtpReply> Execute(string command, bool acceptIllFormed, CancellationToken token = default(CancellationToken));
 		Task<List<string>> ExecuteDownloadText(string command, CancellationToken token = default(CancellationToken));
 		Task<FtpReply> GetReply(CancellationToken token = default(CancellationToken));
 

--- a/FluentFTP/Client/Interfaces/IFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IFtpClient.cs
@@ -27,7 +27,7 @@ namespace FluentFTP {
 		void Connect(bool reConnect);
 		void Disconnect();
 		FtpReply Execute(string command);
-		FtpReply Execute(string command, int linesExpected);
+		FtpReply Execute(string command, bool acceptIllFormed);
 		List<string> ExecuteDownloadText(string command);
 		FtpReply GetReply();
 

--- a/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IInternalFtpClient.cs
@@ -27,19 +27,19 @@ namespace FluentFTP {
 #endif
 
 		FtpReply ExecuteInternal(string command);
-		FtpReply ExecuteInternal(string command, int linesExpected);
+		FtpReply ExecuteInternal(string command, bool acceptIllFormed);
 
 		FtpReply GetReplyInternal(string command);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut);
 		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema);
-		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema, int linesExpected);
+		FtpReply GetReplyInternal(string command, bool exhaustNoop, int timeOut, bool useSema, bool acceptIllFormed);
 
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut);
 		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut, bool useSema);
-		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut, bool useSema, int linesExpected);
+		Task<FtpReply> GetReplyInternal(CancellationToken token, string command, bool exhaustNoop, int timeOut, bool useSema, bool acceptIllFormed);
 
 		bool IsStillConnectedInternal(int timeout = 10000);
 

--- a/FluentFTP/Client/SyncClient/Execute.cs
+++ b/FluentFTP/Client/SyncClient/Execute.cs
@@ -24,10 +24,10 @@ namespace FluentFTP {
 		/// Executes a command
 		/// </summary>
 		/// <param name="command">The command to execute</param>
-		/// <param name="linesExpected">-1 normal operation, 0 accumulate until timeOut, >0 accumulate until n msgs received</param>
+		/// <param name="acceptIllFormed">A flag indicating whether to accept ill-formed responses.</param>
 		/// <returns>The servers reply to the command</returns>
-		public FtpReply Execute(string command, int linesExpected) {
-			return ((IInternalFtpClient)this).ExecuteInternal(command, linesExpected);
+		public FtpReply Execute(string command, bool acceptIllFormed) {
+			return ((IInternalFtpClient)this).ExecuteInternal(command, acceptIllFormed);
 		}
 
 	}


### PR DESCRIPTION
Sorry to bring this dogshit of #1746 up again, but after a while of testing I discovered that the previous approach wasn't quite good enough after all. We also have scenarios where we have a valid positive response, but the error case of the same command brings up an ill-formed response. In addition, there are multiline success responses while the error response is single-line, well, all of the possible ill-formed responses are single-liners (as far as I can tell currently).

As a result, I figured to change this `linesExpected` approach a bit to better fit these requirements. Feel free to have a look, I'd be also open to keep the special case code in my own library, in which case it would be fine to make the `GetReply` method(s) virtual so that I can inherit a subclass, overwriting the essential parts 😄

There is one small change in the handling of multiline responses (independent of the actual changes) though, previously whenever there was a "well-formed" FTP response within the multilines, the FtpReply would be handled as completed single line response. This is no longer the case, now we actually wait for the final closing line. This should technically be an improvement as per RFC, but on the other hand if we occur a disconnect in the middle of a multiline response, we're kinda stuck in the loop until timeout. Which ever way of handling this you find preferable, I'd be fine with, this is just an fyi. Example of this case could be something like this:
```
123-First line  
Second line  
  234 A line beginning with numbers  
123 The last line
```