### PR TITLE
Rework FtpMonitor class's access modifiers

### DIFF
--- a/FluentFTP/Monitors/AsyncFtpMonitor.cs
+++ b/FluentFTP/Monitors/AsyncFtpMonitor.cs
@@ -57,7 +57,7 @@ namespace FluentFTP.Monitors {
 		/// <summary>
 		/// Polls the FTP folder for changes
 		/// </summary>
-		private async void PollFolder(object state) {
+		protected virtual async void PollFolder(object state) {
 			try {
 
 				// exit if not connected
@@ -111,7 +111,7 @@ namespace FluentFTP.Monitors {
 		/// <summary>
 		/// Gets the current listing of files from the FTP server
 		/// </summary>
-		private async Task<Dictionary<string, long>> GetCurrentListing() {
+		protected virtual async Task<Dictionary<string, long>> GetCurrentListing() {
 			FtpListOption options = GetListingOptions(_ftpClient.Capabilities);
 
 			// per folder to check

--- a/FluentFTP/Monitors/BaseFtpMonitor.cs
+++ b/FluentFTP/Monitors/BaseFtpMonitor.cs
@@ -8,20 +8,20 @@ using Timer = System.Threading.Timer;
 namespace FluentFTP.Monitors {
 	public abstract class BaseFtpMonitor {
 
-		internal Dictionary<string, long> _lastListing = new Dictionary<string, long>();
-		internal Dictionary<string, long> _unstableFiles = new Dictionary<string, long>();
+		protected Dictionary<string, long> _lastListing = new Dictionary<string, long>();
+		protected Dictionary<string, long> _unstableFiles = new Dictionary<string, long>();
 
-		internal Timer _timer;
+		protected Timer _timer;
 
 		/// <summary>
 		/// Is the monitoring started?
 		/// </summary>
-		public bool Active { get; internal set; }
+		public bool Active { get; protected set; }
 
 		/// <summary>
 		/// Gets the monitored FTP folder path(s)
 		/// </summary>
-		public List<string> FolderPaths { get; internal set; }
+		public List<string> FolderPaths { get; protected set; }
 
 		/// <summary>
 		/// Gets or sets the polling interval. Default is 10 minutes.
@@ -39,15 +39,15 @@ namespace FluentFTP.Monitors {
 		public bool Recursive { get; set; } = false;
 
 
-		internal void StartTimer(TimerCallback callback) {
+		protected void StartTimer(TimerCallback callback) {
 			_timer = new Timer(callback, null, PollInterval, PollInterval);
 		}
 
-		internal void StopTimer() {
+		protected void StopTimer() {
 			_timer?.Dispose();
 			_timer = null;
 		}
-		internal FtpListOption GetListingOptions(List<FtpCapability> caps) {
+		protected virtual FtpListOption GetListingOptions(List<FtpCapability> caps) {
 			FtpListOption options = FtpListOption.Modify | FtpListOption.Size;
 
 			if (Recursive) {
@@ -67,7 +67,7 @@ namespace FluentFTP.Monitors {
 		/// <summary>
 		/// Handles unstable files when WaitForUpload is true
 		/// </summary>
-		internal Dictionary<string, long> HandleUnstableFiles(Dictionary<string, long> currentListing) {
+		protected virtual Dictionary<string, long> HandleUnstableFiles(Dictionary<string, long> currentListing) {
 			var stableFiles = new Dictionary<string, long>();
 
 			foreach (var file in currentListing) {
@@ -100,7 +100,5 @@ namespace FluentFTP.Monitors {
 
 			return stableFiles;
 		}
-
-
 	}
 }

--- a/FluentFTP/Monitors/BlockingAsyncFtpMonitor.cs
+++ b/FluentFTP/Monitors/BlockingAsyncFtpMonitor.cs
@@ -48,7 +48,7 @@ namespace FluentFTP.Monitors {
 		/// Monitor the FTP folder(s) until the token is cancelled
 		/// or an exception occurs in the FTP client or the handler.
 		/// </summary>
-		public async Task Start(CancellationToken token) {
+		public virtual async Task Start(CancellationToken token) {
 			while (true) {
 				try {
 					var startTimeUtc = DateTime.UtcNow;
@@ -89,7 +89,7 @@ namespace FluentFTP.Monitors {
 		/// <summary>
 		/// Polls the FTP folder(s) for changes
 		/// </summary>
-		private async Task PollFolder(CancellationToken token) {
+		protected virtual async Task PollFolder(CancellationToken token) {
 
 			// Step 1: Get the current listing
 			var currentListing = await GetCurrentListing(token).ConfigureAwait(false);
@@ -136,7 +136,7 @@ namespace FluentFTP.Monitors {
 		/// <summary>
 		/// Gets the current list items from the FTP server
 		/// </summary>
-		private async Task<Dictionary<string, long>> GetCurrentListing(CancellationToken token) {
+		protected virtual async Task<Dictionary<string, long>> GetCurrentListing(CancellationToken token) {
 			var options = GetListingOptions(_ftpClient.Capabilities);
 
 			// per folder to check
@@ -156,6 +156,5 @@ namespace FluentFTP.Monitors {
 
 			return allItems;
 		}
-
 	}
 }


### PR DESCRIPTION
BaseFtpMonitor:
- Set properties internal access modifier to protected, so derived classes can reach them
- Set StartTimer and StopTimer functions access modifier to protected, so derived classes can call them
- Set GetListingOptions and HandleUnstableFiles functions access modifier to protected virtual, so derived classes can override them

AsyncFtpMonitor:
- Set PollFolder and GetCurrentListing functions access modifier to protected virtual, so derived classes can override them

BlockingAsyncFtpMonitor:
- Set Start function access modifier to public virtual, so derived classes can override it
- Set PollFolder and GetCurrentListing functions access modifier to protected virtual, so derived classes can override them
