### PR TITLE
Fix for issue #1771

### DIFF
--- a/FluentFTP/Monitors/BaseFtpMonitor.cs
+++ b/FluentFTP/Monitors/BaseFtpMonitor.cs
@@ -40,7 +40,7 @@ namespace FluentFTP.Monitors {
 
 
 		internal void StartTimer(TimerCallback callback) {
-			_timer = new Timer(callback, null, TimeSpan.Zero, PollInterval);
+			_timer = new Timer(callback, null, PollInterval, PollInterval);
 		}
 
 		internal void StopTimer() {


### PR DESCRIPTION
Tested in Async and in Sync clients.

The user had analyzed the logic correctly when he stated:

"The logic seems to be broken when declaring the Timer in StartTimer, where polling starts immediately with TimeSpan.Zero. Then, in the PollFolder callback, StopTimer is called, which disposes the Timer. At the end of the function, StartTimer is invoked again."

So actually the PollInterval should be inserted as a "DueTime", which is then the actual cause for the loop delay.